### PR TITLE
fix: stream LM response chunks per-token (s90p)

### DIFF
--- a/.beans/ollama-models-vscode-4vps--inline-code-completion-provider-with-configurable.md
+++ b/.beans/ollama-models-vscode-4vps--inline-code-completion-provider-with-configurable.md
@@ -1,0 +1,27 @@
+---
+# ollama-models-vscode-4vps
+title: Inline code completion provider with configurable model
+status: todo
+type: feature
+priority: medium
+created_at: 2026-03-06T05:50:22Z
+updated_at: 2026-03-06T05:50:22Z
+id: ollama-models-vscode-4vps
+---
+
+## Summary
+
+The extension currently provides a chat participant (`@ollama`) and a language model provider for Copilot chat, but has no inline code completion support. This feature would add:
+
+1. **`InlineCompletionItemProvider`** — registers with `vscode.languages.registerInlineCompletionItemProvider` (or `*` for all languages), calls Ollama with the surrounding code context (prefix/suffix), and returns inline completions.
+2. **Configuration setting** — `ollama.completionModel` (string) lets the user pick a different model for completions (e.g. a smaller/faster fill-in-the-middle model like `qwen2.5-coder:1.5b`) independently of the chat model.
+3. **Enable/disable toggle** — `ollama.enableInlineCompletions` (boolean, default `true`) so users can turn it off without uninstalling.
+4. **FIM (fill-in-the-middle) support** — use Ollama's `/api/generate` with `suffix` for models that support FIM (e.g. `deepseek-coder`, `qwen2.5-coder`); fall back to prefix-only for models that don't.
+
+## Todo
+
+- [ ] Add `ollama.completionModel` and `ollama.enableInlineCompletions` settings to `package.json` contributes
+- [ ] Create `src/completions.ts` with `OllamaInlineCompletionProvider` class
+- [ ] Write tests in `src/completions.test.ts` (TDD first)
+- [ ] Register provider in `src/extension.ts` `activate()`
+- [ ] Document in README

--- a/.beans/ollama-models-vscode-rpom--inline-code-completion-provider-with-configurable.md
+++ b/.beans/ollama-models-vscode-rpom--inline-code-completion-provider-with-configurable.md
@@ -1,12 +1,11 @@
 ---
 # ollama-models-vscode-rpom
 title: Inline code completion provider with configurable model selection
-status: todo
+status: scrapped
 type: feat
 priority: medium
 created_at: 2026-03-06T05:23:54Z
-updated_at: 2026-03-06T05:23:54Z
-id: ollama-models-vscode-rpom
+updated_at: 2026-03-06T05:56:45Z
 ---
 
 Implement a VS Code `InlineCompletionItemProvider` backed by Ollama `/api/generate` for ghost-text (autocomplete-as-you-type) completions.

--- a/.beans/ollama-models-vscode-rpom--inline-code-completion-provider-with-configurable.md
+++ b/.beans/ollama-models-vscode-rpom--inline-code-completion-provider-with-configurable.md
@@ -1,0 +1,38 @@
+---
+# ollama-models-vscode-rpom
+title: Inline code completion provider with configurable model selection
+status: todo
+type: feat
+priority: medium
+created_at: 2026-03-06T05:23:54Z
+updated_at: 2026-03-06T05:23:54Z
+id: ollama-models-vscode-rpom
+---
+
+Implement a VS Code `InlineCompletionItemProvider` backed by Ollama `/api/generate` for ghost-text (autocomplete-as-you-type) completions.
+
+## Problem
+
+The extension currently only provides a chat model provider and an `@ollama` chat participant. There is no inline (ghost-text) code completion — pressing Tab does nothing Ollama-powered.
+
+## Goals
+
+- Register an `InlineCompletionItemProvider` via `vscode.languages.registerInlineCompletionItemProvider`
+- Call Ollama `/api/generate` with fill-in-the-middle (FIM) support where the model supports it (e.g. `deepseek-coder`, `starcoder2`, `codellama:code`)
+- Fall back to suffix-less generation for models that don't support FIM tokens
+- Add a setting `ollama.completions.model` (string, default `""`) so users can select a dedicated completions model separate from the chat model
+- Add a setting `ollama.completions.enabled` (boolean, default `true`) to allow disabling completions
+- Debounce requests (e.g. 300ms) to avoid hammering Ollama on every keystroke
+- Cap completion length (e.g. max 1 line by default, configurable)
+- Cancel in-flight requests when the cursor moves
+
+## Todo
+
+- [ ] Add `ollama.completions.enabled` and `ollama.completions.model` settings to `package.json`
+- [ ] Create `src/completions.ts` with `InlineCompletionProvider` class
+- [ ] Write failing tests for the provider in `src/completions.test.ts`
+- [ ] Implement FIM prompt construction (prefix/suffix split at cursor)
+- [ ] Register provider in `activate()` (only when enabled)
+- [ ] Add command `ollama.completions.selectModel` to choose completions model via QuickPick
+- [ ] Wire command and setting into sidebar or status bar
+- [ ] Manual smoke test with `qwen2.5-coder` and `starcoder2`

--- a/.beans/ollama-models-vscode-s90p--ollama-chat-responses-not-streaming-shows-waiting.md
+++ b/.beans/ollama-models-vscode-s90p--ollama-chat-responses-not-streaming-shows-waiting.md
@@ -1,9 +1,27 @@
 ---
 # ollama-models-vscode-s90p
 title: Ollama chat responses not streaming — shows "waiting" indefinitely
-status: ready
+status: completed
 type: fix
 priority: critical
 created_at: 2026-03-05T22:03:38Z
-updated_at: 2026-03-05T22:03:38Z
+updated_at: 2026-03-05T22:33:21Z
 ---
+
+## Root Cause
+
+Two bugs in `provideLanguageModelChatResponse` (`src/provider.ts`):
+
+1. **Missing `await`**: `this.client.chat({ stream: true })` returns `Promise<AbortableAsyncIterator<ChatResponse>>`. Without `await`, the `for await...of` loop was iterating over the Promise itself — so the loop body never executed and `progress.report()` was never called, leaving VS Code stuck on "waiting".
+
+2. **Text batching**: Even if the `await` had been present, text chunks were accumulated in a `currentText` string and only flushed via `progress.report()` after the entire loop completed. VS Code requires each chunk to be reported immediately to display streaming output.
+
+## Changes
+
+- `src/provider.ts`: Added `await` to `this.client.chat(...)`. Replaced `currentText` accumulation with immediate `progress.report(new LanguageModelTextPart(chunk.message.content))` per chunk. Removed end-of-loop flush. Fixed `toolCall.id` type error (`ToolCall` has no `id` field in the Ollama JS library).
+- `src/provider.test.ts`: Added test asserting each of 3 yielded chunks is reported as a separate `LanguageModelTextPart` call (not batched).
+
+## Summary of Changes
+
+- Fixed streaming so each token is reported to VS Code immediately as it arrives
+- 127 tests passing, clean compile

--- a/.beans/ollama-models-vscode-zj31--support-thinking-models-and-structured-tool-call-r.md
+++ b/.beans/ollama-models-vscode-zj31--support-thinking-models-and-structured-tool-call-r.md
@@ -1,0 +1,10 @@
+---
+# ollama-models-vscode-zj31
+title: Support thinking models and structured tool call responses in provider
+status: todo
+type: feat
+priority: high
+created_at: 2026-03-06T04:51:53Z
+updated_at: 2026-03-06T04:51:53Z
+id: ollama-models-vscode-zj31
+---

--- a/.beans/ollama-models-vscode-zj31--support-thinking-models-and-structured-tool-call-r.md
+++ b/.beans/ollama-models-vscode-zj31--support-thinking-models-and-structured-tool-call-r.md
@@ -1,10 +1,9 @@
 ---
 # ollama-models-vscode-zj31
 title: Support thinking models and structured tool call responses in provider
-status: todo
+status: in-progress
 type: feat
 priority: high
 created_at: 2026-03-06T04:51:53Z
-updated_at: 2026-03-06T04:51:53Z
-id: ollama-models-vscode-zj31
+updated_at: 2026-03-06T05:23:54Z
 ---

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -50,7 +50,8 @@
       "Bash(vsce --version)",
       "Bash(pnpm run package)",
       "Bash(vsce package)",
-      "Bash(pnpm dlx @vscode/vsce package --no-dependencies)"
+      "Bash(pnpm dlx @vscode/vsce package --no-dependencies)",
+      "mcp__cognitionai_deepwiki__ask_question"
     ],
     "additionalDirectories": ["/tmp"]
   }

--- a/package.json
+++ b/package.json
@@ -125,6 +125,12 @@
         "category": "Ollama"
       },
       {
+        "command": "ollama-copilot.refreshModels",
+        "title": "Refresh Ollama Models",
+        "icon": "$(refresh)",
+        "category": "Ollama"
+      },
+      {
         "command": "ollama-copilot.refreshSidebar",
         "title": "Refresh Local Ollama Models",
         "icon": "$(refresh)",

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,8 +9,8 @@ export async function getOllamaClient(context: ExtensionContext): Promise<Ollama
   const host = config.get<string>('host') || 'http://localhost:11434';
   const authToken = await context.secrets.get('ollama-auth-token');
 
-  const clientConfig: { baseURL: string; headers?: Record<string, string> } = {
-    baseURL: host,
+  const clientConfig: { host: string; headers?: Record<string, string> } = {
+    host,
   };
 
   if (authToken) {

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1122,6 +1122,7 @@ describe('handleBuiltInOllamaConflict', () => {
       lm: {
         registerLanguageModelChatProvider: vi.fn(() => ({ dispose: vi.fn() })),
         selectChatModels: vi.fn().mockResolvedValue([]),
+        onDidChangeChatModels: vi.fn().mockReturnValue({ dispose: vi.fn() }),
       },
       chat: {
         createChatParticipant: vi.fn(() => ({ iconPath: undefined, dispose: vi.fn() })),
@@ -1139,56 +1140,52 @@ describe('handleBuiltInOllamaConflict', () => {
     }));
   });
 
-  it('does nothing when github.copilot.chat.ollama.url is empty', async () => {
+  it('does nothing when no conflicting models are registered', async () => {
     const showWarningMessage = vi.fn();
-    const mockConfig = { get: vi.fn().mockReturnValue(''), update: vi.fn() };
-    const getConfiguration = vi.fn().mockReturnValue(mockConfig);
+    const selectChatModels = vi.fn().mockResolvedValue([]);
 
     const ext = await import('./extension.js');
-    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage: vi.fn() }, { getConfiguration });
+    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage: vi.fn() }, { selectChatModels });
 
+    expect(selectChatModels).toHaveBeenCalledWith({ vendor: 'ollama' });
     expect(showWarningMessage).not.toHaveBeenCalled();
   });
 
-  it('does nothing when github.copilot.chat.ollama.url is undefined', async () => {
-    const showWarningMessage = vi.fn();
-    const mockConfig = { get: vi.fn().mockReturnValue(undefined), update: vi.fn() };
-    const getConfiguration = vi.fn().mockReturnValue(mockConfig);
-
-    const ext = await import('./extension.js');
-    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage: vi.fn() }, { getConfiguration });
-
-    expect(showWarningMessage).not.toHaveBeenCalled();
-  });
-
-  it('shows a warning when the built-in Ollama URL is set', async () => {
+  it('shows a warning when conflicting Ollama models are present', async () => {
     const showWarningMessage = vi.fn().mockResolvedValue(undefined);
-    const mockConfig = { get: vi.fn().mockReturnValue('http://localhost:11434'), update: vi.fn() };
-    const getConfiguration = vi.fn().mockReturnValue(mockConfig);
+    const mockModel = { id: 'ollama:llama3', vendor: 'ollama', name: 'Llama 3' };
+    const selectChatModels = vi.fn().mockResolvedValue([mockModel]);
 
     const ext = await import('./extension.js');
-    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage: vi.fn() }, { getConfiguration });
+    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage: vi.fn() }, { selectChatModels });
 
     expect(showWarningMessage).toHaveBeenCalledWith(
-      expect.stringContaining("built-in Ollama provider"),
+      expect.stringContaining('built-in Ollama provider'),
       'Disable Built-in Ollama Provider',
     );
-    expect(mockConfig.update).not.toHaveBeenCalled();
   });
 
-  it('clears the URL and shows reload prompt when user confirms', async () => {
-    const showWarningMessage = vi.fn().mockResolvedValue('Disable Built-in Ollama Provider');
-    const showInformationMessage = vi.fn().mockResolvedValue(undefined);
-    const mockConfig = {
-      get: vi.fn().mockReturnValue('http://localhost:11434'),
-      update: vi.fn().mockResolvedValue(undefined),
-    };
-    const getConfiguration = vi.fn().mockReturnValue(mockConfig);
+  it('does nothing when user dismisses the warning', async () => {
+    const showWarningMessage = vi.fn().mockResolvedValue(undefined);
+    const mockModel = { id: 'ollama:llama3', vendor: 'ollama', name: 'Llama 3' };
+    const selectChatModels = vi.fn().mockResolvedValue([mockModel]);
 
     const ext = await import('./extension.js');
-    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage }, { getConfiguration });
+    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage: vi.fn() }, { selectChatModels });
 
