### PR TITLE
fix(j7cp): fetch ?sort=newest from ollama.com when recency sort is active

### DIFF
--- a/.beans/ollama-models-vscode-j7cp--library-recency-sort-should-fetch-newest-first-fro.md
+++ b/.beans/ollama-models-vscode-j7cp--library-recency-sort-should-fetch-newest-first-fro.md
@@ -1,9 +1,19 @@
 ---
 # ollama-models-vscode-j7cp
 title: Library recency sort should fetch newest-first from ollama.com
-status: todo
+status: in-progress
 type: fix
 priority: medium
 created_at: 2026-03-05T22:03:06Z
-updated_at: 2026-03-05T22:03:06Z
+updated_at: 2026-03-06T06:10:12Z
 ---
+
+## Todo
+
+- [x] Write failing test: recency mode must fetch `?sort=newest` URL
+- [x] `fetchLibraryModelNames` accepts `sortMode` and uses correct URL
+- [x] `setSortMode` calls `refresh()` to bust cache on mode change
+- [x] `refresh()` also nulls `loadPromise` + increments `cacheGeneration` to prevent stale write-back
+- [x] `getLibraryModels` passes `sortMode` to fetch and guards cache write with generation check
+- [x] Run tests green
+- [ ] Commit and push

--- a/.beans/ollama-models-vscode-j7cp--library-recency-sort-should-fetch-newest-first-fro.md
+++ b/.beans/ollama-models-vscode-j7cp--library-recency-sort-should-fetch-newest-first-fro.md
@@ -5,7 +5,7 @@ status: in-progress
 type: fix
 priority: medium
 created_at: 2026-03-05T22:03:06Z
-updated_at: 2026-03-06T06:10:12Z
+updated_at: 2026-03-06T06:10:27Z
 ---
 
 ## Todo
@@ -16,4 +16,4 @@ updated_at: 2026-03-06T06:10:12Z
 - [x] `refresh()` also nulls `loadPromise` + increments `cacheGeneration` to prevent stale write-back
 - [x] `getLibraryModels` passes `sortMode` to fetch and guards cache write with generation check
 - [x] Run tests green
-- [ ] Commit and push
+- [x] Commit and push

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -282,6 +282,57 @@ describe('LocalModelsProvider', () => {
     libraryProvider.dispose();
   });
 
