### PR TITLE
fix(0i0b): replace text labels with key icon buttons in panel headers

### DIFF
--- a/.beans/ollama-models-vscode-0i0b--replace-cloud-api-key-text-with-key-icon-button-in.md
+++ b/.beans/ollama-models-vscode-0i0b--replace-cloud-api-key-text-with-key-icon-button-in.md
@@ -5,7 +5,7 @@ status: in-progress
 type: fix
 priority: low
 created_at: 2026-03-05T22:03:25Z
-updated_at: 2026-03-06T06:03:53Z
+updated_at: 2026-03-06T06:04:11Z
 ---
 
 ## Todo
@@ -15,4 +15,4 @@ updated_at: 2026-03-06T06:03:53Z
 - [x] Add `"icon": "$(key)"` to `manageAuthToken` command in package.json
 - [x] Add `manageAuthToken` to `ollama-local-models` view/title header (navigation@9)
 - [x] Run tests green
-- [ ] Commit and push
+- [x] Commit and push

--- a/.beans/ollama-models-vscode-0i0b--replace-cloud-api-key-text-with-key-icon-button-in.md
+++ b/.beans/ollama-models-vscode-0i0b--replace-cloud-api-key-text-with-key-icon-button-in.md
@@ -1,9 +1,18 @@
 ---
 # ollama-models-vscode-0i0b
 title: Replace cloud API key text with key icon button in panel header
-status: todo
+status: in-progress
 type: fix
 priority: low
 created_at: 2026-03-05T22:03:25Z
-updated_at: 2026-03-05T22:03:25Z
+updated_at: 2026-03-06T06:03:53Z
 ---
+
+## Todo
+
+- [x] Write failing test: navigation-group view/title commands must have an icon
+- [x] Add `"icon": "$(key)"` to `manageCloudApiKey` command in package.json
+- [x] Add `"icon": "$(key)"` to `manageAuthToken` command in package.json
+- [x] Add `manageAuthToken` to `ollama-local-models` view/title header (navigation@9)
+- [x] Run tests green
+- [ ] Commit and push

--- a/.beans/ollama-models-vscode-0i0b--replace-cloud-api-key-text-with-key-icon-button-in.md
+++ b/.beans/ollama-models-vscode-0i0b--replace-cloud-api-key-text-with-key-icon-button-in.md
@@ -5,7 +5,7 @@ status: in-progress
 type: fix
 priority: low
 created_at: 2026-03-05T22:03:25Z
-updated_at: 2026-03-06T06:04:11Z
+updated_at: 2026-03-06T06:05:01Z
 ---
 
 ## Todo

--- a/.beans/ollama-models-vscode-tuuz--stop-model-requires-two-clicks-and-alert-persists.md
+++ b/.beans/ollama-models-vscode-tuuz--stop-model-requires-two-clicks-and-alert-persists.md
@@ -1,9 +1,9 @@
 ---
 # ollama-models-vscode-tuuz
 title: Stop model requires two clicks and alert persists
-status: todo
+status: completed
 type: fix
 priority: high
 created_at: 2026-03-05T22:03:16Z
-updated_at: 2026-03-05T22:03:16Z
+updated_at: 2026-03-06T06:00:39Z
 ---

--- a/.beans/ollama-models-vscode-zj31--support-thinking-models-and-structured-tool-call-r.md
+++ b/.beans/ollama-models-vscode-zj31--support-thinking-models-and-structured-tool-call-r.md
@@ -1,9 +1,9 @@
 ---
 # ollama-models-vscode-zj31
 title: Support thinking models and structured tool call responses in provider
-status: in-progress
+status: completed
 type: feat
 priority: high
 created_at: 2026-03-06T04:51:53Z
-updated_at: 2026-03-06T05:23:54Z
+updated_at: 2026-03-06T06:00:26Z
 ---

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
       {
         "command": "ollama-copilot.manageAuthToken",
         "title": "Manage Ollama Auth Token",
+        "icon": "$(key)",
         "category": "Ollama"
       },
       {
@@ -211,6 +212,7 @@
       {
         "command": "ollama-copilot.manageCloudApiKey",
         "title": "Manage Ollama Cloud API Key",
+        "icon": "$(key)",
         "category": "Ollama"
       },
       {
@@ -262,6 +264,11 @@
           "command": "ollama-copilot.refreshLocalModels",
           "when": "view == ollama-local-models",
           "group": "navigation"
+        },
+        {
+          "command": "ollama-copilot.manageAuthToken",
+          "when": "view == ollama-local-models",
+          "group": "navigation@9"
         },
         {
           "command": "ollama-copilot.refreshLibrary",

--- a/src/contributes.test.ts
+++ b/src/contributes.test.ts
@@ -8,10 +8,10 @@ type PackageJson = {
       activitybar?: Array<{ id: string; icon?: string }>;
     };
     views?: Record<string, Array<{ id: string; type?: string }>>;
-    commands?: Array<{ command: string; title?: string; category?: string }>;
+    commands?: Array<{ command: string; title?: string; category?: string; icon?: string }>;
     menus?: {
-      'view/title'?: Array<{ command: string; when?: string }>;
-      'view/item/context'?: Array<{ command: string; when?: string }>;
+      'view/title'?: Array<{ command: string; when?: string; group?: string }>;
+      'view/item/context'?: Array<{ command: string; when?: string; group?: string }>;
     };
     languageModelChatProviders?: Array<{ vendor: string }>;
   };
@@ -93,5 +93,15 @@ describe('package contributes integrity', () => {
     const commands = (pkg.contributes?.commands ?? []) as PkgCommand[];
     const missing = commands.filter(c => c.category !== 'Ollama').map(c => c.command);
     expect(missing).toEqual([]);
+  });
+
+  it('all view/title navigation-group commands have an icon', () => {
+    const pkg = loadPackageJson();
+    const commandIconMap = new Map((pkg.contributes?.commands ?? []).map(c => [c.command, c.icon]));
+    const navMenuEntries = (pkg.contributes?.menus?.['view/title'] ?? []).filter(
+      entry => typeof entry.group === 'string' && entry.group.startsWith('navigation'),
+    );
+    const missingIcon = navMenuEntries.filter(entry => !commandIconMap.get(entry.command)).map(entry => entry.command);
+    expect(missingIcon).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Replaces the plain-text toolbar labels with `$(key)` icon buttons in the Local and Cloud panel headers.

### Changes

- **`manageCloudApiKey`** — added `"icon": "$(key)"` so the Cloud Models panel header shows a key icon button instead of the full text title
- **`manageAuthToken`** — added `"icon": "$(key)"` for the same treatment on the local auth token command
- **`view/title` menu** — added `manageAuthToken` to the `ollama-local-models` navigation group (`navigation@9`) so the key icon also appears in the Local Models panel header

### Test

Added a new assertion in `contributes.test.ts`:

> *All `view/title` navigation-group commands must have an `icon` field declared.*

This prevents text-only toolbar buttons from being introduced in the future.

Closes #0i0b