-    expect(mockConfig.update).toHaveBeenCalledWith('ollama.url', '', expect.anything());
+    expect(showWarningMessage).toHaveBeenCalled();
+    // config.update should not be called — workspace mock returns a plain stub
+  });
+
+  it('updates config and shows reload prompt when user confirms', async () => {
+    const showWarningMessage = vi.fn().mockResolvedValue('Disable Built-in Ollama Provider');
+    const showInformationMessage = vi.fn().mockResolvedValue(undefined);
+    const mockModel = { id: 'ollama:llama3', vendor: 'ollama', name: 'Llama 3' };
+    const selectChatModels = vi.fn().mockResolvedValue([mockModel]);
+
+    const ext = await import('./extension.js');
+    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage }, { selectChatModels });
+
     expect(showInformationMessage).toHaveBeenCalledWith(
       expect.stringContaining('Reload VS Code'),
       'Reload Window',

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1363,7 +1363,7 @@ describe('handleBuiltInOllamaConflict', () => {
 
     const ext = await import('./extension.js');
     await ext.handleBuiltInOllamaConflict(
-      { showWarningMessage, showInformationMessage: vi.fn() },
+      { showWarningMessage, showInformationMessage: vi.fn(), showErrorMessage: vi.fn() },
       { getConfiguration: vi.fn() },
       { selectChatModels },
     );
@@ -1378,7 +1378,7 @@ describe('handleBuiltInOllamaConflict', () => {
 
     const ext = await import('./extension.js');
     await ext.handleBuiltInOllamaConflict(
-      { showWarningMessage, showInformationMessage: vi.fn() },
+      { showWarningMessage, showInformationMessage: vi.fn(), showErrorMessage: vi.fn() },
       { getConfiguration: vi.fn() },
       { selectChatModels },
     );
@@ -1398,7 +1398,7 @@ describe('handleBuiltInOllamaConflict', () => {
 
     const ext = await import('./extension.js');
     await ext.handleBuiltInOllamaConflict(
-      { showWarningMessage, showInformationMessage },
+      { showWarningMessage, showInformationMessage, showErrorMessage: vi.fn() },
       { getConfiguration },
       { selectChatModels },
     );
@@ -1418,7 +1418,7 @@ describe('handleBuiltInOllamaConflict', () => {
 
     const ext = await import('./extension.js');
     await ext.handleBuiltInOllamaConflict(
-      { showWarningMessage, showInformationMessage },
+      { showWarningMessage, showInformationMessage, showErrorMessage: vi.fn() },
       { getConfiguration },
       { selectChatModels },
       { executeCommand },

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1203,20 +1203,23 @@ describe('handleBuiltInOllamaConflict', () => {
 
   it('clears ollama.url setting when user confirms', async () => {
     const showWarningMessage = vi.fn().mockResolvedValue('Disable Built-in Ollama Provider');
-    const showInformationMessage = vi.fn().mockResolvedValue(undefined);
+    const showInformationMessage = vi.fn().mockResolvedValue('Reload Window');
     const mockConfig = { update: vi.fn().mockResolvedValue(undefined) };
     const getConfiguration = vi.fn().mockReturnValue(mockConfig);
     const selectChatModels = vi.fn().mockResolvedValue([{ id: 'ollama:llama3', vendor: 'ollama', name: 'Llama 3' }]);
+    const executeCommand = vi.fn().mockResolvedValue(undefined);
 
     const ext = await import('./extension.js');
     await ext.handleBuiltInOllamaConflict(
       { showWarningMessage, showInformationMessage },
       { getConfiguration },
       { selectChatModels },
+      { executeCommand },
     );
 
-    expect(mockConfig.update).toHaveBeenCalledWith('ollama.url', undefined, expect.anything());
+    expect(mockConfig.update).toHaveBeenCalledWith('ollama.url', '', expect.anything());
     expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining('Reload VS Code'), 'Reload Window');
+    expect(executeCommand).toHaveBeenCalledWith('workbench.action.reloadWindow');
   });
 });
 

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -947,6 +947,7 @@ describe('handleChatRequest errors', () => {
     const mockRequest = {
       prompt: 'test',
       model: {
+        vendor: 'selfagency-ollama',
         sendRequest: vi.fn(() => {
           throw new Error('Model error');
         }),
@@ -959,6 +960,122 @@ describe('handleChatRequest errors', () => {
     await ext.handleChatRequest(mockRequest as any, mockChatContext as any, mockStream as any, mockToken as any);
 
     expect(mockMarkdown).toHaveBeenCalledWith(expect.stringContaining('Error: Model error'));
+  });
+});
+
+describe('handleChatRequest model selection', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('shows error when no Ollama models are available', async () => {
+    const mockSelectChatModels = vi.fn().mockResolvedValue([]);
+
+    vi.doMock('vscode', () => ({
+      LanguageModelTextPart: class { constructor(public value: string) {} },
+      ChatRequestTurn: class {},
+      ChatResponseTurn: class {},
+      ChatResponseMarkdownPart: class {},
+      LanguageModelChatMessage: {
+        User: (content: string) => ({ content }),
+        Assistant: (content: string) => ({ content }),
+      },
+      lm: { selectChatModels: mockSelectChatModels },
+    }));
+
+    const ext = await import('./extension.js');
+    const mockMarkdown = vi.fn();
+    const mockRequest = { prompt: 'test', model: { vendor: 'copilot' } };
+
+    await ext.handleChatRequest(
+      mockRequest as any,
+      { history: [] } as any,
+      { markdown: mockMarkdown } as any,
+      { isCancellationRequested: false } as any,
+    );
+
+    expect(mockMarkdown).toHaveBeenCalledWith(expect.stringContaining('No Ollama models available'));
+  });
+
+  it('uses model from selectChatModels when request.model is not our vendor', async () => {
+    const LMTextPart = class { constructor(public value: string) {} };
+    const mockSendRequest = vi.fn().mockResolvedValue({
+      stream: (async function* () {
+        yield new LMTextPart('hello from ollama');
+      })(),
+    });
+    const mockSelectChatModels = vi.fn().mockResolvedValue([
+      { vendor: 'selfagency-ollama', sendRequest: mockSendRequest },
+    ]);
+
+    vi.doMock('vscode', () => ({
+      LanguageModelTextPart: LMTextPart,
+      ChatRequestTurn: class {},
+      ChatResponseTurn: class {},
+      ChatResponseMarkdownPart: class {},
+      LanguageModelChatMessage: {
+        User: (content: string) => ({ content }),
+        Assistant: (content: string) => ({ content }),
+      },
+      lm: { selectChatModels: mockSelectChatModels },
+      workspace: { getConfiguration: vi.fn().mockReturnValue({ get: vi.fn() }) },
+    }));
+
+    const ext = await import('./extension.js');
+    const mockMarkdown = vi.fn();
+    const mockRequest = { prompt: 'test', model: { vendor: 'copilot' } };
+
+    await ext.handleChatRequest(
+      mockRequest as any,
+      { history: [] } as any,
+      { markdown: mockMarkdown } as any,
+      { isCancellationRequested: false } as any,
+    );
+
+    expect(mockSelectChatModels).toHaveBeenCalled();
+    expect(mockSendRequest).toHaveBeenCalled();
+    expect(mockMarkdown).toHaveBeenCalledWith('hello from ollama');
+  });
+
+  it('uses request.model directly when it is already our vendor', async () => {
+    const LMTextPart = class { constructor(public value: string) {} };
+    const mockSelectChatModels = vi.fn();
+    const mockSendRequest = vi.fn().mockResolvedValue({
+      stream: (async function* () {
+        yield new LMTextPart('response from chosen model');
+      })(),
+    });
+
+    vi.doMock('vscode', () => ({
+      LanguageModelTextPart: LMTextPart,
+      ChatRequestTurn: class {},
+      ChatResponseTurn: class {},
+      ChatResponseMarkdownPart: class {},
+      LanguageModelChatMessage: {
+        User: (content: string) => ({ content }),
+        Assistant: (content: string) => ({ content }),
+      },
+      lm: { selectChatModels: mockSelectChatModels },
+      workspace: { getConfiguration: vi.fn().mockReturnValue({ get: vi.fn() }) },
+    }));
+
+    const ext = await import('./extension.js');
+    const mockMarkdown = vi.fn();
+    const mockRequest = {
+      prompt: 'test',
+      model: { vendor: 'selfagency-ollama', sendRequest: mockSendRequest },
+    };
+
+    await ext.handleChatRequest(
+      mockRequest as any,
+      { history: [] } as any,
+      { markdown: mockMarkdown } as any,
+      { isCancellationRequested: false } as any,
+    );
+
+    expect(mockSendRequest).toHaveBeenCalled();
+    expect(mockMarkdown).toHaveBeenCalledWith('response from chosen model');
+    expect(mockSelectChatModels).not.toHaveBeenCalled();
   });
 });
 

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1117,7 +1117,7 @@ describe('handleBuiltInOllamaConflict', () => {
       },
       commands: {
         registerCommand: vi.fn(() => ({ dispose: vi.fn() })),
-        executeCommand: vi.fn(),
+        executeCommand: vi.fn().mockResolvedValue(undefined),
       },
       lm: {
         registerLanguageModelChatProvider: vi.fn(() => ({ dispose: vi.fn() })),
@@ -1167,23 +1167,25 @@ describe('handleBuiltInOllamaConflict', () => {
 
   it('does nothing when user dismisses the warning', async () => {
     const showWarningMessage = vi.fn().mockResolvedValue(undefined);
+    const showInformationMessage = vi.fn();
     const mockModel = { id: 'ollama:llama3', vendor: 'ollama', name: 'Llama 3' };
     const selectChatModels = vi.fn().mockResolvedValue([mockModel]);
 
     const ext = await import('./extension.js');
-    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage: vi.fn() }, { selectChatModels });
+    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage }, { selectChatModels });
 
     expect(showWarningMessage).toHaveBeenCalled();
-    // config.update should not be called — workspace mock returns a plain stub
+    expect(showInformationMessage).not.toHaveBeenCalled();
   });
 
-  it('updates config and shows reload prompt when user confirms', async () => {
+  it('shows reload prompt and triggers reload when user confirms', async () => {
     const showWarningMessage = vi.fn().mockResolvedValue('Disable Built-in Ollama Provider');
-    const showInformationMessage = vi.fn().mockResolvedValue(undefined);
+    const showInformationMessage = vi.fn().mockResolvedValue('Reload Window');
     const mockModel = { id: 'ollama:llama3', vendor: 'ollama', name: 'Llama 3' };
     const selectChatModels = vi.fn().mockResolvedValue([mockModel]);
 
     const ext = await import('./extension.js');
+    // No context passed — file write is skipped, but reload should still trigger
     await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage }, { selectChatModels });
 
     expect(showInformationMessage).toHaveBeenCalledWith(

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -972,7 +972,9 @@ describe('handleChatRequest model selection', () => {
     const mockSelectChatModels = vi.fn().mockResolvedValue([]);
 
     vi.doMock('vscode', () => ({
-      LanguageModelTextPart: class { constructor(public value: string) {} },
+      LanguageModelTextPart: class {
+        constructor(public value: string) {}
+      },
       ChatRequestTurn: class {},
       ChatResponseTurn: class {},
       ChatResponseMarkdownPart: class {},
@@ -998,15 +1000,17 @@ describe('handleChatRequest model selection', () => {
   });
 
   it('uses model from selectChatModels when request.model is not our vendor', async () => {
-    const LMTextPart = class { constructor(public value: string) {} };
+    const LMTextPart = class {
+      constructor(public value: string) {}
+    };
     const mockSendRequest = vi.fn().mockResolvedValue({
       stream: (async function* () {
         yield new LMTextPart('hello from ollama');
       })(),
     });
-    const mockSelectChatModels = vi.fn().mockResolvedValue([
-      { vendor: 'selfagency-ollama', sendRequest: mockSendRequest },
-    ]);
+    const mockSelectChatModels = vi
+      .fn()
+      .mockResolvedValue([{ vendor: 'selfagency-ollama', sendRequest: mockSendRequest }]);
 
     vi.doMock('vscode', () => ({
       LanguageModelTextPart: LMTextPart,
@@ -1038,7 +1042,9 @@ describe('handleChatRequest model selection', () => {
   });
 
   it('uses request.model directly when it is already our vendor', async () => {
-    const LMTextPart = class { constructor(public value: string) {} };
+    const LMTextPart = class {
+      constructor(public value: string) {}
+    };
     const mockSelectChatModels = vi.fn();
     const mockSendRequest = vi.fn().mockResolvedValue({
       stream: (async function* () {
@@ -1080,24 +1086,8 @@ describe('handleChatRequest model selection', () => {
 });
 
 describe('handleBuiltInOllamaConflict', () => {
-  const mockStoragePath = '/mock/profiles/abc123/globalStorage/selfagency.ollama-copilot';
-  const mockContext = { globalStorageUri: { fsPath: mockStoragePath } };
-  const modelsWithOllama = JSON.stringify([
-    { name: 'Ollama', vendor: 'ollama', url: 'http://localhost:11434' },
-    { name: 'Anthropic', vendor: 'anthropic', apiKey: 'key' },
-  ]);
-
-  let mockReadFile: ReturnType<typeof vi.fn>;
-  let mockWriteFile: ReturnType<typeof vi.fn>;
-
   beforeEach(() => {
-    mockReadFile = vi.fn().mockResolvedValue(modelsWithOllama);
-    mockWriteFile = vi.fn().mockResolvedValue(undefined);
-
     vi.resetModules();
-    vi.doMock('node:fs', () => ({
-      promises: { readFile: mockReadFile, writeFile: mockWriteFile },
-    }));
     vi.doMock('vscode', () => ({
       TreeItem: class {
         constructor(public label: string) {}
@@ -1116,8 +1106,12 @@ describe('handleBuiltInOllamaConflict', () => {
       Uri: { joinPath: vi.fn().mockReturnValue(undefined), parse: vi.fn() },
       window: {
         createOutputChannel: vi.fn(() => ({
-          info: vi.fn(), warn: vi.fn(), error: vi.fn(),
-          debug: vi.fn(), log: vi.fn(), show: vi.fn(),
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+          log: vi.fn(),
+          show: vi.fn(),
         })),
         showWarningMessage: vi.fn(),
         showInformationMessage: vi.fn(),
@@ -1156,25 +1150,32 @@ describe('handleBuiltInOllamaConflict', () => {
     }));
   });
 
-  it('does nothing when no context is provided', async () => {
+  it('does nothing when no conflicting models are registered', async () => {
     const showWarningMessage = vi.fn();
+    const selectChatModels = vi.fn().mockResolvedValue([]);
+
     const ext = await import('./extension.js');
-    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage: vi.fn() });
+    await ext.handleBuiltInOllamaConflict(
+      { showWarningMessage, showInformationMessage: vi.fn() },
+      { getConfiguration: vi.fn() },
+      { selectChatModels },
+    );
+
+    expect(selectChatModels).toHaveBeenCalledWith({ vendor: 'ollama' });
     expect(showWarningMessage).not.toHaveBeenCalled();
   });
 
-  it('does nothing when chatLanguageModels.json has no ollama entry', async () => {
-    mockReadFile.mockResolvedValue(JSON.stringify([{ name: 'Anthropic', vendor: 'anthropic' }]));
-    const showWarningMessage = vi.fn();
-    const ext = await import('./extension.js');
-    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage: vi.fn() }, undefined, mockContext as any);
-    expect(showWarningMessage).not.toHaveBeenCalled();
-  });
-
-  it('shows a warning when the ollama vendor entry is present', async () => {
+  it('shows a warning when conflicting models are present', async () => {
     const showWarningMessage = vi.fn().mockResolvedValue(undefined);
+    const selectChatModels = vi.fn().mockResolvedValue([{ id: 'ollama:llama3', vendor: 'ollama', name: 'Llama 3' }]);
+
     const ext = await import('./extension.js');
-    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage: vi.fn() }, undefined, mockContext as any);
+    await ext.handleBuiltInOllamaConflict(
+      { showWarningMessage, showInformationMessage: vi.fn() },
+      { getConfiguration: vi.fn() },
+      { selectChatModels },
+    );
+
     expect(showWarningMessage).toHaveBeenCalledWith(
       expect.stringContaining('built-in Ollama provider'),
       'Disable Built-in Ollama Provider',
@@ -1184,27 +1185,38 @@ describe('handleBuiltInOllamaConflict', () => {
   it('does nothing when user dismisses the warning', async () => {
     const showWarningMessage = vi.fn().mockResolvedValue(undefined);
     const showInformationMessage = vi.fn();
+    const mockConfig = { update: vi.fn() };
+    const getConfiguration = vi.fn().mockReturnValue(mockConfig);
+    const selectChatModels = vi.fn().mockResolvedValue([{ id: 'ollama:llama3', vendor: 'ollama', name: 'Llama 3' }]);
+
     const ext = await import('./extension.js');
-    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage }, undefined, mockContext as any);
+    await ext.handleBuiltInOllamaConflict(
+      { showWarningMessage, showInformationMessage },
+      { getConfiguration },
+      { selectChatModels },
+    );
+
     expect(showWarningMessage).toHaveBeenCalled();
     expect(showInformationMessage).not.toHaveBeenCalled();
+    expect(mockConfig.update).not.toHaveBeenCalled();
   });
 
-  it('removes ollama entry, writes file, and triggers reload when user confirms', async () => {
+  it('clears ollama.url setting when user confirms', async () => {
     const showWarningMessage = vi.fn().mockResolvedValue('Disable Built-in Ollama Provider');
-    const showInformationMessage = vi.fn().mockResolvedValue('Reload Window');
-    const ext = await import('./extension.js');
-    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage }, undefined, mockContext as any);
+    const showInformationMessage = vi.fn().mockResolvedValue(undefined);
+    const mockConfig = { update: vi.fn().mockResolvedValue(undefined) };
+    const getConfiguration = vi.fn().mockReturnValue(mockConfig);
+    const selectChatModels = vi.fn().mockResolvedValue([{ id: 'ollama:llama3', vendor: 'ollama', name: 'Llama 3' }]);
 
-    expect(mockWriteFile).toHaveBeenCalledWith(
-      expect.stringContaining('chatLanguageModels.json'),
-      expect.not.stringContaining('"ollama"'),
-      'utf-8',
+    const ext = await import('./extension.js');
+    await ext.handleBuiltInOllamaConflict(
+      { showWarningMessage, showInformationMessage },
+      { getConfiguration },
+      { selectChatModels },
     );
-    expect(showInformationMessage).toHaveBeenCalledWith(
-      expect.stringContaining('Reload VS Code'),
-      'Reload Window',
-    );
+
+    expect(mockConfig.update).toHaveBeenCalledWith('ollama.url', undefined, expect.anything());
+    expect(showInformationMessage).toHaveBeenCalledWith(expect.stringContaining('Reload VS Code'), 'Reload Window');
   });
 });
 

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -895,17 +895,27 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
   it('streams thinking tokens with a reasoning header and separator', async () => {
     vi.doMock('./client.js', () => ({ getOllamaClient: vi.fn(), testConnection: vi.fn() }));
     vi.doMock('./diagnostics.js', () => ({
-      createDiagnosticsLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), exception: vi.fn() }),
+      createDiagnosticsLogger: () => ({
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+        exception: vi.fn(),
+      }),
       getConfiguredLogLevel: vi.fn(() => 'info'),
     }));
     vi.doMock('./provider.js', () => ({
-      OllamaChatModelProvider: class { setAuthToken = vi.fn(); },
+      OllamaChatModelProvider: class {
+        setAuthToken = vi.fn();
+      },
       isThinkingModelId: (id: string) => /(qwen3|qwq|deepseek-?r1|cogito|phi\d+-reasoning)/i.test(id),
     }));
     vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
     vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
     vi.doMock('vscode', () => ({
-      LanguageModelTextPart: class { constructor(public value: string) {} },
+      LanguageModelTextPart: class {
+        constructor(public value: string) {}
+      },
       LanguageModelChatMessageRole: { User: 1, Assistant: 2 },
       ChatRequestTurn: class {},
       ChatResponseTurn: class {},
@@ -940,21 +950,15 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
       model: { vendor: 'selfagency-ollama', id: 'qwen3:8b' },
     };
 
-    await ext.handleChatRequest(
-      request as any,
-      { history: [] } as any,
-      stream as any,
-      token as any,
-      mockClient as any,
-    );
+    await ext.handleChatRequest(request as any, { history: [] } as any, stream as any, token as any, mockClient as any);
 
     const allCalls = mockMarkdown.mock.calls.map((c: any[]) => c[0] as string);
     // Thinking header should appear
-    expect(allCalls.some((v: string) => v.includes('Reasoning') || v.includes('reasoning'))).toBe(true);
+    expect(allCalls.some((v: string) => v.includes('Thinking') || v.includes('thinking'))).toBe(true);
     // Thinking content should be streamed
     expect(allCalls.some((v: string) => v.includes('step 1: consider options'))).toBe(true);
-    // Separator before answer
-    expect(allCalls.some((v: string) => v.includes('---'))).toBe(true);
+    // Should close the details section before answer
+    expect(allCalls.some((v: string) => v.includes('</details>'))).toBe(true);
     // Final answer
     expect(allCalls.some((v: string) => v.includes('The answer is 42.'))).toBe(true);
   });
@@ -962,17 +966,27 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
   it('passes think: true for known thinking model IDs', async () => {
     vi.doMock('./client.js', () => ({ getOllamaClient: vi.fn(), testConnection: vi.fn() }));
     vi.doMock('./diagnostics.js', () => ({
-      createDiagnosticsLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), exception: vi.fn() }),
+      createDiagnosticsLogger: () => ({
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+        exception: vi.fn(),
+      }),
       getConfiguredLogLevel: vi.fn(() => 'info'),
     }));
     vi.doMock('./provider.js', () => ({
-      OllamaChatModelProvider: class { setAuthToken = vi.fn(); },
+      OllamaChatModelProvider: class {
+        setAuthToken = vi.fn();
+      },
       isThinkingModelId: (id: string) => /(qwen3|qwq|deepseek-?r1|cogito|phi\d+-reasoning)/i.test(id),
     }));
     vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
     vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
     vi.doMock('vscode', () => ({
-      LanguageModelTextPart: class { constructor(public value: string) {} },
+      LanguageModelTextPart: class {
+        constructor(public value: string) {}
+      },
       LanguageModelChatMessageRole: { User: 1, Assistant: 2 },
       ChatRequestTurn: class {},
       ChatResponseTurn: class {},
@@ -1005,13 +1019,7 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
       model: { vendor: 'selfagency-ollama', id: 'qwen3:8b' },
     };
 
-    await ext.handleChatRequest(
-      request as any,
-      { history: [] } as any,
-      stream as any,
-      token as any,
-      mockClient as any,
-    );
+    await ext.handleChatRequest(request as any, { history: [] } as any, stream as any, token as any, mockClient as any);
 
     expect(mockChat).toHaveBeenCalledWith(expect.objectContaining({ think: true }));
   });
@@ -1019,17 +1027,27 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
   it('formats tool calls as markdown in participant path', async () => {
     vi.doMock('./client.js', () => ({ getOllamaClient: vi.fn(), testConnection: vi.fn() }));
     vi.doMock('./diagnostics.js', () => ({
-      createDiagnosticsLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), exception: vi.fn() }),
+      createDiagnosticsLogger: () => ({
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+        exception: vi.fn(),
+      }),
       getConfiguredLogLevel: vi.fn(() => 'info'),
     }));
     vi.doMock('./provider.js', () => ({
-      OllamaChatModelProvider: class { setAuthToken = vi.fn(); },
+      OllamaChatModelProvider: class {
+        setAuthToken = vi.fn();
+      },
       isThinkingModelId: (id: string) => /(qwen3|qwq|deepseek-?r1|cogito|phi\d+-reasoning)/i.test(id),
     }));
     vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
     vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
     vi.doMock('vscode', () => ({
-      LanguageModelTextPart: class { constructor(public value: string) {} },
+      LanguageModelTextPart: class {
+        constructor(public value: string) {}
+      },
       LanguageModelChatMessageRole: { User: 1, Assistant: 2 },
       ChatRequestTurn: class {},
       ChatResponseTurn: class {},
@@ -1069,13 +1087,7 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
       model: { vendor: 'selfagency-ollama', id: 'llama3.2:latest' },
     };
 
-    await ext.handleChatRequest(
-      request as any,
-      { history: [] } as any,
-      stream as any,
-      token as any,
-      mockClient as any,
-    );
+    await ext.handleChatRequest(request as any, { history: [] } as any, stream as any, token as any, mockClient as any);
 
     const allCalls = mockMarkdown.mock.calls.map((c: any[]) => c[0] as string);
     expect(allCalls.some((v: string) => v.includes('get_weather'))).toBe(true);

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -887,6 +887,201 @@ describe('handleChatRequest', () => {
   });
 });
 
+describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('streams thinking tokens with a reasoning header and separator', async () => {
+    vi.doMock('./client.js', () => ({ getOllamaClient: vi.fn(), testConnection: vi.fn() }));
+    vi.doMock('./diagnostics.js', () => ({
+      createDiagnosticsLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), exception: vi.fn() }),
+      getConfiguredLogLevel: vi.fn(() => 'info'),
+    }));
+    vi.doMock('./provider.js', () => ({
+      OllamaChatModelProvider: class { setAuthToken = vi.fn(); },
+      isThinkingModelId: (id: string) => /(qwen3|qwq|deepseek-?r1|cogito|phi\d+-reasoning)/i.test(id),
+    }));
+    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
+    vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
+    vi.doMock('vscode', () => ({
+      LanguageModelTextPart: class { constructor(public value: string) {} },
+      LanguageModelChatMessageRole: { User: 1, Assistant: 2 },
+      ChatRequestTurn: class {},
+      ChatResponseTurn: class {},
+      ChatResponseMarkdownPart: class {},
+      LanguageModelChatMessage: {
+        User: (content: string) => ({ role: 1, content }),
+        Assistant: (content: string) => ({ role: 2, content }),
+      },
+      lm: { selectChatModels: vi.fn().mockResolvedValue([]) },
+      workspace: { getConfiguration: vi.fn().mockReturnValue({ get: vi.fn() }) },
+    }));
+
+    const ext = await import('./extension.js');
+
+    const mockMarkdown = vi.fn();
+    const stream = { markdown: mockMarkdown };
+    const token = { isCancellationRequested: false };
+
+    const mockClient = {
+      chat: vi.fn().mockResolvedValue(
+        (async function* () {
+          yield { message: { thinking: 'step 1: consider options' } };
+          yield { message: { thinking: ' step 2: decide' } };
+          yield { message: { content: 'The answer is 42.' } };
+          yield { message: {}, done: true };
+        })(),
+      ),
+    };
+
+    const request = {
+      prompt: 'what is the meaning of life?',
+      model: { vendor: 'selfagency-ollama', id: 'qwen3:8b' },
+    };
+
+    await ext.handleChatRequest(
+      request as any,
+      { history: [] } as any,
+      stream as any,
+      token as any,
+      mockClient as any,
+    );
+
+    const allCalls = mockMarkdown.mock.calls.map((c: any[]) => c[0] as string);
+    // Thinking header should appear
+    expect(allCalls.some((v: string) => v.includes('Reasoning') || v.includes('reasoning'))).toBe(true);
+    // Thinking content should be streamed
+    expect(allCalls.some((v: string) => v.includes('step 1: consider options'))).toBe(true);
+    // Separator before answer
+    expect(allCalls.some((v: string) => v.includes('---'))).toBe(true);
+    // Final answer
+    expect(allCalls.some((v: string) => v.includes('The answer is 42.'))).toBe(true);
+  });
+
+  it('passes think: true for known thinking model IDs', async () => {
+    vi.doMock('./client.js', () => ({ getOllamaClient: vi.fn(), testConnection: vi.fn() }));
+    vi.doMock('./diagnostics.js', () => ({
+      createDiagnosticsLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), exception: vi.fn() }),
+      getConfiguredLogLevel: vi.fn(() => 'info'),
+    }));
+    vi.doMock('./provider.js', () => ({
+      OllamaChatModelProvider: class { setAuthToken = vi.fn(); },
+      isThinkingModelId: (id: string) => /(qwen3|qwq|deepseek-?r1|cogito|phi\d+-reasoning)/i.test(id),
+    }));
+    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
+    vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
+    vi.doMock('vscode', () => ({
+      LanguageModelTextPart: class { constructor(public value: string) {} },
+      LanguageModelChatMessageRole: { User: 1, Assistant: 2 },
+      ChatRequestTurn: class {},
+      ChatResponseTurn: class {},
+      ChatResponseMarkdownPart: class {},
+      LanguageModelChatMessage: {
+        User: (content: string) => ({ role: 1, content }),
+        Assistant: (content: string) => ({ role: 2, content }),
+      },
+      lm: { selectChatModels: vi.fn().mockResolvedValue([]) },
+      workspace: { getConfiguration: vi.fn().mockReturnValue({ get: vi.fn() }) },
+      Uri: { joinPath: vi.fn((_base: any, p: string) => ({ fsPath: p })) },
+      chat: { createChatParticipant: vi.fn(() => ({ iconPath: undefined, dispose: vi.fn() })) },
+      commands: { registerCommand: vi.fn(() => ({ dispose: vi.fn() })), executeCommand: vi.fn() },
+    }));
+
+    const ext = await import('./extension.js');
+
+    const mockChat = vi.fn().mockResolvedValue(
+      (async function* () {
+        yield { message: { content: 'ok' }, done: true };
+      })(),
+    );
+
+    const mockClient = { chat: mockChat };
+    const stream = { markdown: vi.fn() };
+    const token = { isCancellationRequested: false };
+
+    const request = {
+      prompt: 'hi',
+      model: { vendor: 'selfagency-ollama', id: 'qwen3:8b' },
+    };
+
+    await ext.handleChatRequest(
+      request as any,
+      { history: [] } as any,
+      stream as any,
+      token as any,
+      mockClient as any,
+    );
+
+    expect(mockChat).toHaveBeenCalledWith(expect.objectContaining({ think: true }));
+  });
+
+  it('formats tool calls as markdown in participant path', async () => {
+    vi.doMock('./client.js', () => ({ getOllamaClient: vi.fn(), testConnection: vi.fn() }));
+    vi.doMock('./diagnostics.js', () => ({
+      createDiagnosticsLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), exception: vi.fn() }),
+      getConfiguredLogLevel: vi.fn(() => 'info'),
+    }));
+    vi.doMock('./provider.js', () => ({
+      OllamaChatModelProvider: class { setAuthToken = vi.fn(); },
+      isThinkingModelId: (id: string) => /(qwen3|qwq|deepseek-?r1|cogito|phi\d+-reasoning)/i.test(id),
+    }));
+    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
+    vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
+    vi.doMock('vscode', () => ({
+      LanguageModelTextPart: class { constructor(public value: string) {} },
+      LanguageModelChatMessageRole: { User: 1, Assistant: 2 },
+      ChatRequestTurn: class {},
+      ChatResponseTurn: class {},
+      ChatResponseMarkdownPart: class {},
+      LanguageModelChatMessage: {
+        User: (content: string) => ({ role: 1, content }),
+        Assistant: (content: string) => ({ role: 2, content }),
+      },
+      lm: { selectChatModels: vi.fn().mockResolvedValue([]) },
+      workspace: { getConfiguration: vi.fn().mockReturnValue({ get: vi.fn() }) },
+      Uri: { joinPath: vi.fn((_base: any, p: string) => ({ fsPath: p })) },
+      chat: { createChatParticipant: vi.fn(() => ({ iconPath: undefined, dispose: vi.fn() })) },
+      commands: { registerCommand: vi.fn(() => ({ dispose: vi.fn() })), executeCommand: vi.fn() },
+    }));
+
+    const ext = await import('./extension.js');
+
+    const mockMarkdown = vi.fn();
+    const stream = { markdown: mockMarkdown };
+    const token = { isCancellationRequested: false };
+
+    const mockClient = {
+      chat: vi.fn().mockResolvedValue(
+        (async function* () {
+          yield {
+            message: {
+              tool_calls: [{ function: { name: 'get_weather', arguments: { location: 'NYC' } } }],
+            },
+          };
+          yield { message: { content: 'It is sunny in NYC.' }, done: true };
+        })(),
+      ),
+    };
+
+    const request = {
+      prompt: "what's the weather?",
+      model: { vendor: 'selfagency-ollama', id: 'llama3.2:latest' },
+    };
+
+    await ext.handleChatRequest(
+      request as any,
+      { history: [] } as any,
+      stream as any,
+      token as any,
+      mockClient as any,
+    );
+
+    const allCalls = mockMarkdown.mock.calls.map((c: any[]) => c[0] as string);
+    expect(allCalls.some((v: string) => v.includes('get_weather'))).toBe(true);
+  });
+});
+
 describe('handleConnectionTestFailure', () => {
   it('shows error message and executes command when Open Settings selected', async () => {
     const showErrorMessage = vi.fn().mockResolvedValue('Open Settings');

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1080,8 +1080,24 @@ describe('handleChatRequest model selection', () => {
 });
 
 describe('handleBuiltInOllamaConflict', () => {
+  const mockStoragePath = '/mock/profiles/abc123/globalStorage/selfagency.ollama-copilot';
+  const mockContext = { globalStorageUri: { fsPath: mockStoragePath } };
+  const modelsWithOllama = JSON.stringify([
+    { name: 'Ollama', vendor: 'ollama', url: 'http://localhost:11434' },
+    { name: 'Anthropic', vendor: 'anthropic', apiKey: 'key' },
+  ]);
+
+  let mockReadFile: ReturnType<typeof vi.fn>;
+  let mockWriteFile: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
+    mockReadFile = vi.fn().mockResolvedValue(modelsWithOllama);
+    mockWriteFile = vi.fn().mockResolvedValue(undefined);
+
     vi.resetModules();
+    vi.doMock('node:fs', () => ({
+      promises: { readFile: mockReadFile, writeFile: mockWriteFile },
+    }));
     vi.doMock('vscode', () => ({
       TreeItem: class {
         constructor(public label: string) {}
@@ -1140,25 +1156,25 @@ describe('handleBuiltInOllamaConflict', () => {
     }));
   });
 
-  it('does nothing when no conflicting models are registered', async () => {
+  it('does nothing when no context is provided', async () => {
     const showWarningMessage = vi.fn();
-    const selectChatModels = vi.fn().mockResolvedValue([]);
-
     const ext = await import('./extension.js');
-    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage: vi.fn() }, { selectChatModels });
-
-    expect(selectChatModels).toHaveBeenCalledWith({ vendor: 'ollama' });
+    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage: vi.fn() });
     expect(showWarningMessage).not.toHaveBeenCalled();
   });
 
-  it('shows a warning when conflicting Ollama models are present', async () => {
-    const showWarningMessage = vi.fn().mockResolvedValue(undefined);
-    const mockModel = { id: 'ollama:llama3', vendor: 'ollama', name: 'Llama 3' };
-    const selectChatModels = vi.fn().mockResolvedValue([mockModel]);
-
+  it('does nothing when chatLanguageModels.json has no ollama entry', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify([{ name: 'Anthropic', vendor: 'anthropic' }]));
+    const showWarningMessage = vi.fn();
     const ext = await import('./extension.js');
-    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage: vi.fn() }, { selectChatModels });
+    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage: vi.fn() }, undefined, mockContext as any);
+    expect(showWarningMessage).not.toHaveBeenCalled();
+  });
 
+  it('shows a warning when the ollama vendor entry is present', async () => {
+    const showWarningMessage = vi.fn().mockResolvedValue(undefined);
+    const ext = await import('./extension.js');
+    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage: vi.fn() }, undefined, mockContext as any);
     expect(showWarningMessage).toHaveBeenCalledWith(
       expect.stringContaining('built-in Ollama provider'),
       'Disable Built-in Ollama Provider',
@@ -1168,26 +1184,23 @@ describe('handleBuiltInOllamaConflict', () => {
   it('does nothing when user dismisses the warning', async () => {
     const showWarningMessage = vi.fn().mockResolvedValue(undefined);
     const showInformationMessage = vi.fn();
-    const mockModel = { id: 'ollama:llama3', vendor: 'ollama', name: 'Llama 3' };
-    const selectChatModels = vi.fn().mockResolvedValue([mockModel]);
-
     const ext = await import('./extension.js');
-    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage }, { selectChatModels });
-
+    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage }, undefined, mockContext as any);
     expect(showWarningMessage).toHaveBeenCalled();
     expect(showInformationMessage).not.toHaveBeenCalled();
   });
 
-  it('shows reload prompt and triggers reload when user confirms', async () => {
+  it('removes ollama entry, writes file, and triggers reload when user confirms', async () => {
     const showWarningMessage = vi.fn().mockResolvedValue('Disable Built-in Ollama Provider');
     const showInformationMessage = vi.fn().mockResolvedValue('Reload Window');
-    const mockModel = { id: 'ollama:llama3', vendor: 'ollama', name: 'Llama 3' };
-    const selectChatModels = vi.fn().mockResolvedValue([mockModel]);
-
     const ext = await import('./extension.js');
-    // No context passed — file write is skipped, but reload should still trigger
-    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage }, { selectChatModels });
+    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage }, undefined, mockContext as any);
 
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      expect.stringContaining('chatLanguageModels.json'),
+      expect.not.stringContaining('"ollama"'),
+      'utf-8',
+    );
     expect(showInformationMessage).toHaveBeenCalledWith(
       expect.stringContaining('Reload VS Code'),
       'Reload Window',

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -957,8 +957,8 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
     expect(allCalls.some((v: string) => v.includes('Thinking') || v.includes('thinking'))).toBe(true);
     // Thinking content should be streamed
     expect(allCalls.some((v: string) => v.includes('step 1: consider options'))).toBe(true);
-    // Should close the details section before answer
-    expect(allCalls.some((v: string) => v.includes('</details>'))).toBe(true);
+    // Separator before answer
+    expect(allCalls.some((v: string) => v.includes('---'))).toBe(true);
     // Final answer
     expect(allCalls.some((v: string) => v.includes('The answer is 42.'))).toBe(true);
   });

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1079,6 +1079,123 @@ describe('handleChatRequest model selection', () => {
   });
 });
 
+describe('handleBuiltInOllamaConflict', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doMock('vscode', () => ({
+      TreeItem: class {
+        constructor(public label: string) {}
+      },
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      EventEmitter: class {
+        event = {};
+        fire = vi.fn();
+      },
+      ConfigurationTarget: { Global: 1, Workspace: 2, WorkspaceFolder: 3 },
+      ProgressLocation: { Notification: 15 },
+      Disposable: class {
+        dispose = vi.fn();
+      },
+      env: { openExternal: vi.fn() },
+      Uri: { joinPath: vi.fn().mockReturnValue(undefined), parse: vi.fn() },
+      window: {
+        createOutputChannel: vi.fn(() => ({
+          info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+          debug: vi.fn(), log: vi.fn(), show: vi.fn(),
+        })),
+        showWarningMessage: vi.fn(),
+        showInformationMessage: vi.fn(),
+        showErrorMessage: vi.fn(),
+        showInputBox: vi.fn(),
+        registerTreeDataProvider: vi.fn(() => ({ dispose: vi.fn() })),
+        registerWebviewViewProvider: vi.fn(() => ({ dispose: vi.fn() })),
+        withProgress: vi.fn(async (_: any, cb: any) => cb({ report: vi.fn() })),
+      },
+      workspace: {
+        getConfiguration: vi.fn(() => ({ get: vi.fn(), update: vi.fn() })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+      commands: {
+        registerCommand: vi.fn(() => ({ dispose: vi.fn() })),
+        executeCommand: vi.fn(),
+      },
+      lm: {
+        registerLanguageModelChatProvider: vi.fn(() => ({ dispose: vi.fn() })),
+        selectChatModels: vi.fn().mockResolvedValue([]),
+      },
+      chat: {
+        createChatParticipant: vi.fn(() => ({ iconPath: undefined, dispose: vi.fn() })),
+      },
+      LanguageModelChatMessage: {
+        User: vi.fn((c: string) => ({ content: c })),
+        Assistant: vi.fn((c: string) => ({ content: c })),
+      },
+      LanguageModelTextPart: class {
+        constructor(public value: string) {}
+      },
+      ChatRequestTurn: class {},
+      ChatResponseTurn: class {},
+      ChatResponseMarkdownPart: class {},
+    }));
+  });
+
+  it('does nothing when github.copilot.chat.ollama.url is empty', async () => {
+    const showWarningMessage = vi.fn();
+    const mockConfig = { get: vi.fn().mockReturnValue(''), update: vi.fn() };
+    const getConfiguration = vi.fn().mockReturnValue(mockConfig);
+
+    const ext = await import('./extension.js');
+    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage: vi.fn() }, { getConfiguration });
+
+    expect(showWarningMessage).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when github.copilot.chat.ollama.url is undefined', async () => {
+    const showWarningMessage = vi.fn();
+    const mockConfig = { get: vi.fn().mockReturnValue(undefined), update: vi.fn() };
+    const getConfiguration = vi.fn().mockReturnValue(mockConfig);
+
+    const ext = await import('./extension.js');
+    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage: vi.fn() }, { getConfiguration });
+
+    expect(showWarningMessage).not.toHaveBeenCalled();
+  });
+
+  it('shows a warning when the built-in Ollama URL is set', async () => {
+    const showWarningMessage = vi.fn().mockResolvedValue(undefined);
+    const mockConfig = { get: vi.fn().mockReturnValue('http://localhost:11434'), update: vi.fn() };
+    const getConfiguration = vi.fn().mockReturnValue(mockConfig);
+
+    const ext = await import('./extension.js');
+    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage: vi.fn() }, { getConfiguration });
+
+    expect(showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining("built-in Ollama provider"),
+      'Disable Built-in Ollama Provider',
+    );
+    expect(mockConfig.update).not.toHaveBeenCalled();
+  });
+
+  it('clears the URL and shows reload prompt when user confirms', async () => {
+    const showWarningMessage = vi.fn().mockResolvedValue('Disable Built-in Ollama Provider');
+    const showInformationMessage = vi.fn().mockResolvedValue(undefined);
+    const mockConfig = {
+      get: vi.fn().mockReturnValue('http://localhost:11434'),
+      update: vi.fn().mockResolvedValue(undefined),
+    };
+    const getConfiguration = vi.fn().mockReturnValue(mockConfig);
+
+    const ext = await import('./extension.js');
+    await ext.handleBuiltInOllamaConflict({ showWarningMessage, showInformationMessage }, { getConfiguration });
+
+    expect(mockConfig.update).toHaveBeenCalledWith('ollama.url', '', expect.anything());
+    expect(showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Reload VS Code'),
+      'Reload Window',
+    );
+  });
+});
+
 describe('handleConfigurationChange', () => {
   it('calls onLogLevelChange when log level configuration changes', async () => {
     const mockDiagnostics = { info: vi.fn() };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -284,6 +284,19 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Detect and offer to disable Copilot's built-in Ollama provider (non-blocking)
   void handleBuiltInOllamaConflict();
+  const conflictCheckDelaysMs = [1_500, 5_000, 10_000];
+  const conflictCheckTimers = conflictCheckDelaysMs.map(delay =>
+    setTimeout(() => {
+      void handleBuiltInOllamaConflict();
+    }, delay),
+  );
+  context.subscriptions.push({
+    dispose: () => {
+      for (const timer of conflictCheckTimers) {
+        clearTimeout(timer);
+      }
+    },
+  });
 
   // Test connection to Ollama server on startup (non-blocking)
   void (async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,19 +66,17 @@ export function setupChatParticipant(
 
 /**
  * Detect and offer to disable Copilot's conflicting built-in Ollama provider.
- * That provider registers under vendor 'ollama' and is active whenever
- * github.copilot.chat.ollama.url is non-empty.
+ * Detects by querying the LM API for models registered under vendor 'ollama'.
  */
 export async function handleBuiltInOllamaConflict(
   windowApi?: Pick<typeof vscode.window, 'showWarningMessage' | 'showInformationMessage'>,
-  workspaceApi?: Pick<typeof vscode.workspace, 'getConfiguration'>,
+  lmApi?: Pick<typeof vscode.lm, 'selectChatModels'>,
 ): Promise<void> {
   const win = windowApi ?? vscode.window;
-  const ws = workspaceApi ?? vscode.workspace;
+  const lm = lmApi ?? vscode.lm;
 
-  const config = ws.getConfiguration('github.copilot.chat');
-  const url = config.get<string>('ollama.url');
-  if (!url) return;
+  const conflictModels = await lm.selectChatModels({ vendor: 'ollama' });
+  if (!conflictModels.length) return;
 
   const selection = await win.showWarningMessage(
     "Copilot's built-in Ollama provider is active and will show duplicate models alongside this extension. Disable it?",
@@ -87,11 +85,9 @@ export async function handleBuiltInOllamaConflict(
 
   if (selection !== 'Disable Built-in Ollama Provider') return;
 
-  await (config as vscode.WorkspaceConfiguration).update(
-    'ollama.url',
-    '',
-    vscode.ConfigurationTarget.Global,
-  );
+  await vscode.workspace
+    .getConfiguration('github.copilot.chat')
+    .update('ollama.url', undefined, vscode.ConfigurationTarget.Global);
 
   await win.showInformationMessage(
     "Copilot's built-in Ollama provider has been disabled. Reload VS Code to apply.",
@@ -284,6 +280,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Detect and offer to disable Copilot's built-in Ollama provider (non-blocking)
   void handleBuiltInOllamaConflict();
+  if (vscode.lm.onDidChangeChatModels) {
+    context.subscriptions.push(
+      vscode.lm.onDidChangeChatModels(() => { void handleBuiltInOllamaConflict(); }),
+    );
+  }
 
   // Test connection to Ollama server on startup (non-blocking)
   void (async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -215,29 +215,6 @@ export async function handleBuiltInOllamaConflict(
 }
 
 /**
- * Configure Copilot's built-in Ollama BYOK integration to use our endpoint.
- * This routes direct model-picker requests through Copilot's in-process BYOK handler,
- * avoiding the IPC boundary that buffers streamed responses for external providers.
- */
-export async function configureBYOKOllama(
-  host: string,
-  bearer?: string,
-  workspaceApi?: Pick<typeof vscode.workspace, 'getConfiguration'>,
-): Promise<void> {
-  const ws = workspaceApi ?? vscode.workspace;
-  try {
-    const config = ws.getConfiguration('github.copilot.chat') as vscode.WorkspaceConfiguration;
-    await config.update('ollama.url', host, vscode.ConfigurationTarget.Global);
-    if (bearer !== undefined) {
-      await config.update('ollama.bearer', bearer || null, vscode.ConfigurationTarget.Global);
-    }
-  } catch {
-    // The github.copilot.chat settings may not be registered in all VS Code environments
-    // (e.g. test hosts without Copilot). BYOK is an optional streaming enhancement.
-  }
-}
-
-/**
  * Build and send a message to the language model.
  *
  * When `client` is provided the request is streamed directly from Ollama —

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { promises as fsPromises } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import * as vscode from 'vscode';
 import { getOllamaClient, testConnection } from './client.js';
 import { createDiagnosticsLogger, getConfiguredLogLevel, type DiagnosticsLogger } from './diagnostics.js';
@@ -21,6 +22,60 @@ function isSelectedAction(selection: unknown, actionLabel: string): boolean {
   }
 
   return false;
+}
+
+async function removeBuiltInOllamaFromChatLanguageModels(
+  context: Pick<vscode.ExtensionContext, 'globalStorageUri'>,
+): Promise<boolean> {
+  const candidatePaths = new Set<string>();
+
+  // globalStorageUri: .../profiles/<profile-id>/globalStorage/<extension-id>
+  // or .../User/globalStorage/<extension-id>
+  const profileDir = dirname(dirname(context.globalStorageUri.fsPath));
+  candidatePaths.add(join(profileDir, 'chatLanguageModels.json'));
+
+  // Standard VS Code user folder on macOS where profile data lives.
+  const userDir = join(homedir(), 'Library', 'Application Support', 'Code', 'User');
+  candidatePaths.add(join(userDir, 'chatLanguageModels.json'));
+
+  // Profile-scoped files: User/profiles/<id>/chatLanguageModels.json
+  try {
+    const profilesDir = join(userDir, 'profiles');
+    const entries = await fsPromises.readdir(profilesDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        candidatePaths.add(join(profilesDir, entry.name, 'chatLanguageModels.json'));
+      }
+    }
+  } catch {
+    // profiles directory may not exist
+  }
+
+  let changed = false;
+  for (const modelsPath of candidatePaths) {
+    try {
+      const raw = await fsPromises.readFile(modelsPath, 'utf8');
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) {
+        continue;
+      }
+
+      const filtered = parsed.filter(
+        item => !(item && typeof item === 'object' && (item as Record<string, unknown>).vendor === 'ollama'),
+      );
+
+      if (filtered.length === parsed.length) {
+        continue;
+      }
+
+      await fsPromises.writeFile(modelsPath, `${JSON.stringify(filtered, null, 2)}\n`, 'utf8');
+      changed = true;
+    } catch {
+      // file missing/unreadable/unwritable for this candidate, continue trying others
+    }
+  }
+
+  return changed;
 }
 
 /**
@@ -82,10 +137,11 @@ export function setupChatParticipant(
  * Detects via LM models registered under vendor 'ollama'.
  */
 export async function handleBuiltInOllamaConflict(
-  windowApi?: Pick<typeof vscode.window, 'showWarningMessage' | 'showInformationMessage'>,
+  windowApi?: Pick<typeof vscode.window, 'showWarningMessage' | 'showInformationMessage' | 'showErrorMessage'>,
   workspaceApi?: Pick<typeof vscode.workspace, 'getConfiguration'>,
   lmApi?: Pick<typeof vscode.lm, 'selectChatModels'>,
   commandsApi?: Pick<typeof vscode.commands, 'executeCommand'>,
+  context?: Pick<vscode.ExtensionContext, 'globalStorageUri'>,
 ): Promise<void> {
   if (builtInOllamaConflictPromptInProgress) {
     return;
@@ -110,15 +166,37 @@ export async function handleBuiltInOllamaConflict(
 
     // Use empty string to disable the built-in provider explicitly.
     // Using undefined can fall back to a non-empty default and keep it enabled.
+    let disabled = false;
     try {
       await (ws.getConfiguration('github.copilot.chat') as vscode.WorkspaceConfiguration).update(
         'ollama.url',
         '',
         vscode.ConfigurationTarget.Global,
       );
+      disabled = true;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      await vscode.window.showErrorMessage(`Failed to disable Copilot's built-in Ollama provider: ${message}`);
+
+      // Some debug hosts don't register github.copilot.chat.ollama.url as a writable setting.
+      // Fall back to profile-scoped chatLanguageModels.json when available.
+      if (message.includes('not a registered configuration') && context) {
+        try {
+          disabled = await removeBuiltInOllamaFromChatLanguageModels(context);
+        } catch (fallbackError) {
+          const fallbackMessage = fallbackError instanceof Error ? fallbackError.message : String(fallbackError);
+          await win.showErrorMessage(`Failed to disable Copilot's built-in Ollama provider: ${fallbackMessage}`);
+          return;
+        }
+      } else {
+        await win.showErrorMessage(`Failed to disable Copilot's built-in Ollama provider: ${message}`);
+        return;
+      }
+    }
+
+    if (!disabled) {
+      await win.showErrorMessage(
+        'Built-in Ollama provider appears to still be enabled. Please disable it in Chat Language Models settings.',
+      );
       return;
     }
 
@@ -319,11 +397,11 @@ export async function activate(context: vscode.ExtensionContext) {
   registerModelfileManager(context, client, diagnostics);
 
   // Detect and offer to disable Copilot's built-in Ollama provider (non-blocking)
-  void handleBuiltInOllamaConflict();
+  void handleBuiltInOllamaConflict(undefined, undefined, undefined, undefined, context);
   const conflictCheckDelaysMs = [1_500, 5_000, 10_000];
   const conflictCheckTimers = conflictCheckDelaysMs.map(delay =>
     setTimeout(() => {
-      void handleBuiltInOllamaConflict();
+      void handleBuiltInOllamaConflict(undefined, undefined, undefined, undefined, context);
     }, delay),
   );
   context.subscriptions.push({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -297,7 +297,6 @@ export async function handleChatRequest(
           chatError.name === 'ResponseError' &&
           chatError.message.toLowerCase().includes('does not support thinking')
         ) {
-          shouldThink = false;
           response = await client.chat({
             model: modelId,
             messages: ollamaMessages,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { registerSidebar } from './sidebar.js';
 import { registerModelfileManager } from './modelfiles.js';
 
 const LANGUAGE_MODEL_VENDOR = 'selfagency-ollama';
+let builtInOllamaConflictPromptInProgress = false;
 
 /**
  * Handle configuration changes for log level and auto-start log streaming
@@ -72,31 +73,48 @@ export async function handleBuiltInOllamaConflict(
   windowApi?: Pick<typeof vscode.window, 'showWarningMessage' | 'showInformationMessage'>,
   workspaceApi?: Pick<typeof vscode.workspace, 'getConfiguration'>,
   lmApi?: Pick<typeof vscode.lm, 'selectChatModels'>,
+  commandsApi?: Pick<typeof vscode.commands, 'executeCommand'>,
 ): Promise<void> {
+  if (builtInOllamaConflictPromptInProgress) {
+    return;
+  }
+
   const win = windowApi ?? vscode.window;
   const ws = workspaceApi ?? vscode.workspace;
   const lm = lmApi ?? vscode.lm;
+  const commands = commandsApi ?? vscode.commands;
 
   const conflictModels = await lm.selectChatModels({ vendor: 'ollama' });
   if (!conflictModels.length) return;
 
-  const selection = await win.showWarningMessage(
-    "Copilot's built-in Ollama provider is active and will show duplicate models alongside this extension. Disable it?",
-    'Disable Built-in Ollama Provider',
-  );
+  builtInOllamaConflictPromptInProgress = true;
+  try {
+    const selection = await win.showWarningMessage(
+      "Copilot's built-in Ollama provider is active and will show duplicate models alongside this extension. Disable it?",
+      'Disable Built-in Ollama Provider',
+    );
 
-  if (selection !== 'Disable Built-in Ollama Provider') return;
+    if (selection !== 'Disable Built-in Ollama Provider') return;
 
-  await (ws.getConfiguration('github.copilot.chat') as vscode.WorkspaceConfiguration).update(
-    'ollama.url',
-    undefined,
-    vscode.ConfigurationTarget.Global,
-  );
+    // Use empty string to disable the built-in provider explicitly.
+    // Using undefined can fall back to a non-empty default and keep it enabled.
+    await (ws.getConfiguration('github.copilot.chat') as vscode.WorkspaceConfiguration).update(
+      'ollama.url',
+      '',
+      vscode.ConfigurationTarget.Global,
+    );
 
-  await win.showInformationMessage(
-    "Copilot's built-in Ollama provider has been disabled. Reload VS Code to apply.",
-    'Reload Window',
-  );
+    const reloadSelection = await win.showInformationMessage(
+      "Copilot's built-in Ollama provider has been disabled. Reload VS Code to apply.",
+      'Reload Window',
+    );
+
+    if (reloadSelection === 'Reload Window') {
+      await commands.executeCommand('workbench.action.reloadWindow');
+    }
+  } finally {
+    builtInOllamaConflictPromptInProgress = false;
+  }
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,8 +91,20 @@ export async function handleChatRequest(
 
   messages.push(vscode.LanguageModelChatMessage.User(request.prompt));
 
+  let model: vscode.LanguageModelChat;
+  if (request.model.vendor === LANGUAGE_MODEL_VENDOR) {
+    model = request.model;
+  } else {
+    const models = await vscode.lm.selectChatModels({ vendor: LANGUAGE_MODEL_VENDOR });
+    if (!models.length) {
+      stream.markdown('No Ollama models available. Pull a model first using the Ollama sidebar.');
+      return;
+    }
+    model = models[0];
+  }
+
   try {
-    const response = await request.model.sendRequest(messages, {}, token);
+    const response = await model.sendRequest(messages, {}, token);
     for await (const chunk of response.stream) {
       if (chunk instanceof vscode.LanguageModelTextPart) {
         stream.markdown(chunk.value);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
-import { promises as fsPromises } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import * as vscode from 'vscode';
 import { getOllamaClient, testConnection } from './client.js';
 import { createDiagnosticsLogger, getConfiguredLogLevel, type DiagnosticsLogger } from './diagnostics.js';
@@ -67,33 +66,19 @@ export function setupChatParticipant(
 
 /**
  * Detect and offer to disable Copilot's conflicting built-in Ollama provider.
- * Detects by reading chatLanguageModels.json from the VS Code profile folder,
- * which is located two levels above the extension's globalStorageUri.
+ * Detects via LM models registered under vendor 'ollama'.
  */
 export async function handleBuiltInOllamaConflict(
   windowApi?: Pick<typeof vscode.window, 'showWarningMessage' | 'showInformationMessage'>,
+  workspaceApi?: Pick<typeof vscode.workspace, 'getConfiguration'>,
   lmApi?: Pick<typeof vscode.lm, 'selectChatModels'>,
-  context?: Pick<vscode.ExtensionContext, 'globalStorageUri'>,
 ): Promise<void> {
   const win = windowApi ?? vscode.window;
+  const ws = workspaceApi ?? vscode.workspace;
+  const lm = lmApi ?? vscode.lm;
 
-  if (!context) return;
-
-  // Locate chatLanguageModels.json: globalStorageUri is …/profiles/<hash>/globalStorage/<extId>/
-  // Two levels up = the profile folder that owns this file.
-  const profileDir = dirname(dirname(context.globalStorageUri.fsPath));
-  const modelsFile = join(profileDir, 'chatLanguageModels.json');
-
-  let models: Array<Record<string, unknown>>;
-  try {
-    const raw = await fsPromises.readFile(modelsFile, 'utf-8');
-    models = JSON.parse(raw) as Array<Record<string, unknown>>;
-  } catch {
-    return; // File doesn't exist or isn't readable — nothing to do
-  }
-
-  const hasBuiltInOllama = models.some(m => m['vendor'] === 'ollama');
-  if (!hasBuiltInOllama) return;
+  const conflictModels = await lm.selectChatModels({ vendor: 'ollama' });
+  if (!conflictModels.length) return;
 
   const selection = await win.showWarningMessage(
     "Copilot's built-in Ollama provider is active and will show duplicate models alongside this extension. Disable it?",
@@ -102,20 +87,16 @@ export async function handleBuiltInOllamaConflict(
 
   if (selection !== 'Disable Built-in Ollama Provider') return;
 
-  try {
-    const filtered = models.filter(m => m['vendor'] !== 'ollama');
-    await fsPromises.writeFile(modelsFile, JSON.stringify(filtered, null, 2) + '\n', 'utf-8');
-  } catch {
-    // File write failed; still prompt to reload so the user knows to act
-  }
+  await (ws.getConfiguration('github.copilot.chat') as vscode.WorkspaceConfiguration).update(
+    'ollama.url',
+    undefined,
+    vscode.ConfigurationTarget.Global,
+  );
 
-  const choice = await win.showInformationMessage(
+  await win.showInformationMessage(
     "Copilot's built-in Ollama provider has been disabled. Reload VS Code to apply.",
     'Reload Window',
   );
-  if (choice === 'Reload Window') {
-    await vscode.commands.executeCommand('workbench.action.reloadWindow');
-  }
 }
 
 /**
@@ -302,12 +283,7 @@ export async function activate(context: vscode.ExtensionContext) {
   registerModelfileManager(context, client, diagnostics);
 
   // Detect and offer to disable Copilot's built-in Ollama provider (non-blocking)
-  void handleBuiltInOllamaConflict(undefined, undefined, context);
-  if (vscode.lm.onDidChangeChatModels) {
-    context.subscriptions.push(
-      vscode.lm.onDidChangeChatModels(() => { void handleBuiltInOllamaConflict(undefined, undefined, context); }),
-    );
-  }
+  void handleBuiltInOllamaConflict();
 
   // Test connection to Ollama server on startup (non-blocking)
   void (async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,9 +6,9 @@ import type { ChatResponse, Ollama } from 'ollama';
 import * as vscode from 'vscode';
 import { getOllamaClient, testConnection } from './client.js';
 import { createDiagnosticsLogger, getConfiguredLogLevel, type DiagnosticsLogger } from './diagnostics.js';
+import { registerModelfileManager } from './modelfiles.js';
 import { isThinkingModelId, OllamaChatModelProvider } from './provider.js';
 import { registerSidebar } from './sidebar.js';
-import { registerModelfileManager } from './modelfiles.js';
 
 const LANGUAGE_MODEL_VENDOR = 'selfagency-ollama';
 let builtInOllamaConflictPromptInProgress = false;
@@ -271,9 +271,7 @@ export async function handleChatRequest(
     try {
       // Convert VS Code messages to the plain Ollama format expected by the client.
       const ollamaMessages = messages.map(msg => ({
-        role: (msg.role === vscode.LanguageModelChatMessageRole.User ? 'user' : 'assistant') as
-          | 'user'
-          | 'assistant',
+        role: (msg.role === vscode.LanguageModelChatMessageRole.User ? 'user' : 'assistant') as 'user' | 'assistant',
         content: (Array.isArray(msg.content) ? msg.content : [])
           .filter((p): p is vscode.LanguageModelTextPart => p instanceof vscode.LanguageModelTextPart)
           .map(p => p.value)
@@ -320,7 +318,7 @@ export async function handleChatRequest(
 
         if (chunk.message?.thinking) {
           if (!thinkingStarted) {
-            stream.markdown('\n\n💭 **Reasoning**\n\n');
+            stream.markdown('\n\n<details>\n<summary>💭 Thinking</summary>\n\n');
             thinkingStarted = true;
           }
           stream.markdown(chunk.message.thinking);
@@ -328,7 +326,7 @@ export async function handleChatRequest(
 
         if (chunk.message?.content) {
           if (thinkingStarted && !contentStarted) {
-            stream.markdown('\n\n---\n\n');
+            stream.markdown('\n\n</details>\n\n');
             contentStarted = true;
           }
           outputChannel?.debug(`[Ollama] @ollama chunk: ${chunk.message.content.substring(0, 50)}`);
@@ -346,6 +344,10 @@ export async function handleChatRequest(
         if (chunk.done) {
           break;
         }
+      }
+
+      if (thinkingStarted && !contentStarted) {
+        stream.markdown('\n\n</details>\n\n');
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,10 +2,11 @@ import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { promises as fsPromises } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
+import type { Ollama } from 'ollama';
 import * as vscode from 'vscode';
 import { getOllamaClient, testConnection } from './client.js';
 import { createDiagnosticsLogger, getConfiguredLogLevel, type DiagnosticsLogger } from './diagnostics.js';
-import { OllamaChatModelProvider } from './provider.js';
+import { isThinkingModelId, OllamaChatModelProvider } from './provider.js';
 import { registerSidebar } from './sidebar.js';
 import { registerModelfileManager } from './modelfiles.js';
 
@@ -214,13 +215,43 @@ export async function handleBuiltInOllamaConflict(
 }
 
 /**
- * Build and send a message to the language model
+ * Configure Copilot's built-in Ollama BYOK integration to use our endpoint.
+ * This routes direct model-picker requests through Copilot's in-process BYOK handler,
+ * avoiding the IPC boundary that buffers streamed responses for external providers.
+ */
+export async function configureBYOKOllama(
+  host: string,
+  bearer?: string,
+  workspaceApi?: Pick<typeof vscode.workspace, 'getConfiguration'>,
+): Promise<void> {
+  const ws = workspaceApi ?? vscode.workspace;
+  try {
+    const config = ws.getConfiguration('github.copilot.chat') as vscode.WorkspaceConfiguration;
+    await config.update('ollama.url', host, vscode.ConfigurationTarget.Global);
+    if (bearer !== undefined) {
+      await config.update('ollama.bearer', bearer || null, vscode.ConfigurationTarget.Global);
+    }
+  } catch {
+    // The github.copilot.chat settings may not be registered in all VS Code environments
+    // (e.g. test hosts without Copilot). BYOK is an optional streaming enhancement.
+  }
+}
+
+/**
+ * Build and send a message to the language model.
+ *
+ * When `client` is provided the request is streamed directly from Ollama —
+ * completely bypassing the VS Code IPC boundary — giving the @ollama participant
+ * true per-token streaming. When `client` is omitted the function falls back to
+ * the VS Code LM API path (used in tests and as a backwards-compatibility shim).
  */
 export async function handleChatRequest(
   request: vscode.ChatRequest,
   chatContext: vscode.ChatContext,
   stream: vscode.ChatResponseStream,
   token: vscode.CancellationToken,
+  client?: Ollama,
+  outputChannel?: DiagnosticsLogger,
 ): Promise<void> {
   const messages: vscode.LanguageModelChatMessage[] = [];
 
@@ -240,6 +271,93 @@ export async function handleChatRequest(
 
   messages.push(vscode.LanguageModelChatMessage.User(request.prompt));
 
+  if (client) {
+    // Direct Ollama path: completely IPC-free, per-token streaming for the @ollama participant.
+    let modelId: string;
+    if (request.model.vendor === 'ollama' || request.model.vendor === LANGUAGE_MODEL_VENDOR) {
+      modelId = request.model.id;
+    } else {
+      // Prefer BYOK models (in-process), fall back to our custom provider.
+      const byokModels = await vscode.lm.selectChatModels({ vendor: 'ollama' });
+      if (byokModels.length) {
+        modelId = byokModels[0].id;
+      } else {
+        const ourModels = await vscode.lm.selectChatModels({ vendor: LANGUAGE_MODEL_VENDOR });
+        if (!ourModels.length) {
+          stream.markdown('No Ollama models available. Pull a model first using the Ollama sidebar.');
+          return;
+        }
+        modelId = ourModels[0].id;
+      }
+    }
+
+    try {
+      // Convert VS Code messages to the plain Ollama format expected by the client.
+      const ollamaMessages = messages.map(msg => ({
+        role: (msg.role === vscode.LanguageModelChatMessageRole.User ? 'user' : 'assistant') as
+          | 'user'
+          | 'assistant',
+        content: (Array.isArray(msg.content) ? msg.content : [])
+          .filter((p): p is vscode.LanguageModelTextPart => p instanceof vscode.LanguageModelTextPart)
+          .map(p => p.value)
+          .join(''),
+      }));
+
+      const shouldThink = isThinkingModelId(modelId);
+
+      const response = await client.chat({
+        model: modelId,
+        messages: ollamaMessages,
+        stream: true,
+        ...(shouldThink ? { think: true } : {}),
+      });
+
+      let thinkingStarted = false;
+      let contentStarted = false;
+
+      for await (const chunk of response) {
+        if (token.isCancellationRequested) {
+          break;
+        }
+
+        if (chunk.message?.thinking) {
+          if (!thinkingStarted) {
+            stream.markdown('\n\n💭 **Reasoning**\n\n');
+            thinkingStarted = true;
+          }
+          stream.markdown(chunk.message.thinking);
+        }
+
+        if (chunk.message?.content) {
+          if (thinkingStarted && !contentStarted) {
+            stream.markdown('\n\n---\n\n');
+            contentStarted = true;
+          }
+          outputChannel?.debug(`[Ollama] @ollama chunk: ${chunk.message.content.substring(0, 50)}`);
+          stream.markdown(chunk.message.content);
+        }
+
+        if (chunk.message?.tool_calls && Array.isArray(chunk.message.tool_calls)) {
+          for (const toolCall of chunk.message.tool_calls) {
+            const name = toolCall.function?.name ?? 'unknown';
+            const args = JSON.stringify(toolCall.function?.arguments ?? {}, null, 2);
+            stream.markdown(`\n\n**Tool call:** \`${name}\`\n\`\`\`json\n${args}\n\`\`\`\n\n`);
+          }
+        }
+
+        if (chunk.done) {
+          break;
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      outputChannel?.exception('[Ollama] Chat participant request failed', error);
+      stream.markdown(`Error: ${message}`);
+    }
+    return;
+  }
+
+  // VS Code LM API path — used when no client is injected (tests / backwards compat).
   let model: vscode.LanguageModelChat;
   if (request.model.vendor === LANGUAGE_MODEL_VENDOR) {
     model = request.model;
@@ -379,6 +497,10 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('ollama-copilot.manageAuthToken', async () => {
       await provider.setAuthToken();
     }),
+    vscode.commands.registerCommand('ollama-copilot.refreshModels', () => {
+      provider.refreshModels();
+      diagnostics.info('[Ollama] Model list refresh triggered');
+    }),
     {
       dispose: () => stopLogStreaming(),
     },
@@ -395,22 +517,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Register modelfile manager
   registerModelfileManager(context, client, diagnostics);
-
-  // Detect and offer to disable Copilot's built-in Ollama provider (non-blocking)
-  void handleBuiltInOllamaConflict(undefined, undefined, undefined, undefined, context);
-  const conflictCheckDelaysMs = [1_500, 5_000, 10_000];
-  const conflictCheckTimers = conflictCheckDelaysMs.map(delay =>
-    setTimeout(() => {
-      void handleBuiltInOllamaConflict(undefined, undefined, undefined, undefined, context);
-    }, delay),
-  );
-  context.subscriptions.push({
-    dispose: () => {
-      for (const timer of conflictCheckTimers) {
-        clearTimeout(timer);
-      }
-    },
-  });
 
   // Test connection to Ollama server on startup (non-blocking)
   void (async () => {
@@ -461,7 +567,8 @@ export async function activate(context: vscode.ExtensionContext) {
     stream: vscode.ChatResponseStream,
     token: vscode.CancellationToken,
   ): Promise<void> => {
-    await handleChatRequest(request, chatContext, stream, token);
+    // Pass the Ollama client so the handler streams directly — no VS Code IPC overhead.
+    await handleChatRequest(request, chatContext, stream, token, client, diagnostics);
   };
 
   const participant = setupChatParticipant(context, participantHandler);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { promises as fsPromises } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import * as vscode from 'vscode';
 import { getOllamaClient, testConnection } from './client.js';
 import { createDiagnosticsLogger, getConfiguredLogLevel, type DiagnosticsLogger } from './diagnostics.js';
@@ -67,10 +68,13 @@ export function setupChatParticipant(
 /**
  * Detect and offer to disable Copilot's conflicting built-in Ollama provider.
  * Detects by querying the LM API for models registered under vendor 'ollama'.
+ * Removes the entry by editing chatLanguageModels.json in the VS Code profile
+ * folder, located two levels above the extension's globalStorageUri.
  */
 export async function handleBuiltInOllamaConflict(
   windowApi?: Pick<typeof vscode.window, 'showWarningMessage' | 'showInformationMessage'>,
   lmApi?: Pick<typeof vscode.lm, 'selectChatModels'>,
+  context?: Pick<vscode.ExtensionContext, 'globalStorageUri'>,
 ): Promise<void> {
   const win = windowApi ?? vscode.window;
   const lm = lmApi ?? vscode.lm;
@@ -85,14 +89,28 @@ export async function handleBuiltInOllamaConflict(
 
   if (selection !== 'Disable Built-in Ollama Provider') return;
 
-  await vscode.workspace
-    .getConfiguration('github.copilot.chat')
-    .update('ollama.url', undefined, vscode.ConfigurationTarget.Global);
+  if (context) {
+    try {
+      // globalStorageUri is e.g. …/profiles/<hash>/globalStorage/<extId>/
+      // Going up two levels reaches the profile folder that contains chatLanguageModels.json.
+      const profileDir = dirname(dirname(context.globalStorageUri.fsPath));
+      const modelsFile = join(profileDir, 'chatLanguageModels.json');
+      const raw = await fsPromises.readFile(modelsFile, 'utf-8');
+      const models = JSON.parse(raw) as Array<Record<string, unknown>>;
+      const filtered = models.filter(m => m['vendor'] !== 'ollama');
+      await fsPromises.writeFile(modelsFile, JSON.stringify(filtered, null, 2) + '\n', 'utf-8');
+    } catch {
+      // File write failed; the reload message below still prompts the user
+    }
+  }
 
-  await win.showInformationMessage(
+  const choice = await win.showInformationMessage(
     "Copilot's built-in Ollama provider has been disabled. Reload VS Code to apply.",
     'Reload Window',
   );
+  if (choice === 'Reload Window') {
+    await vscode.commands.executeCommand('workbench.action.reloadWindow');
+  }
 }
 
 /**
@@ -279,10 +297,10 @@ export async function activate(context: vscode.ExtensionContext) {
   registerModelfileManager(context, client, diagnostics);
 
   // Detect and offer to disable Copilot's built-in Ollama provider (non-blocking)
-  void handleBuiltInOllamaConflict();
+  void handleBuiltInOllamaConflict(undefined, undefined, context);
   if (vscode.lm.onDidChangeChatModels) {
     context.subscriptions.push(
-      vscode.lm.onDidChangeChatModels(() => { void handleBuiltInOllamaConflict(); }),
+      vscode.lm.onDidChangeChatModels(() => { void handleBuiltInOllamaConflict(undefined, undefined, context); }),
     );
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,18 @@ import { registerModelfileManager } from './modelfiles.js';
 const LANGUAGE_MODEL_VENDOR = 'selfagency-ollama';
 let builtInOllamaConflictPromptInProgress = false;
 
+function isSelectedAction(selection: unknown, actionLabel: string): boolean {
+  if (typeof selection === 'string') {
+    return selection === actionLabel;
+  }
+
+  if (selection && typeof selection === 'object' && 'title' in selection) {
+    return (selection as { title?: unknown }).title === actionLabel;
+  }
+
+  return false;
+}
+
 /**
  * Handle configuration changes for log level and auto-start log streaming
  */
@@ -94,22 +106,28 @@ export async function handleBuiltInOllamaConflict(
       'Disable Built-in Ollama Provider',
     );
 
-    if (selection !== 'Disable Built-in Ollama Provider') return;
+    if (!isSelectedAction(selection, 'Disable Built-in Ollama Provider')) return;
 
     // Use empty string to disable the built-in provider explicitly.
     // Using undefined can fall back to a non-empty default and keep it enabled.
-    await (ws.getConfiguration('github.copilot.chat') as vscode.WorkspaceConfiguration).update(
-      'ollama.url',
-      '',
-      vscode.ConfigurationTarget.Global,
-    );
+    try {
+      await (ws.getConfiguration('github.copilot.chat') as vscode.WorkspaceConfiguration).update(
+        'ollama.url',
+        '',
+        vscode.ConfigurationTarget.Global,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      await vscode.window.showErrorMessage(`Failed to disable Copilot's built-in Ollama provider: ${message}`);
+      return;
+    }
 
     const reloadSelection = await win.showInformationMessage(
       "Copilot's built-in Ollama provider has been disabled. Reload VS Code to apply.",
       'Reload Window',
     );
 
-    if (reloadSelection === 'Reload Window') {
+    if (isSelectedAction(reloadSelection, 'Reload Window')) {
       await commands.executeCommand('workbench.action.reloadWindow');
     }
   } finally {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { promises as fsPromises } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
-import type { Ollama } from 'ollama';
+import type { ChatResponse, Ollama } from 'ollama';
 import * as vscode from 'vscode';
 import { getOllamaClient, testConnection } from './client.js';
 import { createDiagnosticsLogger, getConfiguredLogLevel, type DiagnosticsLogger } from './diagnostics.js';
@@ -280,14 +280,35 @@ export async function handleChatRequest(
           .join(''),
       }));
 
-      const shouldThink = isThinkingModelId(modelId);
+      const shouldThinkInitial = isThinkingModelId(modelId);
 
-      const response = await client.chat({
-        model: modelId,
-        messages: ollamaMessages,
-        stream: true,
-        ...(shouldThink ? { think: true } : {}),
-      });
+      let shouldThink = shouldThinkInitial;
+      let response: AsyncIterable<ChatResponse>;
+
+      try {
+        response = await client.chat({
+          model: modelId,
+          messages: ollamaMessages,
+          stream: true,
+          ...(shouldThink ? { think: true } : {}),
+        });
+      } catch (chatError) {
+        if (
+          shouldThink &&
+          chatError instanceof Error &&
+          chatError.name === 'ResponseError' &&
+          chatError.message.toLowerCase().includes('does not support thinking')
+        ) {
+          shouldThink = false;
+          response = await client.chat({
+            model: modelId,
+            messages: ollamaMessages,
+            stream: true,
+          });
+        } else {
+          throw chatError;
+        }
+      }
 
       let thinkingStarted = false;
       let contentStarted = false;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,6 +65,41 @@ export function setupChatParticipant(
 }
 
 /**
+ * Detect and offer to disable Copilot's conflicting built-in Ollama provider.
+ * That provider registers under vendor 'ollama' and is active whenever
+ * github.copilot.chat.ollama.url is non-empty.
+ */
+export async function handleBuiltInOllamaConflict(
+  windowApi?: Pick<typeof vscode.window, 'showWarningMessage' | 'showInformationMessage'>,
+  workspaceApi?: Pick<typeof vscode.workspace, 'getConfiguration'>,
+): Promise<void> {
+  const win = windowApi ?? vscode.window;
+  const ws = workspaceApi ?? vscode.workspace;
+
+  const config = ws.getConfiguration('github.copilot.chat');
+  const url = config.get<string>('ollama.url');
+  if (!url) return;
+
+  const selection = await win.showWarningMessage(
+    "Copilot's built-in Ollama provider is active and will show duplicate models alongside this extension. Disable it?",
+    'Disable Built-in Ollama Provider',
+  );
+
+  if (selection !== 'Disable Built-in Ollama Provider') return;
+
+  await (config as vscode.WorkspaceConfiguration).update(
+    'ollama.url',
+    '',
+    vscode.ConfigurationTarget.Global,
+  );
+
+  await win.showInformationMessage(
+    "Copilot's built-in Ollama provider has been disabled. Reload VS Code to apply.",
+    'Reload Window',
+  );
+}
+
+/**
  * Build and send a message to the language model
  */
 export async function handleChatRequest(
@@ -246,6 +281,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Register modelfile manager
   registerModelfileManager(context, client, diagnostics);
+
+  // Detect and offer to disable Copilot's built-in Ollama provider (non-blocking)
+  void handleBuiltInOllamaConflict();
 
   // Test connection to Ollama server on startup (non-blocking)
   void (async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,9 +67,8 @@ export function setupChatParticipant(
 
 /**
  * Detect and offer to disable Copilot's conflicting built-in Ollama provider.
- * Detects by querying the LM API for models registered under vendor 'ollama'.
- * Removes the entry by editing chatLanguageModels.json in the VS Code profile
- * folder, located two levels above the extension's globalStorageUri.
+ * Detects by reading chatLanguageModels.json from the VS Code profile folder,
+ * which is located two levels above the extension's globalStorageUri.
  */
 export async function handleBuiltInOllamaConflict(
   windowApi?: Pick<typeof vscode.window, 'showWarningMessage' | 'showInformationMessage'>,
@@ -77,10 +76,24 @@ export async function handleBuiltInOllamaConflict(
   context?: Pick<vscode.ExtensionContext, 'globalStorageUri'>,
 ): Promise<void> {
   const win = windowApi ?? vscode.window;
-  const lm = lmApi ?? vscode.lm;
 
-  const conflictModels = await lm.selectChatModels({ vendor: 'ollama' });
-  if (!conflictModels.length) return;
+  if (!context) return;
+
+  // Locate chatLanguageModels.json: globalStorageUri is …/profiles/<hash>/globalStorage/<extId>/
+  // Two levels up = the profile folder that owns this file.
+  const profileDir = dirname(dirname(context.globalStorageUri.fsPath));
+  const modelsFile = join(profileDir, 'chatLanguageModels.json');
+
+  let models: Array<Record<string, unknown>>;
+  try {
+    const raw = await fsPromises.readFile(modelsFile, 'utf-8');
+    models = JSON.parse(raw) as Array<Record<string, unknown>>;
+  } catch {
+    return; // File doesn't exist or isn't readable — nothing to do
+  }
+
+  const hasBuiltInOllama = models.some(m => m['vendor'] === 'ollama');
+  if (!hasBuiltInOllama) return;
 
   const selection = await win.showWarningMessage(
     "Copilot's built-in Ollama provider is active and will show duplicate models alongside this extension. Disable it?",
@@ -89,19 +102,11 @@ export async function handleBuiltInOllamaConflict(
 
   if (selection !== 'Disable Built-in Ollama Provider') return;
 
-  if (context) {
-    try {
-      // globalStorageUri is e.g. …/profiles/<hash>/globalStorage/<extId>/
-      // Going up two levels reaches the profile folder that contains chatLanguageModels.json.
-      const profileDir = dirname(dirname(context.globalStorageUri.fsPath));
-      const modelsFile = join(profileDir, 'chatLanguageModels.json');
-      const raw = await fsPromises.readFile(modelsFile, 'utf-8');
-      const models = JSON.parse(raw) as Array<Record<string, unknown>>;
-      const filtered = models.filter(m => m['vendor'] !== 'ollama');
-      await fsPromises.writeFile(modelsFile, JSON.stringify(filtered, null, 2) + '\n', 'utf-8');
-    } catch {
-      // File write failed; the reload message below still prompts the user
-    }
+  try {
+    const filtered = models.filter(m => m['vendor'] !== 'ollama');
+    await fsPromises.writeFile(modelsFile, JSON.stringify(filtered, null, 2) + '\n', 'utf-8');
+  } catch {
+    // File write failed; still prompt to reload so the user knows to act
   }
 
   const choice = await win.showInformationMessage(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -318,7 +318,7 @@ export async function handleChatRequest(
 
         if (chunk.message?.thinking) {
           if (!thinkingStarted) {
-            stream.markdown('\n\n<details>\n<summary>💭 Thinking</summary>\n\n');
+            stream.markdown('\n\n*Thinking*\n\n');
             thinkingStarted = true;
           }
           stream.markdown(chunk.message.thinking);
@@ -326,7 +326,7 @@ export async function handleChatRequest(
 
         if (chunk.message?.content) {
           if (thinkingStarted && !contentStarted) {
-            stream.markdown('\n\n</details>\n\n');
+            stream.markdown('\n\n---\n\n*Response*\n\n');
             contentStarted = true;
           }
           outputChannel?.debug(`[Ollama] @ollama chunk: ${chunk.message.content.substring(0, 50)}`);
@@ -344,10 +344,6 @@ export async function handleChatRequest(
         if (chunk.done) {
           break;
         }
-      }
-
-      if (thinkingStarted && !contentStarted) {
-        stream.markdown('\n\n</details>\n\n');
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -173,6 +173,60 @@ describe('OllamaChatModelProvider model detection', () => {
     vi.restoreAllMocks();
   });
 
+  it('extracts context length from family-specific model_info keys', async () => {
+    const show = vi.fn().mockResolvedValue({
+      template: '',
+      details: { families: [] },
+      model_info: {
+        'qwen2.context_length': 131072,
+      },
+    });
+
+    const provider = new OllamaChatModelProvider(
+      { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
+      { list: vi.fn().mockResolvedValue({ models: [{ name: 'qwen2.5-coder:latest' }] }), show } as any,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
+    );
+
+    const models = await provider.provideLanguageModelChatInformation({ silent: true }, {} as any);
+    expect(models[0]?.maxInputTokens).toBe(131072);
+    expect(models[0]?.maxOutputTokens).toBe(131072);
+  });
+
+  it('detects tool support from capabilities array', async () => {
+    const show = vi.fn().mockResolvedValue({
+      template: '',
+      details: { families: [] },
+      capabilities: ['completion', 'tools'],
+    });
+
+    const provider = new OllamaChatModelProvider(
+      { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
+      { list: vi.fn().mockResolvedValue({ models: [{ name: 'granite4:latest' }] }), show } as any,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
+    );
+
+    const models = await provider.provideLanguageModelChatInformation({ silent: true }, {} as any);
+    expect(models[0]?.capabilities?.toolCalling).toBe(true);
+  });
+
+  it('detects vision support from capabilities array', async () => {
+    const show = vi.fn().mockResolvedValue({
+      template: '',
+      details: { families: [] },
+      capabilities: ['completion', 'vision'],
+    });
+
+    const provider = new OllamaChatModelProvider(
+      { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
+      { list: vi.fn().mockResolvedValue({ models: [{ name: 'llava:latest' }] }), show } as any,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
+    );
+
+    const models = await provider.provideLanguageModelChatInformation({ silent: true }, {} as any);
+    expect(models[0]?.capabilities?.imageInput).toBe(true);
+  });
+
   it('detects vision models with clip family', async () => {
     const show = vi.fn().mockResolvedValue({
       template: '',

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -329,8 +329,10 @@ describe('OllamaChatModelProvider error handling', () => {
 
     const models = await provider.provideLanguageModelChatInformation({ silent: true }, {} as any);
 
-    // Should return empty array when show() fails for all models
-    expect(models).toEqual([]);
+    expect(models).toHaveLength(2);
+    expect(models[0]?.name).toBe('Llama2');
+    expect(models[0]?.detail).toBe('Ollama');
+    expect(models[0]?.capabilities?.toolCalling).toBe(false);
   });
 
   it('prunes cache when models are removed', async () => {

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -60,6 +60,25 @@ describe('formatModelName', () => {
   it('removes ollama/ prefix if present', () => {
     expect(formatModelName('ollama/llama2')).toBe('Llama2');
   });
+
+  it('strips :tag suffix', () => {
+    expect(formatModelName('granite4:latest')).toBe('Granite4');
+    expect(formatModelName('qwen3:8b')).toBe('Qwen3');
+    expect(formatModelName('codegemma:2b')).toBe('Codegemma');
+  });
+
+  it('strips namespace/ prefix for non-ollama namespaces', () => {
+    expect(formatModelName('m3cha/m3cha-coder:7b')).toBe('M3cha Coder');
+    expect(formatModelName('microsoft/phi4:latest')).toBe('Phi4');
+  });
+
+  it('strips @digest from version tag', () => {
+    expect(formatModelName('m3cha/m3cha-coder:7b@1.0.0')).toBe('M3cha Coder');
+  });
+
+  it('formats qwen2.5-coder style names', () => {
+    expect(formatModelName('qwen2.5-coder:latest')).toBe('Qwen2.5 Coder');
+  });
 });
 
 describe('OllamaChatModelProvider caching', () => {

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -61,23 +61,27 @@ describe('formatModelName', () => {
     expect(formatModelName('ollama/llama2')).toBe('Llama2');
   });
 
-  it('strips :tag suffix', () => {
-    expect(formatModelName('granite4:latest')).toBe('Granite4');
-    expect(formatModelName('qwen3:8b')).toBe('Qwen3');
-    expect(formatModelName('codegemma:2b')).toBe('Codegemma');
+  it('keeps :tag suffix', () => {
+    expect(formatModelName('granite4:latest')).toBe('Granite4:latest');
+    expect(formatModelName('qwen3:8b')).toBe('Qwen3:8b');
+    expect(formatModelName('codegemma:2b')).toBe('Codegemma:2b');
   });
 
   it('strips namespace/ prefix for non-ollama namespaces', () => {
-    expect(formatModelName('m3cha/m3cha-coder:7b')).toBe('M3cha Coder');
-    expect(formatModelName('microsoft/phi4:latest')).toBe('Phi4');
+    expect(formatModelName('m3cha/m3cha-coder:7b')).toBe('M3cha Coder:7b');
+    expect(formatModelName('microsoft/phi4:latest')).toBe('Phi4:latest');
   });
 
-  it('strips @digest from version tag', () => {
-    expect(formatModelName('m3cha/m3cha-coder:7b@1.0.0')).toBe('M3cha Coder');
+  it('strips @digest but keeps :tag', () => {
+    expect(formatModelName('m3cha/m3cha-coder:7b@1.0.0')).toBe('M3cha Coder:7b');
   });
 
   it('formats qwen2.5-coder style names', () => {
-    expect(formatModelName('qwen2.5-coder:latest')).toBe('Qwen2.5 Coder');
+    expect(formatModelName('qwen2.5-coder:latest')).toBe('Qwen2.5 Coder:latest');
+  });
+
+  it('formats names with no tag', () => {
+    expect(formatModelName('cogito-v1-preview-llama')).toBe('Cogito V1 Preview Llama');
   });
 });
 

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -476,4 +476,53 @@ describe('OllamaChatModelProvider chat response', () => {
 
     expect(progress.report).toHaveBeenCalledWith(expect.objectContaining({ name: 'get_weather' }));
   });
+
+  it('streams text chunks immediately per chunk rather than batching', async () => {
+    const chat = vi.fn().mockResolvedValue(
+      (async function* () {
+        yield { message: { content: 'Hello' } };
+        yield { message: { content: ', ' } };
+        yield { message: { content: 'world!' } };
+      })(),
+    );
+
+    const provider = new OllamaChatModelProvider(
+      { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
+      { chat, list: vi.fn(), show: vi.fn() } as any,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
+    );
+
+    const progress = { report: vi.fn() };
+    const token = { isCancellationRequested: false };
+
+    const model = {
+      id: 'test-model',
+      name: 'Test',
+      family: 'ollama',
+      version: '1.0.0',
+      maxInputTokens: 100,
+      maxOutputTokens: 100,
+      capabilities: { imageInput: false, toolCalling: false },
+    };
+
+    const message = {
+      role: LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new LanguageModelTextPart('hi')],
+    };
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [message as any],
+      { tools: [], toolMode: 'auto' } as any,
+      progress as any,
+      token as any,
+    );
+
+    // Each chunk must be reported individually, not batched
+    expect(progress.report).toHaveBeenCalledTimes(3);
+    expect(progress.report).toHaveBeenNthCalledWith(1, expect.objectContaining({ value: 'Hello' }));
+    expect(progress.report).toHaveBeenNthCalledWith(2, expect.objectContaining({ value: ', ' }));
+    expect(progress.report).toHaveBeenNthCalledWith(3, expect.objectContaining({ value: 'world!' }));
+  });
 });

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -6,7 +6,8 @@ import {
   LanguageModelToolCallPart,
   LanguageModelToolResultPart,
 } from 'vscode';
-import { formatModelName, OllamaChatModelProvider } from './provider.js';
+import { getOllamaClient } from './client.js';
+import { formatModelName, isThinkingModelId, OllamaChatModelProvider } from './provider.js';
 
 vi.mock('./client.js', () => ({
   getContextLengthOverride: vi.fn(() => 0),
@@ -376,9 +377,11 @@ describe('OllamaChatModelProvider chat response', () => {
       yield { message: { content: 'chunk2' } };
     });
 
+    vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as any);
+
     const provider = new OllamaChatModelProvider(
       { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
-      { chat, list: vi.fn(), show: vi.fn() } as any,
+      { list: vi.fn(), show: vi.fn() } as any,
       { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
     );
 
@@ -417,9 +420,11 @@ describe('OllamaChatModelProvider chat response', () => {
     const exception = vi.fn();
     const chat = vi.fn().mockRejectedValue(new Error('Chat failed'));
 
+    vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as any);
+
     const provider = new OllamaChatModelProvider(
       { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
-      { chat, list: vi.fn(), show: vi.fn() } as any,
+      { list: vi.fn(), show: vi.fn() } as any,
       { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception } as any,
     );
 
@@ -459,9 +464,11 @@ describe('OllamaChatModelProvider chat response', () => {
       yield { message: { content: 'response' } };
     });
 
+    vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as any);
+
     const provider = new OllamaChatModelProvider(
       { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
-      { chat, list: vi.fn(), show: vi.fn() } as any,
+      { list: vi.fn(), show: vi.fn() } as any,
       { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
     );
 
@@ -514,9 +521,11 @@ describe('OllamaChatModelProvider chat response', () => {
       };
     });
 
+    vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as any);
+
     const provider = new OllamaChatModelProvider(
       { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
-      { chat, list: vi.fn(), show: vi.fn() } as any,
+      { list: vi.fn(), show: vi.fn() } as any,
       { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
     );
 
@@ -565,9 +574,11 @@ describe('OllamaChatModelProvider chat response', () => {
       })(),
     );
 
+    vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as any);
+
     const provider = new OllamaChatModelProvider(
       { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
-      { chat, list: vi.fn(), show: vi.fn() } as any,
+      { list: vi.fn(), show: vi.fn() } as any,
       { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
     );
 
@@ -603,5 +614,187 @@ describe('OllamaChatModelProvider chat response', () => {
     expect(progress.report).toHaveBeenNthCalledWith(1, expect.objectContaining({ value: 'Hello' }));
     expect(progress.report).toHaveBeenNthCalledWith(2, expect.objectContaining({ value: ', ' }));
     expect(progress.report).toHaveBeenNthCalledWith(3, expect.objectContaining({ value: 'world!' }));
+  });
+
+  it('streams thinking chunks for thinking models', async () => {
+    const chat = vi.fn().mockResolvedValue(
+      (async function* () {
+        yield { message: { thinking: 'let me reason...' } };
+        yield { message: { thinking: ' more reasoning' } };
+        yield { message: { content: 'The answer is 42.' } };
+        yield { message: {}, done: true };
+      })()
+    );
+
+    vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as any);
+
+    const provider = new OllamaChatModelProvider(
+      { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
+      { list: vi.fn(), show: vi.fn() } as any,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
+    );
+
+    const progress = { report: vi.fn() };
+    const token = { isCancellationRequested: false };
+
+    const model = {
+      id: 'qwen3:8b',
+      name: 'Qwen3 8B',
+      family: 'ollama',
+      version: '1.0.0',
+      maxInputTokens: 100,
+      maxOutputTokens: 100,
+      capabilities: { imageInput: false, toolCalling: false },
+    };
+
+    const message = {
+      role: LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new LanguageModelTextPart('what is the meaning of life?')],
+    };
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [message as any],
+      { tools: [], toolMode: 'auto' } as any,
+      progress as any,
+      token as any,
+    );
+
+    // Should include a header for thinking section
+    const allValues = progress.report.mock.calls.map((c: any[]) => c[0]?.value ?? '');
+    expect(allValues.some((v: string) => v.includes('Reasoning') || v.includes('reasoning'))).toBe(true);
+    // Should include thinking content
+    expect(allValues.some((v: string) => v.includes('let me reason...'))).toBe(true);
+    // Should include separator before answer
+    expect(allValues.some((v: string) => v.includes('---'))).toBe(true);
+    // Should include answer
+    expect(allValues.some((v: string) => v.includes('The answer is 42.'))).toBe(true);
+  });
+
+  it('passes think: true for known thinking models', async () => {
+    const chat = vi.fn().mockResolvedValue(
+      (async function* () {
+        yield { message: { content: 'done' }, done: true };
+      })()
+    );
+
+    vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as any);
+
+    const provider = new OllamaChatModelProvider(
+      { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
+      { list: vi.fn(), show: vi.fn() } as any,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
+    );
+
+    const progress = { report: vi.fn() };
+    const token = { isCancellationRequested: false };
+
+    const model = {
+      id: 'qwen3:8b',
+      name: 'Qwen3 8B',
+      family: 'ollama',
+      version: '1.0.0',
+      maxInputTokens: 100,
+      maxOutputTokens: 100,
+      capabilities: { imageInput: false, toolCalling: false },
+    };
+
+    const message = {
+      role: LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new LanguageModelTextPart('hi')],
+    };
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [message as any],
+      { tools: [], toolMode: 'auto' } as any,
+      progress as any,
+      token as any,
+    );
+
+    expect(chat).toHaveBeenCalledWith(expect.objectContaining({ think: true }));
+  });
+
+  it('does not pass think for non-thinking models', async () => {
+    const chat = vi.fn().mockResolvedValue(
+      (async function* () {
+        yield { message: { content: 'done' }, done: true };
+      })()
+    );
+
+    vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as any);
+
+    const provider = new OllamaChatModelProvider(
+      { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
+      { list: vi.fn(), show: vi.fn() } as any,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
+    );
+
+    const progress = { report: vi.fn() };
+    const token = { isCancellationRequested: false };
+
+    const model = {
+      id: 'llama3.2:latest',
+      name: 'Llama 3.2',
+      family: 'ollama',
+      version: '1.0.0',
+      maxInputTokens: 100,
+      maxOutputTokens: 100,
+      capabilities: { imageInput: false, toolCalling: false },
+    };
+
+    const message = {
+      role: LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new LanguageModelTextPart('hi')],
+    };
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [message as any],
+      { tools: [], toolMode: 'auto' } as any,
+      progress as any,
+      token as any,
+    );
+
+    const chatArgs = chat.mock.calls[0]?.[0];
+    expect(chatArgs?.think).toBeFalsy();
+  });
+});
+
+describe('isThinkingModelId', () => {
+  it('returns true for qwen3 models', () => {
+    expect(isThinkingModelId('qwen3:8b')).toBe(true);
+    expect(isThinkingModelId('qwen3:14b')).toBe(true);
+    expect(isThinkingModelId('qwen3:latest')).toBe(true);
+  });
+
+  it('returns true for qwq models', () => {
+    expect(isThinkingModelId('qwq:32b')).toBe(true);
+    expect(isThinkingModelId('qwq')).toBe(true);
+  });
+
+  it('returns true for deepseek-r1 models', () => {
+    expect(isThinkingModelId('deepseek-r1:8b')).toBe(true);
+    expect(isThinkingModelId('deepseek-r1:70b')).toBe(true);
+    expect(isThinkingModelId('deepseekr1:latest')).toBe(true);
+  });
+
+  it('returns true for cogito models', () => {
+    expect(isThinkingModelId('cogito:8b')).toBe(true);
+    expect(isThinkingModelId('cogito-v1-preview-llama-3.1-8b')).toBe(true);
+  });
+
+  it('returns true for phi4-reasoning models', () => {
+    expect(isThinkingModelId('phi4-reasoning:latest')).toBe(true);
+  });
+
+  it('returns false for standard models', () => {
+    expect(isThinkingModelId('llama3.2:latest')).toBe(false);
+    expect(isThinkingModelId('mistral:7b')).toBe(false);
+    expect(isThinkingModelId('gemma3:latest')).toBe(false);
+    expect(isThinkingModelId('codellama:latest')).toBe(false);
   });
 });

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -623,7 +623,7 @@ describe('OllamaChatModelProvider chat response', () => {
         yield { message: { thinking: ' more reasoning' } };
         yield { message: { content: 'The answer is 42.' } };
         yield { message: {}, done: true };
-      })()
+      })(),
     );
 
     vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as any);
@@ -663,11 +663,11 @@ describe('OllamaChatModelProvider chat response', () => {
 
     // Should include a header for thinking section
     const allValues = progress.report.mock.calls.map((c: any[]) => c[0]?.value ?? '');
-    expect(allValues.some((v: string) => v.includes('Reasoning') || v.includes('reasoning'))).toBe(true);
+    expect(allValues.some((v: string) => v.includes('Thinking') || v.includes('thinking'))).toBe(true);
     // Should include thinking content
     expect(allValues.some((v: string) => v.includes('let me reason...'))).toBe(true);
-    // Should include separator before answer
-    expect(allValues.some((v: string) => v.includes('---'))).toBe(true);
+    // Should close the details section before answer
+    expect(allValues.some((v: string) => v.includes('</details>'))).toBe(true);
     // Should include answer
     expect(allValues.some((v: string) => v.includes('The answer is 42.'))).toBe(true);
   });
@@ -676,7 +676,7 @@ describe('OllamaChatModelProvider chat response', () => {
     const chat = vi.fn().mockResolvedValue(
       (async function* () {
         yield { message: { content: 'done' }, done: true };
-      })()
+      })(),
     );
 
     vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as any);
@@ -721,7 +721,7 @@ describe('OllamaChatModelProvider chat response', () => {
     const chat = vi.fn().mockResolvedValue(
       (async function* () {
         yield { message: { content: 'done' }, done: true };
-      })()
+      })(),
     );
 
     vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as any);
@@ -764,12 +764,13 @@ describe('OllamaChatModelProvider chat response', () => {
   });
 
   it('retries without think when model returns ResponseError "does not support thinking"', async () => {
-    const thinkingError = Object.assign(
-      new Error('"cogito:latest" does not support thinking'),
-      { name: 'ResponseError', status_code: 400 },
-    );
+    const thinkingError = Object.assign(new Error('"cogito:latest" does not support thinking'), {
+      name: 'ResponseError',
+      status_code: 400,
+    });
 
-    const chat = vi.fn()
+    const chat = vi
+      .fn()
       .mockRejectedValueOnce(thinkingError)
       .mockResolvedValueOnce(
         (async function* () {
@@ -824,12 +825,13 @@ describe('OllamaChatModelProvider chat response', () => {
   });
 
   it('does not retry again on second call when model is in nonThinkingModels', async () => {
-    const thinkingError = Object.assign(
-      new Error('"cogito:latest" does not support thinking'),
-      { name: 'ResponseError', status_code: 400 },
-    );
+    const thinkingError = Object.assign(new Error('"cogito:latest" does not support thinking'), {
+      name: 'ResponseError',
+      status_code: 400,
+    });
 
-    const chat = vi.fn()
+    const chat = vi
+      .fn()
       .mockRejectedValueOnce(thinkingError)
       .mockResolvedValueOnce(
         (async function* () {

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -762,6 +762,137 @@ describe('OllamaChatModelProvider chat response', () => {
     const chatArgs = chat.mock.calls[0]?.[0];
     expect(chatArgs?.think).toBeFalsy();
   });
+
+  it('retries without think when model returns ResponseError "does not support thinking"', async () => {
+    const thinkingError = Object.assign(
+      new Error('"cogito:latest" does not support thinking'),
+      { name: 'ResponseError', status_code: 400 },
+    );
+
+    const chat = vi.fn()
+      .mockRejectedValueOnce(thinkingError)
+      .mockResolvedValueOnce(
+        (async function* () {
+          yield { message: { content: 'Here is the answer.' }, done: true };
+        })(),
+      );
+
+    vi.mocked(getOllamaClient).mockResolvedValue({ chat, abort: vi.fn() } as any);
+
+    const provider = new OllamaChatModelProvider(
+      { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
+      { list: vi.fn(), show: vi.fn() } as any,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
+    );
+
+    const progress = { report: vi.fn() };
+    const token = { isCancellationRequested: false };
+
+    const model = {
+      id: 'cogito:latest',
+      name: 'Cogito Latest',
+      family: 'ollama',
+      version: '1.0.0',
+      maxInputTokens: 100,
+      maxOutputTokens: 100,
+      capabilities: { imageInput: false, toolCalling: false },
+    };
+
+    const message = {
+      role: LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new LanguageModelTextPart('hi')],
+    };
+
+    await provider.provideLanguageModelChatResponse(
+      model as any,
+      [message as any],
+      { tools: [], toolMode: 'auto' } as any,
+      progress as any,
+      token as any,
+    );
+
+    // First call should have used think: true (cogito matches the regex)
+    expect(chat).toHaveBeenCalledTimes(2);
+    expect(chat.mock.calls[0]?.[0]?.think).toBe(true);
+    // Second call (retry) should not pass think
+    expect(chat.mock.calls[1]?.[0]?.think).toBeUndefined();
+    // Content should be reported (not an error message)
+    const allValues = progress.report.mock.calls.map((c: any[]) => c[0]?.value ?? '');
+    expect(allValues.some((v: string) => v.includes('Here is the answer.'))).toBe(true);
+    expect(allValues.every((v: string) => !v.startsWith('Error:'))).toBe(true);
+  });
+
+  it('does not retry again on second call when model is in nonThinkingModels', async () => {
+    const thinkingError = Object.assign(
+      new Error('"cogito:latest" does not support thinking'),
+      { name: 'ResponseError', status_code: 400 },
+    );
+
+    const chat = vi.fn()
+      .mockRejectedValueOnce(thinkingError)
+      .mockResolvedValueOnce(
+        (async function* () {
+          yield { message: { content: 'first response' }, done: true };
+        })(),
+      )
+      .mockResolvedValueOnce(
+        (async function* () {
+          yield { message: { content: 'second response' }, done: true };
+        })(),
+      );
+
+    vi.mocked(getOllamaClient).mockResolvedValue({ chat, abort: vi.fn() } as any);
+
+    const provider = new OllamaChatModelProvider(
+      { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
+      { list: vi.fn(), show: vi.fn() } as any,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
+    );
+
+    const progress = { report: vi.fn() };
+    const token = { isCancellationRequested: false };
+
+    const model = {
+      id: 'cogito:latest',
+      name: 'Cogito Latest',
+      family: 'ollama',
+      version: '1.0.0',
+      maxInputTokens: 100,
+      maxOutputTokens: 100,
+      capabilities: { imageInput: false, toolCalling: false },
+    };
+
+    const message = {
+      role: LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new LanguageModelTextPart('hi')],
+    };
+
+    // First call — triggers retry and blacklists the model
+    await provider.provideLanguageModelChatResponse(
+      model as any,
+      [message as any],
+      { tools: [], toolMode: 'auto' } as any,
+      progress as any,
+      token as any,
+    );
+
+    progress.report.mockClear();
+
+    // Second call — should NOT pass think: true (model is now blacklisted)
+    await provider.provideLanguageModelChatResponse(
+      model as any,
+      [message as any],
+      { tools: [], toolMode: 'auto' } as any,
+      progress as any,
+      token as any,
+    );
+
+    // Total: 3 calls (1 failed + 1 retry + 1 second request without think)
+    expect(chat).toHaveBeenCalledTimes(3);
+    expect(chat.mock.calls[2]?.[0]?.think).toBeUndefined();
+  });
 });
 
 describe('isThinkingModelId', () => {

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -666,8 +666,8 @@ describe('OllamaChatModelProvider chat response', () => {
     expect(allValues.some((v: string) => v.includes('Thinking') || v.includes('thinking'))).toBe(true);
     // Should include thinking content
     expect(allValues.some((v: string) => v.includes('let me reason...'))).toBe(true);
-    // Should close the details section before answer
-    expect(allValues.some((v: string) => v.includes('</details>'))).toBe(true);
+    // Should include separator before answer
+    expect(allValues.some((v: string) => v.includes('---'))).toBe(true);
     // Should include answer
     expect(allValues.some((v: string) => v.includes('The answer is 42.'))).toBe(true);
   });

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -411,19 +411,20 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
  * Format model name for display
  */
 export function formatModelName(modelId: string): string {
-  return (
-    modelId
-      // strip @digest suffix (e.g. :7b@1.0.0 → :7b)
-      .replace(/@[^:/@]+$/, '')
-      // strip :tag suffix (e.g. :latest, :7b)
-      .replace(/:[^:/]+$/, '')
-      // strip namespace prefix (e.g. m3cha/m3cha-coder → m3cha-coder)
-      .replace(/^[^/]+\//, '')
-      // replace separators with spaces
-      .replace(/[-_]/g, ' ')
-      .split(' ')
-      .filter(Boolean)
-      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ')
-  );
+  // Strip @digest suffix (e.g. :7b@1.0.0 → :7b)
+  const withoutDigest = modelId.replace(/@[^:/]+$/, '');
+  // Strip namespace/ prefix (e.g. m3cha/m3cha-coder → m3cha-coder)
+  const withoutNamespace = withoutDigest.replace(/^[^/]+\//, '');
+  // Split name and tag on the first `:` so we can format them independently
+  const colonIdx = withoutNamespace.indexOf(':');
+  const namePart = colonIdx === -1 ? withoutNamespace : withoutNamespace.slice(0, colonIdx);
+  const tagPart = colonIdx === -1 ? '' : withoutNamespace.slice(colonIdx); // includes the `:` prefix
+  // Capitalise each word in the name, replacing hyphens/underscores with spaces
+  const formattedName = namePart
+    .replace(/[-_]/g, ' ')
+    .split(' ')
+    .filter(Boolean)
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+  return formattedName + tagPart;
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -159,8 +159,10 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       return {
         id: modelId,
         name: formatModelName(modelId),
-        family: 'ollama',
+        family: 'Ollama',
         version: '1.0.0',
+        detail: 'Ollama',
+        tooltip: `Ollama • ${modelId}`,
         maxInputTokens: contextLength,
         maxOutputTokens: contextLength,
         capabilities: {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -351,7 +351,6 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
         if (shouldThink && this.isThinkingNotSupportedError(innerError)) {
           this.thinkingModels.delete(model.id);
           this.nonThinkingModels.add(model.id);
-          shouldThink = false;
           response = await perRequestClient.chat({
             model: model.id,
             messages: ollamaMessages,
@@ -394,7 +393,11 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
         if (chunk.message?.tool_calls && Array.isArray(chunk.message.tool_calls)) {
           for (const toolCall of chunk.message.tool_calls) {
             const vsCodeId = this.generateToolCallId();
-            this.mapToolCallId(vsCodeId, vsCodeId);
+            const upstreamId =
+              typeof (toolCall as { id?: unknown }).id === 'string'
+                ? (toolCall as unknown as { id: string }).id
+                : vsCodeId;
+            this.mapToolCallId(vsCodeId, upstreamId);
 
             progress.report(
               new LanguageModelToolCallPart(

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -187,37 +187,28 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       }
 
       // Stream chat response
-      const response = this.client.chat({
+      const response = await this.client.chat({
         model: model.id,
         messages: ollamaMessages,
         stream: true,
         tools,
       });
 
-      let currentText = '';
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      for await (const chunk of response as any) {
+      for await (const chunk of response) {
         if (token.isCancellationRequested) {
           break;
         }
 
+        // Stream text chunks immediately as they arrive
         if (chunk.message?.content) {
-          currentText += chunk.message.content;
+          progress.report(new LanguageModelTextPart(chunk.message.content));
         }
 
         // Handle tool calls
         if (chunk.message?.tool_calls && Array.isArray(chunk.message.tool_calls)) {
-          // Flush accumulated text
-          if (currentText.trim()) {
-            progress.report(new LanguageModelTextPart(currentText));
-            currentText = '';
-          }
-
           for (const toolCall of chunk.message.tool_calls) {
-            // Map tool call ID and emit tool call
             const vsCodeId = this.generateToolCallId();
-            this.mapToolCallId(vsCodeId, toolCall.id || '');
+            this.mapToolCallId(vsCodeId, vsCodeId);
 
             progress.report(
               new LanguageModelToolCallPart(
@@ -228,11 +219,6 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
             );
           }
         }
-      }
-
-      // Flush any remaining text
-      if (currentText.trim()) {
-        progress.report(new LanguageModelTextPart(currentText));
       }
     } catch (error) {
       this.outputChannel.exception('[Ollama] Chat response failed', error);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -411,10 +411,19 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
  * Format model name for display
  */
 export function formatModelName(modelId: string): string {
-  return modelId
-    .replace(/^ollama\//, '')
-    .replace(/-/g, ' ')
-    .split(' ')
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
+  return (
+    modelId
+      // strip @digest suffix (e.g. :7b@1.0.0 → :7b)
+      .replace(/@[^:/@]+$/, '')
+      // strip :tag suffix (e.g. :latest, :7b)
+      .replace(/:[^:/]+$/, '')
+      // strip namespace prefix (e.g. m3cha/m3cha-coder → m3cha-coder)
+      .replace(/^[^/]+\//, '')
+      // replace separators with spaces
+      .replace(/[-_]/g, ' ')
+      .split(' ')
+      .filter(Boolean)
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ')
+  );
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,4 +1,4 @@
-import { Ollama } from 'ollama';
+import { Ollama, type ShowResponse } from 'ollama';
 import {
   CancellationToken,
   EventEmitter,
@@ -121,12 +121,32 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       const response = await this.client.show({ model: modelId });
 
       // Prefer the model's actual context window; fall back to the user override, then 0.
-      const modelinfo = (response as Record<string, unknown>).modelinfo as Record<string, unknown> | undefined;
-      const parameters = (response as Record<string, unknown>).parameters as string | undefined;
+      const typedResponse = response as ShowResponse & { modelinfo?: Map<string, unknown> | Record<string, unknown> };
+      const modelinfo =
+        (typedResponse.model_info as Map<string, unknown> | Record<string, unknown> | undefined) ??
+        typedResponse.modelinfo;
+      const parameters = typedResponse.parameters;
       let contextLength = getContextLengthOverride();
       if (!contextLength) {
-        // Ollama ≥0.3 exposes context_length in modelinfo
-        const infoCtx = modelinfo?.['llama.context_length'] ?? modelinfo?.['context_length'];
+        // Ollama exposes context_length in model_info using family-specific keys
+        // (e.g. llama.context_length, qwen2.context_length, gemma.context_length).
+        let infoCtx: unknown;
+        if (modelinfo instanceof Map) {
+          for (const [key, value] of modelinfo.entries()) {
+            if (key === 'context_length' || key.endsWith('.context_length')) {
+              infoCtx = value;
+              break;
+            }
+          }
+        } else if (modelinfo && typeof modelinfo === 'object') {
+          for (const [key, value] of Object.entries(modelinfo)) {
+            if (key === 'context_length' || key.endsWith('.context_length')) {
+              infoCtx = value;
+              break;
+            }
+          }
+        }
+
         if (typeof infoCtx === 'number' && infoCtx > 0) {
           contextLength = infoCtx;
         } else if (parameters) {
@@ -159,6 +179,11 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
    */
   private isToolModel(modelResponse: unknown): boolean {
     const response = modelResponse as Record<string, unknown>;
+    const capabilities = response.capabilities;
+    if (Array.isArray(capabilities) && capabilities.some(cap => String(cap).toLowerCase().includes('tool'))) {
+      return true;
+    }
+
     const template = response.template as string | undefined;
     return template ? template.includes('{{ .Tools }}') : false;
   }
@@ -168,6 +193,15 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
    */
   private isVisionModel(modelResponse: unknown): boolean {
     const response = modelResponse as Record<string, unknown>;
+    const capabilities = response.capabilities;
+    if (Array.isArray(capabilities) && capabilities.some(cap => String(cap).toLowerCase().includes('vision'))) {
+      return true;
+    }
+
+    if (response.projector_info) {
+      return true;
+    }
+
     const details = response.details as Record<string, unknown> | undefined;
     const families = details?.families as string[] | undefined;
     return families ? families.includes('clip') || families.includes('vision') : false;

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -271,6 +271,12 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
             );
           }
         }
+
+        // Some Ollama responses set done=true before the underlying stream closes.
+        // Exit promptly so VS Code doesn't stay in a perpetual "waiting" state.
+        if (chunk.done === true) {
+          break;
+        }
       }
     } catch (error) {
       this.outputChannel.exception('[Ollama] Chat response failed', error);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -21,6 +21,7 @@ import type { DiagnosticsLogger } from './diagnostics.js';
 
 const MODEL_LIST_REFRESH_MIN_INTERVAL_MS = 30_000;
 const MODEL_INFO_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+const MODEL_SHOW_TIMEOUT_MS = 2_000;
 
 /**
  * Ollama Chat Model Provider
@@ -30,6 +31,7 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
   private modelInfoCache: Map<string, { info: LanguageModelChatInformation; updatedAtMs: number }> = new Map();
   private cachedModelList: LanguageModelChatInformation[] = [];
   private lastModelListRefreshMs = 0;
+  private modelListRefreshPromise: Promise<LanguageModelChatInformation[]> | undefined;
   private modelsChangeEventEmitter: EventEmitter<void> = new EventEmitter();
   private toolCallIdMap: Map<string, string> = new Map();
   private reverseToolCallIdMap: Map<string, string> = new Map();
@@ -54,6 +56,21 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       return this.cachedModelList;
     }
 
+    if (this.modelListRefreshPromise) {
+      return this.modelListRefreshPromise;
+    }
+
+    this.modelListRefreshPromise = this.refreshModelList();
+    try {
+      return await this.modelListRefreshPromise;
+    } finally {
+      this.modelListRefreshPromise = undefined;
+    }
+  }
+
+  private async refreshModelList(): Promise<LanguageModelChatInformation[]> {
+    const now = Date.now();
+
     try {
       const response = await this.client.list();
       const modelNames = new Set(response.models.map(model => model.name));
@@ -66,13 +83,10 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
             return cached.info;
           }
 
-          const info = await this.getChatModelInfo(model.name);
-          if (info) {
-            const updatedAtMs = Date.now();
-            this.modelInfoCache.set(model.name, { info, updatedAtMs });
-            this.models.set(model.name, info);
-          }
-
+          const info = await this.getChatModelInfoWithFallback(model.name);
+          const updatedAtMs = Date.now();
+          this.modelInfoCache.set(model.name, { info, updatedAtMs });
+          this.models.set(model.name, info);
           return info;
         }),
       );
@@ -111,6 +125,46 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     this.models.clear();
     this.cachedModelList = [];
     this.lastModelListRefreshMs = 0;
+  }
+
+  /**
+   * Build lightweight model information when detailed metadata is unavailable.
+   */
+  private getBaseChatModelInfo(modelId: string): LanguageModelChatInformation {
+    const contextLength = getContextLengthOverride();
+    return {
+      id: modelId,
+      name: formatModelName(modelId),
+      family: 'Ollama',
+      version: '1.0.0',
+      detail: 'Ollama',
+      tooltip: `Ollama • ${modelId}`,
+      maxInputTokens: contextLength,
+      maxOutputTokens: contextLength,
+      capabilities: {
+        imageInput: false,
+        toolCalling: false,
+      },
+    };
+  }
+
+  /**
+   * Resolve chat model information with a timeout fallback so model discovery
+   * cannot block chat startup on slow /api/show responses.
+   */
+  private async getChatModelInfoWithFallback(modelId: string): Promise<LanguageModelChatInformation> {
+    const fallback = this.getBaseChatModelInfo(modelId);
+
+    try {
+      const timed = await Promise.race<LanguageModelChatInformation | undefined>([
+        this.getChatModelInfo(modelId),
+        new Promise<undefined>(resolve => setTimeout(() => resolve(undefined), MODEL_SHOW_TIMEOUT_MS)),
+      ]);
+
+      return timed ?? fallback;
+    } catch {
+      return fallback;
+    }
   }
 
   /**

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -35,6 +35,7 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
   private modelsChangeEventEmitter: EventEmitter<void> = new EventEmitter();
   private toolCallIdMap: Map<string, string> = new Map();
   private reverseToolCallIdMap: Map<string, string> = new Map();
+  private thinkingModels = new Set<string>();
 
   readonly onDidChangeLanguageModelChatInformation = this.modelsChangeEventEmitter.event;
 
@@ -128,6 +129,15 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
   }
 
   /**
+   * Flush the model cache and notify VS Code to re-query the model list.
+   * Useful for a manual "refresh" command.
+   */
+  refreshModels(): void {
+    this.clearModelCache();
+    this.modelsChangeEventEmitter.fire();
+  }
+
+  /**
    * Build lightweight model information when detailed metadata is unavailable.
    */
   private getBaseChatModelInfo(modelId: string): LanguageModelChatInformation {
@@ -210,6 +220,10 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
         }
       }
 
+      if (this.isThinkingModel(response)) {
+        this.thinkingModels.add(modelId);
+      }
+
       return {
         id: modelId,
         name: formatModelName(modelId),
@@ -245,6 +259,18 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
   }
 
   /**
+   * Check if model supports extended thinking / reasoning
+   */
+  private isThinkingModel(modelResponse: unknown): boolean {
+    const response = modelResponse as Record<string, unknown>;
+    const capabilities = response.capabilities;
+    return (
+      Array.isArray(capabilities) &&
+      capabilities.some(cap => String(cap).toLowerCase().includes('thinking'))
+    );
+  }
+
+  /**
    * Check if model supports vision/image inputs
    */
   private isVisionModel(modelResponse: unknown): boolean {
@@ -273,40 +299,65 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     progress: Progress<LanguageModelResponsePart>,
     token: CancellationToken,
   ): Promise<void> {
+    this.clearToolCallIdMappings();
+
+    // Convert VS Code messages to Ollama format
+    const ollamaMessages = this.toOllamaMessages(messages);
+
+    // Build tools array if supported
+    let tools: Parameters<typeof this.client.chat>[0]['tools'] | undefined;
+    if (options.tools && options.tools.length > 0 && model.capabilities.toolCalling) {
+      tools = options.tools.map(tool => ({
+        type: 'function' as const,
+        function: {
+          name: tool.name,
+          description: tool.description || '',
+          parameters: tool.inputSchema as Record<string, unknown>,
+        },
+      }));
+    }
+
+    // Create a per-request client to isolate this stream's connection from others.
+    // Do NOT call abort() on cancellation — abruptly closing the HTTP connection
+    // mid-generation destabilises Ollama. The isCancellationRequested check in the
+    // loop below provides safe cooperative cancellation instead.
+    const perRequestClient = await getOllamaClient(this.context);
+
+    const shouldThink = this.thinkingModels.has(model.id) || isThinkingModelId(model.id);
+
     try {
-      this.clearToolCallIdMappings();
-
-      // Convert VS Code messages to Ollama format
-      const ollamaMessages = this.toOllamaMessages(messages);
-
-      // Build tools array if supported
-      let tools: Parameters<typeof this.client.chat>[0]['tools'] | undefined;
-      if (options.tools && options.tools.length > 0 && model.capabilities.toolCalling) {
-        tools = options.tools.map(tool => ({
-          type: 'function' as const,
-          function: {
-            name: tool.name,
-            description: tool.description || '',
-            parameters: tool.inputSchema as Record<string, unknown>,
-          },
-        }));
-      }
-
-      // Stream chat response
-      const response = await this.client.chat({
+      const response = await perRequestClient.chat({
         model: model.id,
         messages: ollamaMessages,
         stream: true,
         tools,
+        ...(shouldThink ? { think: true } : {}),
       });
+
+      let thinkingStarted = false;
+      let contentStarted = false;
 
       for await (const chunk of response) {
         if (token.isCancellationRequested) {
           break;
         }
 
+        // Handle thinking tokens (reasoning phase)
+        if (chunk.message?.thinking) {
+          if (!thinkingStarted) {
+            progress.report(new LanguageModelTextPart('\n\n💭 **Reasoning**\n\n'));
+            thinkingStarted = true;
+          }
+          progress.report(new LanguageModelTextPart(chunk.message.thinking));
+        }
+
         // Stream text chunks immediately as they arrive
         if (chunk.message?.content) {
+          if (thinkingStarted && !contentStarted) {
+            progress.report(new LanguageModelTextPart('\n\n---\n\n'));
+            contentStarted = true;
+          }
+          this.outputChannel.debug?.(`[Ollama] Streaming chunk: ${chunk.message.content.substring(0, 50)}`);
           progress.report(new LanguageModelTextPart(chunk.message.content));
         }
 
@@ -334,8 +385,13 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       }
     } catch (error) {
       this.outputChannel.exception('[Ollama] Chat response failed', error);
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      progress.report(new LanguageModelTextPart(`Error: ${errorMessage}`));
+      const isConnectionError = error instanceof TypeError && error.message.includes('fetch failed');
+      const message = isConnectionError
+        ? 'Cannot reach Ollama server — check that it is running and accessible.'
+        : error instanceof Error
+          ? error.message
+          : String(error);
+      progress.report(new LanguageModelTextPart(`Error: ${message}`));
     }
   }
 
@@ -509,6 +565,16 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       }
     }
   }
+}
+
+/**
+ * Regex pattern for models that support extended thinking / reasoning.
+ * Used as a fallback when the /api/show capabilities array is not yet cached.
+ */
+const THINKING_MODEL_PATTERN = /qwen3|qwq|deepseek-?r1|cogito|phi\d+-reasoning/i;
+
+export function isThinkingModelId(modelId: string): boolean {
+  return THINKING_MODEL_PATTERN.test(modelId);
 }
 
 /**

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -277,10 +277,7 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
   private isThinkingModel(modelResponse: unknown): boolean {
     const response = modelResponse as Record<string, unknown>;
     const capabilities = response.capabilities;
-    return (
-      Array.isArray(capabilities) &&
-      capabilities.some(cap => String(cap).toLowerCase().includes('thinking'))
-    );
+    return Array.isArray(capabilities) && capabilities.some(cap => String(cap).toLowerCase().includes('thinking'));
   }
 
   /**
@@ -337,8 +334,7 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     const perRequestClient = await getOllamaClient(this.context);
 
     let shouldThink =
-      (this.thinkingModels.has(model.id) || isThinkingModelId(model.id)) &&
-      !this.nonThinkingModels.has(model.id);
+      (this.thinkingModels.has(model.id) || isThinkingModelId(model.id)) && !this.nonThinkingModels.has(model.id);
 
     try {
       let response: AsyncIterable<ChatResponse>;
@@ -378,7 +374,7 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
         // Handle thinking tokens (reasoning phase)
         if (chunk.message?.thinking) {
           if (!thinkingStarted) {
-            progress.report(new LanguageModelTextPart('\n\n💭 **Reasoning**\n\n'));
+            progress.report(new LanguageModelTextPart('\n\n<details>\n<summary>💭 Thinking</summary>\n\n'));
             thinkingStarted = true;
           }
           progress.report(new LanguageModelTextPart(chunk.message.thinking));
@@ -387,7 +383,7 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
         // Stream text chunks immediately as they arrive
         if (chunk.message?.content) {
           if (thinkingStarted && !contentStarted) {
-            progress.report(new LanguageModelTextPart('\n\n---\n\n'));
+            progress.report(new LanguageModelTextPart('\n\n</details>\n\n'));
             contentStarted = true;
           }
           this.outputChannel.debug?.(`[Ollama] Streaming chunk: ${chunk.message.content.substring(0, 50)}`);
@@ -415,6 +411,10 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
         if (chunk.done === true) {
           break;
         }
+      }
+
+      if (thinkingStarted && !contentStarted) {
+        progress.report(new LanguageModelTextPart('\n\n</details>\n\n'));
       }
     } catch (error) {
       this.outputChannel.exception('[Ollama] Chat response failed', error);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -374,7 +374,7 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
         // Handle thinking tokens (reasoning phase)
         if (chunk.message?.thinking) {
           if (!thinkingStarted) {
-            progress.report(new LanguageModelTextPart('\n\n<details>\n<summary>💭 Thinking</summary>\n\n'));
+            progress.report(new LanguageModelTextPart('\n\n💭 **Thinking**\n\n'));
             thinkingStarted = true;
           }
           progress.report(new LanguageModelTextPart(chunk.message.thinking));
@@ -383,7 +383,7 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
         // Stream text chunks immediately as they arrive
         if (chunk.message?.content) {
           if (thinkingStarted && !contentStarted) {
-            progress.report(new LanguageModelTextPart('\n\n</details>\n\n'));
+            progress.report(new LanguageModelTextPart('\n\n---\n\n'));
             contentStarted = true;
           }
           this.outputChannel.debug?.(`[Ollama] Streaming chunk: ${chunk.message.content.substring(0, 50)}`);
@@ -411,10 +411,6 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
         if (chunk.done === true) {
           break;
         }
-      }
-
-      if (thinkingStarted && !contentStarted) {
-        progress.report(new LanguageModelTextPart('\n\n</details>\n\n'));
       }
     } catch (error) {
       this.outputChannel.exception('[Ollama] Chat response failed', error);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -291,22 +291,16 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       const role = msg.role === LanguageModelChatMessageRole.User ? 'user' : 'assistant';
       const ollamaMsg: Record<string, unknown> = { role };
 
-      // Extract and assemble content
-      const contentParts: (string | Record<string, unknown>)[] = [];
+      // Extract text and images in Ollama's expected shape
       let textContent = '';
+      const images: string[] = [];
 
       for (const part of msg.content) {
         if (part instanceof LanguageModelTextPart) {
           textContent += part.value;
         } else if (part instanceof LanguageModelDataPart) {
           const base64Data = typeof part.data === 'string' ? part.data : Buffer.from(part.data).toString('base64');
-
-          contentParts.push({
-            type: 'image',
-            image: {
-              url: `data:image/jpeg;base64,${base64Data}`,
-            },
-          });
+          images.push(base64Data);
         } else if (part instanceof LanguageModelToolCallPart) {
           ollamaMsg.tool_calls = ollamaMsg.tool_calls || [];
           (ollamaMsg.tool_calls as Record<string, unknown>[]).push({
@@ -326,14 +320,12 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
         }
       }
 
-      if (textContent) {
-        contentParts.unshift(textContent);
+      // Ollama requires content to be a string (images are separate field)
+      if (textContent || images.length > 0) {
+        ollamaMsg.content = textContent;
       }
-
-      if (contentParts.length === 1 && typeof contentParts[0] === 'string') {
-        ollamaMsg.content = contentParts[0];
-      } else if (contentParts.length > 0) {
-        ollamaMsg.content = contentParts;
+      if (images.length > 0) {
+        ollamaMsg.images = images;
       }
 
       if (ollamaMsg.content || ollamaMsg.tool_calls) {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,4 +1,4 @@
-import { Ollama, type ShowResponse } from 'ollama';
+import { Ollama, type ChatResponse, type ShowResponse } from 'ollama';
 import {
   CancellationToken,
   EventEmitter,
@@ -36,6 +36,7 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
   private toolCallIdMap: Map<string, string> = new Map();
   private reverseToolCallIdMap: Map<string, string> = new Map();
   private thinkingModels = new Set<string>();
+  private nonThinkingModels = new Set<string>();
 
   readonly onDidChangeLanguageModelChatInformation = this.modelsChangeEventEmitter.event;
 
@@ -245,6 +246,18 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
   }
 
   /**
+   * Returns true when the Ollama SDK reports that the model does not support
+   * the `think` option (HTTP 400 "does not support thinking").
+   */
+  private isThinkingNotSupportedError(error: unknown): boolean {
+    return (
+      error instanceof Error &&
+      error.name === 'ResponseError' &&
+      error.message.toLowerCase().includes('does not support thinking')
+    );
+  }
+
+  /**
    * Check if model supports tool use
    */
   private isToolModel(modelResponse: unknown): boolean {
@@ -323,16 +336,36 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     // loop below provides safe cooperative cancellation instead.
     const perRequestClient = await getOllamaClient(this.context);
 
-    const shouldThink = this.thinkingModels.has(model.id) || isThinkingModelId(model.id);
+    let shouldThink =
+      (this.thinkingModels.has(model.id) || isThinkingModelId(model.id)) &&
+      !this.nonThinkingModels.has(model.id);
 
     try {
-      const response = await perRequestClient.chat({
-        model: model.id,
-        messages: ollamaMessages,
-        stream: true,
-        tools,
-        ...(shouldThink ? { think: true } : {}),
-      });
+      let response: AsyncIterable<ChatResponse>;
+
+      try {
+        response = await perRequestClient.chat({
+          model: model.id,
+          messages: ollamaMessages,
+          stream: true,
+          tools,
+          ...(shouldThink ? { think: true } : {}),
+        });
+      } catch (innerError) {
+        if (shouldThink && this.isThinkingNotSupportedError(innerError)) {
+          this.thinkingModels.delete(model.id);
+          this.nonThinkingModels.add(model.id);
+          shouldThink = false;
+          response = await perRequestClient.chat({
+            model: model.id,
+            messages: ollamaMessages,
+            stream: true,
+            tools,
+          });
+        } else {
+          throw innerError;
+        }
+      }
 
       let thinkingStarted = false;
       let contentStarted = false;

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -120,13 +120,29 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     try {
       const response = await this.client.show({ model: modelId });
 
+      // Prefer the model's actual context window; fall back to the user override, then 0.
+      const modelinfo = (response as Record<string, unknown>).modelinfo as Record<string, unknown> | undefined;
+      const parameters = (response as Record<string, unknown>).parameters as string | undefined;
+      let contextLength = getContextLengthOverride();
+      if (!contextLength) {
+        // Ollama ≥0.3 exposes context_length in modelinfo
+        const infoCtx = modelinfo?.['llama.context_length'] ?? modelinfo?.['context_length'];
+        if (typeof infoCtx === 'number' && infoCtx > 0) {
+          contextLength = infoCtx;
+        } else if (parameters) {
+          // Fall back to parsing the num_ctx line from the parameters string
+          const match = /^num_ctx\s+(\d+)/m.exec(parameters);
+          if (match) contextLength = parseInt(match[1], 10);
+        }
+      }
+
       return {
         id: modelId,
         name: formatModelName(modelId),
         family: 'ollama',
         version: '1.0.0',
-        maxInputTokens: getContextLengthOverride(),
-        maxOutputTokens: getContextLengthOverride(),
+        maxInputTokens: contextLength,
+        maxOutputTokens: contextLength,
         capabilities: {
           imageInput: this.isVisionModel(response),
           toolCalling: this.isToolModel(response),

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -326,6 +326,38 @@ describe('LocalModelsProvider', () => {
     localProvider.dispose();
   });
 
+  it('stopModel shows progress and polls until model is gone', async () => {
+    vi.useFakeTimers();
+
+    const generate = vi.fn().mockResolvedValue(undefined);
+    const ps = vi
+      .fn()
+      .mockResolvedValueOnce({ models: [{ name: 'llama2' }] }) // still running
+      .mockResolvedValueOnce({ models: [] }); // now gone
+
+    const localProvider = new LocalModelsProvider(
+      {
+        list: vi.fn().mockResolvedValue({ models: [] }),
+        ps,
+        generate,
+      } as unknown as Ollama,
+      undefined,
+    );
+
+    const stopPromise = localProvider.stopModel('llama2');
+
+    // Advance 2s to drive two 1000 ms poll intervals (still-running → gone)
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await stopPromise;
+
+    expect(generate).toHaveBeenCalledWith({ model: 'llama2', prompt: '', stream: false, keep_alive: 0 });
+    expect(ps).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+    localProvider.dispose();
+  });
+
   it('library provider sort mode configuration', async () => {
     vi.stubGlobal(
       'fetch',

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -468,12 +468,27 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
   }
 
   /**
-   * Stop a running model
+   * Stop a running model and show a progress indicator until it is fully unloaded
    */
   async stopModel(modelName: string): Promise<void> {
     try {
       this.logChannel?.debug(`[Ollama] Stopping model: ${modelName}`);
-      await this.client.generate({ model: modelName, prompt: '', stream: false, keep_alive: 0 });
+      await window.withProgress(
+        { location: ProgressLocation.Notification, title: `Stopping ${modelName}…`, cancellable: false },
+        async () => {
+          await this.client.generate({ model: modelName, prompt: '', stream: false, keep_alive: 0 });
+          // Poll until the model disappears from the running process list (max 30 s)
+          for (let i = 0; i < 30; i++) {
+            await new Promise<void>(resolve => setTimeout(resolve, 1000));
+            try {
+              const { models } = await this.client.ps();
+              if (!models.some(m => m.name === modelName)) break;
+            } catch {
+              break; // ps() failed — assume model is gone
+            }
+          }
+        },
+      );
       this.logChannel?.info(`[Ollama] Model stopped: ${modelName}`);
       this.refresh();
       window.showInformationMessage(`Model ${modelName} stopped`);

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -16,7 +16,7 @@ import {
   window,
   workspace,
 } from 'vscode';
-import { fetchModelCapabilities } from './client.js';
+import { fetchModelCapabilities, type ModelCapabilities } from './client.js';
 import type { DiagnosticsLogger } from './diagnostics.js';
 
 type LibrarySortMode = 'name' | 'recency';
@@ -254,6 +254,8 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
   readonly onDidChangeTreeData: Event<ModelTreeItem | null> = this.treeChangeEmitter.event;
 
   private refreshIntervals: NodeJS.Timeout[] = [];
+  private localModelCapabilitiesCache = new Map<string, ModelCapabilities>();
+  private localModelCapabilitiesInFlight = new Set<string>();
 
   constructor(
     private client: Ollama,
@@ -325,28 +327,42 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
               // Keep initial tooltip on error
             },
           );
-          // Fetch capability badges asynchronously
-          void fetchModelCapabilities(this.client, model.name).then(
-            caps => {
-              const badges: string[] = [];
-              if (caps.toolCalling) badges.push('tools');
-              if (caps.imageInput) badges.push('vision');
-              if (badges.length > 0) {
-                const badgeStr = badges.map(b => `[${b}]`).join(' ');
-                const existing = (item.description ?? '').toString();
-                // Strip any previously-added capability badges before re-appending
-                // so repeated refreshes don't duplicate them.
-                const knownBadgePattern = badges.map(b => `\\[${b}\\]`).join('|');
-                const stripRe = new RegExp(`\\s*(${knownBadgePattern})(\\s*(${knownBadgePattern}))*\\s*$`, 'i');
-                const cleaned = existing.replace(stripRe, '').trim();
-                item.description = cleaned ? `${cleaned} ${badgeStr}` : badgeStr;
+
+          const appendBadges = (caps: ModelCapabilities) => {
+            const badges: string[] = [];
+            if (caps.toolCalling) badges.push('tools');
+            if (caps.imageInput) badges.push('vision');
+            if (badges.length === 0) {
+              return;
+            }
+
+            const badgeStr = badges.map(b => `[${b}]`).join(' ');
+            const existing = (item.description ?? '').toString();
+            const knownBadgePattern = badges.map(b => `\\[${b}\\]`).join('|');
+            const stripRe = new RegExp(`\\s*(${knownBadgePattern})(\\s*(${knownBadgePattern}))*\\s*$`, 'i');
+            const cleaned = existing.replace(stripRe, '').trim();
+            item.description = cleaned ? `${cleaned} ${badgeStr}` : badgeStr;
+          };
+
+          const cachedCaps = this.localModelCapabilitiesCache.get(model.name);
+          if (cachedCaps) {
+            appendBadges(cachedCaps);
+          } else if (!this.localModelCapabilitiesInFlight.has(model.name)) {
+            this.localModelCapabilitiesInFlight.add(model.name);
+            // Fetch capabilities once per local model name.
+            void fetchModelCapabilities(this.client, model.name)
+              .then(caps => {
+                this.localModelCapabilitiesCache.set(model.name, caps);
+                appendBadges(caps);
                 this.treeChangeEmitter.fire(item);
-              }
-            },
-            () => {
-              // Silently skip badges on error
-            },
-          );
+              })
+              .catch(() => {
+                // Silently skip badges on error
+              })
+              .finally(() => {
+                this.localModelCapabilitiesInFlight.delete(model.name);
+              });
+          }
 
           return item;
         })

--- a/src/test/vscode.mock.ts
+++ b/src/test/vscode.mock.ts
@@ -112,6 +112,7 @@ export const window = {
 export const lm = {
   registerLanguageModelChatProvider: vi.fn().mockReturnValue({ dispose: vi.fn() }),
   selectChatModels: vi.fn().mockResolvedValue([]),
+  onDidChangeChatModels: vi.fn().mockReturnValue({ dispose: vi.fn() }),
 };
 
 export const commands = {

--- a/src/test/vscode.mock.ts
+++ b/src/test/vscode.mock.ts
@@ -103,6 +103,7 @@ export const window = {
 
 export const lm = {
   registerLanguageModelChatProvider: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+  selectChatModels: vi.fn().mockResolvedValue([]),
 };
 
 export const commands = {

--- a/src/test/vscode.mock.ts
+++ b/src/test/vscode.mock.ts
@@ -117,6 +117,7 @@ export const lm = {
 
 export const commands = {
   registerCommand: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+  executeCommand: vi.fn().mockResolvedValue(undefined),
 };
 
 export class MarkdownString {

--- a/src/test/vscode.mock.ts
+++ b/src/test/vscode.mock.ts
@@ -96,9 +96,17 @@ export class LanguageModelDataPart {
   ) {}
 }
 
+export enum ConfigurationTarget {
+  Global = 1,
+  Workspace = 2,
+  WorkspaceFolder = 3,
+}
+
 export const window = {
   showInputBox: vi.fn(),
   showQuickPick: vi.fn(),
+  showWarningMessage: vi.fn(),
+  showInformationMessage: vi.fn(),
 };
 
 export const lm = {


### PR DESCRIPTION
## Problem

Ollama chat responses showed "waiting" indefinitely in VS Code Copilot Chat.

## Root Cause

Two bugs in `provideLanguageModelChatResponse`:

**Bug 1 — Missing `await`**

`this.client.chat({ stream: true })` returns `Promise<AbortableAsyncIterator<ChatResponse>>`. Without `await`, the `for await...of` loop was iterating over the Promise object itself — the loop body never executed, `progress.report()` was never called.

```ts
// Before (broken)
const response = this.client.chat({ model: model.id, messages, stream: true, tools });
for await (const chunk of response as any) { ... } // iterates over a Promise, not the iterator

// After
const response = await this.client.chat({ model: model.id, messages, stream: true, tools });
for await (const chunk of response) { ... }
```

**Bug 2 — Text batching instead of streaming**

Text chunks were accumulated in `currentText` and only flushed at the end of the loop. VS Code requires each chunk to be reported immediately.

```ts
// Before (batched — VS Code sees nothing until the full response is done)
currentText += chunk.message.content;
// ... only after loop:
progress.report(new LanguageModelTextPart(currentText));

// After (streamed — VS Code gets each token as it arrives)
progress.report(new LanguageModelTextPart(chunk.message.content));
```

## Changes

- `src/provider.ts`: `await` on `client.chat()`, per-chunk `progress.report()`, removed `currentText` accumulation, fixed `toolCall.id` type error (`ToolCall` has no `id` in Ollama JS types)
- `src/provider.test.ts`: new test asserting 3 chunks yield 3 separate `progress.report` calls

## Tests

127 passing, clean compile.