+  it('does not use stale results when sort mode changes during an in-flight fetch', async () => {
+    let resolveFirstFetch: ((value: { ok: boolean; text: () => Promise<string> }) => void) | undefined;
+
+    const mockFetch = vi.fn().mockImplementation((url: string) => {
+      if (url === 'https://ollama.com/library') {
+        return new Promise(resolve => {
+          resolveFirstFetch = value => resolve(value);
+        });
+      }
+      if (url === 'https://ollama.com/library?sort=newest') {
+        return Promise.resolve({
+          ok: true,
+          text: async () => '<a href="/library/zeta"></a>',
+        });
+      }
+      // Model preview fetches — fail silently so they don't interfere
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+
+    vi.stubGlobal('fetch', mockFetch);
+
+    const libraryProvider = new LibraryModelsProvider(async () => new Set<string>(), undefined);
+
+    // Start the initial fetch (name sort, default) but leave it pending.
+    const firstFetchPromise = libraryProvider.getChildren();
+
+    // Change sort mode while the first fetch is still in-flight.
+    libraryProvider.setSortMode('recency');
+
+    // Now resolve the original (stale) fetch response.
+    resolveFirstFetch?.({
+      ok: true,
+      text: async () => '<a href="/library/alpha"></a>',
+    });
+    await firstFetchPromise;
+
+    // After the sort change, requesting children should trigger a new fetch
+    // and use the response corresponding to the new sort mode.
+    const modelsAfterSortChange = await libraryProvider.getChildren();
+
+    const libraryFetchUrls = mockFetch.mock.calls
+      .map(([url]: [string]) => url)
+      .filter(
+        (url: string) => url === 'https://ollama.com/library' || url === 'https://ollama.com/library?sort=newest',
+      );
+    expect(libraryFetchUrls).toHaveLength(2);
+    expect(modelsAfterSortChange[0].label).toBe('zeta');
+
+    libraryProvider.dispose();
+  });
+
   it('shows status item when cloud API key is missing', async () => {
     const cloudProvider = new CloudModelsProvider(
       {

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -251,6 +251,37 @@ describe('LocalModelsProvider', () => {
     libraryProvider.dispose();
   });
 
+  it('fetches from ?sort=newest URL when recency sort is active', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => '<a href="/library/newmodel"></a>',
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const libraryProvider = new LibraryModelsProvider(async () => new Set<string>(), undefined);
+    libraryProvider.setSortMode('recency');
+    await libraryProvider.getChildren();
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toBe('https://ollama.com/library?sort=newest');
+    libraryProvider.dispose();
+  });
+
+  it('fetches from plain /library URL when name sort is active', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => '<a href="/library/alpha"></a>',
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const libraryProvider = new LibraryModelsProvider(async () => new Set<string>(), undefined);
+    await libraryProvider.getChildren();
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toBe('https://ollama.com/library');
+    libraryProvider.dispose();
+  });
+
   it('shows status item when cloud API key is missing', async () => {
     const cloudProvider = new CloudModelsProvider(
       {

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -538,6 +538,8 @@ export class LibraryModelsProvider implements TreeDataProvider<ModelTreeItem>, D
   refresh(): void {
     this.cache = [];
     this.cacheTimeMs = 0;
+    this.loadPromise = null;
+    this.cacheGeneration++;
     this.treeChangeEmitter.fire(null);
   }
 

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -509,6 +509,7 @@ export class LibraryModelsProvider implements TreeDataProvider<ModelTreeItem>, D
 
   private cache: string[] = [];
   private cacheTimeMs = 0;
+  private cacheGeneration = 0;
   private refreshTimeout: NodeJS.Timeout | null = null;
   private refreshIntervals: NodeJS.Timeout[] = [];
   private loadPromise: Promise<string[]> | null = null;
@@ -551,7 +552,7 @@ export class LibraryModelsProvider implements TreeDataProvider<ModelTreeItem>, D
 
     this.sortMode = mode;
     void workspace.getConfiguration('ollama').update('librarySortMode', mode, true);
-    this.treeChangeEmitter.fire(null);
+    this.refresh();
   }
 
   dispose(): void {
@@ -578,10 +579,13 @@ export class LibraryModelsProvider implements TreeDataProvider<ModelTreeItem>, D
       return this.buildItems(pendingNames);
     }
 
-    this.loadPromise = this.fetchLibraryModelNames(12000)
+    const gen = this.cacheGeneration;
+    this.loadPromise = this.fetchLibraryModelNames(12000, this.sortMode)
       .then(names => {
-        this.cache = names;
-        this.cacheTimeMs = Date.now();
+        if (this.cacheGeneration === gen) {
+          this.cache = names;
+          this.cacheTimeMs = Date.now();
+        }
         return names;
       })
       .catch(error => {
@@ -600,14 +604,17 @@ export class LibraryModelsProvider implements TreeDataProvider<ModelTreeItem>, D
     return this.buildItems(names);
   }
 
-  private async fetchLibraryModelNames(timeoutMs: number): Promise<string[]> {
-    this.logChannel?.debug(`[Ollama] Fetching remote model library from ollama.com (timeout=${timeoutMs}ms)`);
+  private async fetchLibraryModelNames(timeoutMs: number, sortMode: LibrarySortMode): Promise<string[]> {
+    this.logChannel?.debug(
+      `[Ollama] Fetching remote model library from ollama.com (timeout=${timeoutMs}ms, sort=${sortMode})`,
+    );
 
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    const url = sortMode === 'recency' ? 'https://ollama.com/library?sort=newest' : 'https://ollama.com/library';
 
     try {
-      const response = await fetch('https://ollama.com/library', {
+      const response = await fetch(url, {
         method: 'GET',
         signal: controller.signal,
       });


### PR DESCRIPTION
## Summary

Previously, switching to "recency" sort in the Library panel only re-ordered an already-fetched alphabetical list client-side — it never asked ollama.com for the actual newest-first ordering.

### Root cause

`fetchLibraryModelNames` always fetched `https://ollama.com/library` regardless of sort mode, and `setSortMode` only fired the tree change emitter without busting the cache.

### Changes

**[src/sidebar.ts](src/sidebar.ts)**

- `fetchLibraryModelNames(timeoutMs, sortMode)` — passes `?sort=newest` for recency mode, plain `/library` for name mode
- `setSortMode` now calls `this.refresh()` instead of `fire(null)`, busting the cache so the next fetch uses the new URL
- `refresh()` nulls `loadPromise` and increments `cacheGeneration` to prevent any in-flight old-URL fetch from writing stale results back after a sort mode change
- `getLibraryModels` captures the generation before starting a fetch and guards the cache write with a generation equality check

**[src/sidebar.test.ts](src/sidebar.test.ts)**

- `fetches from ?sort=newest URL when recency sort is active`
- `fetches from plain /library URL when name sort is active`

Closes #j7cp