### PR TITLE
fix(22ff): remove model details view and associated commands

### DIFF
--- a/.beans/ollama-models-vscode-0i0b--replace-cloud-api-key-text-with-key-icon-button-in.md
+++ b/.beans/ollama-models-vscode-0i0b--replace-cloud-api-key-text-with-key-icon-button-in.md
@@ -1,11 +1,11 @@
 ---
 # ollama-models-vscode-0i0b
 title: Replace cloud API key text with key icon button in panel header
-status: in-progress
+status: completed
 type: fix
 priority: low
 created_at: 2026-03-05T22:03:25Z
-updated_at: 2026-03-06T06:05:01Z
+updated_at: 2026-03-06T06:17:18Z
 ---
 
 ## Todo

--- a/.beans/ollama-models-vscode-22ff--remove-model-details-view-and-associated-commands.md
+++ b/.beans/ollama-models-vscode-22ff--remove-model-details-view-and-associated-commands.md
@@ -1,12 +1,13 @@
 ---
 # ollama-models-vscode-22ff
 title: Remove model details view and associated commands
-status: in-progress
+status: completed
 type: fix
 priority: medium
 created_at: 2026-03-05T22:02:46Z
 updated_at: 2026-03-06T06:12:42Z
 branch: fix/22ff-remove-model-details-view
+pr: https://github.com/selfagency/ollama-copilot/pull/12
 ---
 
 ## Todo
@@ -21,5 +22,8 @@ branch: fix/22ff-remove-model-details-view
 - [x] Remove `previewProvider` instantiation and registrations from `registerSidebar()`
 - [x] Remove `handleShowModelDetails` tests from `sidebar.test.ts`
 - [x] Run full test suite green
-- [ ] Commit and push
+- [x] Commit and push
 
+## Summary of Changes
+
+Removed the `ollama-model-preview` webview view panel and all associated machinery (`ModelPreviewViewProvider`, `handleShowModelDetails`, `previewLibraryModel` command). `fetchModelPagePreview` was kept as it is still used for tooltip descriptions on local and library model tree items. Three regression tests guard against re-introduction.

--- a/.beans/ollama-models-vscode-22ff--remove-model-details-view-and-associated-commands.md
+++ b/.beans/ollama-models-vscode-22ff--remove-model-details-view-and-associated-commands.md
@@ -1,9 +1,25 @@
 ---
 # ollama-models-vscode-22ff
 title: Remove model details view and associated commands
-status: todo
+status: in-progress
 type: fix
 priority: medium
 created_at: 2026-03-05T22:02:46Z
-updated_at: 2026-03-05T22:02:46Z
+updated_at: 2026-03-06T06:12:42Z
+branch: fix/22ff-remove-model-details-view
 ---
+
+## Todo
+
+- [x] Write failing tests confirming removal
+- [x] Remove `ollama-model-preview` view from `package.json`
+- [x] Remove `previewLibraryModel` command from `package.json`
+- [x] Remove `previewLibraryModel` menu entry from `package.json`
+- [x] Remove `ModelPreviewViewProvider` class from `sidebar.ts`
+- [x] Remove `handleShowModelDetails` function from `sidebar.ts`
+- [x] Remove `WebviewView`/`WebviewViewProvider` imports from `sidebar.ts`
+- [x] Remove `previewProvider` instantiation and registrations from `registerSidebar()`
+- [x] Remove `handleShowModelDetails` tests from `sidebar.test.ts`
+- [x] Run full test suite green
+- [ ] Commit and push
+

--- a/.beans/ollama-models-vscode-u168--move-runstopdownload-icons-to-left-side-of-tree-it.md
+++ b/.beans/ollama-models-vscode-u168--move-runstopdownload-icons-to-left-side-of-tree-it.md
@@ -1,9 +1,11 @@
 ---
 # ollama-models-vscode-u168
-title: Move run/stop/download icons to left side of tree items
+title: Add running/stopped icons to left side of running models
 status: todo
 type: fix
 priority: medium
 created_at: 2026-03-05T22:02:56Z
 updated_at: 2026-03-05T22:02:56Z
 ---
+
+Use circle-play and stop-circle for the icons and stop and play for the clickable actions

--- a/package.json
+++ b/package.json
@@ -107,11 +107,6 @@
           "name": "Library"
         },
         {
-          "id": "ollama-model-preview",
-          "name": "Model Details",
-          "type": "webview"
-        },
-        {
           "icon": "$(file-code)",
           "id": "ollama-modelfiles",
           "name": "Modelfiles"
@@ -195,12 +190,6 @@
         "command": "ollama-copilot.openLibraryModelPage",
         "title": "Open Ollama Model Page",
         "icon": "$(link-external)",
-        "category": "Ollama"
-      },
-      {
-        "command": "ollama-copilot.previewLibraryModel",
-        "title": "Ollama Model Details",
-        "icon": "$(preview)",
         "category": "Ollama"
       },
       {
@@ -341,11 +330,6 @@
           "command": "ollama-copilot.openLibraryModelPage",
           "when": "view == ollama-library-models && viewItem == library-model",
           "group": "inline@2"
-        },
-        {
-          "command": "ollama-copilot.previewLibraryModel",
-          "when": "view == ollama-library-models && viewItem == library-model",
-          "group": "navigation@1"
         },
         {
           "command": "ollama-copilot.startCloudModel",

--- a/src/contributes.test.ts
+++ b/src/contributes.test.ts
@@ -104,4 +104,23 @@ describe('package contributes integrity', () => {
     const missingIcon = navMenuEntries.filter(entry => !commandIconMap.get(entry.command)).map(entry => entry.command);
     expect(missingIcon).toEqual([]);
   });
+
+  it('does not declare the ollama-model-preview webview view', () => {
+    const pkg = loadPackageJson();
+    const explorerViews = pkg.contributes?.views?.['ollama-explorer'] ?? [];
+    const ids = explorerViews.map(view => view.id);
+    expect(ids).not.toContain('ollama-model-preview');
+  });
+
+  it('does not declare the previewLibraryModel command', () => {
+    const pkg = loadPackageJson();
+    const commands = (pkg.contributes?.commands ?? []).map(c => c.command);
+    expect(commands).not.toContain('ollama-copilot.previewLibraryModel');
+  });
+
+  it('does not include previewLibraryModel in context menus', () => {
+    const pkg = loadPackageJson();
+    const contextCommands = (pkg.contributes?.menus?.['view/item/context'] ?? []).map(m => m.command);
+    expect(contextCommands).not.toContain('ollama-copilot.previewLibraryModel');
+  });
 });

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -36,7 +36,6 @@ describe('LocalModelsProvider', () => {
       },
       window: {
         registerTreeDataProvider: vi.fn(() => ({ dispose: vi.fn() })),
-        registerWebviewViewProvider: vi.fn(() => ({ dispose: vi.fn() })),
         withProgress: vi.fn(async (_options: unknown, callback: () => Promise<void>) => callback()),
         showInputBox: vi.fn(),
         showErrorMessage: vi.fn(),
@@ -705,41 +704,6 @@ describe('Extracted command handlers', () => {
     handleOpenLibraryModelPage(item);
 
     expect(handleOpenLibraryModelPage).toBeDefined();
-  });
-
-  it('handleShowModelDetails returns early for status items', async () => {
-    const { handleShowModelDetails, ModelTreeItem } = await import('./sidebar.js');
-
-    const mockPreviewProvider = {
-      setLoading: vi.fn(),
-      setModelPreview: vi.fn(),
-      setError: vi.fn(),
-      setModelDetails: vi.fn(),
-    } as any;
-
-    const item = new ModelTreeItem('Status', 'status');
-
-    handleShowModelDetails(item, mockPreviewProvider);
-
-    expect(mockPreviewProvider.setModelDetails).not.toHaveBeenCalled();
-  });
-
-  it('handleShowModelDetails shows local model details', async () => {
-    const { handleShowModelDetails, ModelTreeItem } = await import('./sidebar.js');
-
-    const mockPreviewProvider = {
-      setLoading: vi.fn(),
-      setModelPreview: vi.fn(),
-      setError: vi.fn(),
-      setModelDetails: vi.fn(),
-    } as any;
-
-    const item = new ModelTreeItem('test-model', 'local-running', 1024);
-    item.description = '1GB • running';
-
-    handleShowModelDetails(item, mockPreviewProvider);
-
-    expect(mockPreviewProvider.setModelDetails).toHaveBeenCalled();
   });
 
   it('handlePullModel handles model name input', async () => {

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -11,8 +11,6 @@ import {
   TreeItem,
   TreeItemCollapsibleState,
   Uri,
-  WebviewView,
-  WebviewViewProvider,
   window,
   workspace,
 } from 'vscode';
@@ -172,77 +170,6 @@ async function fetchModelPagePreview(
     return { title, description };
   } finally {
     clearTimeout(timeout);
-  }
-}
-
-export class ModelPreviewViewProvider implements WebviewViewProvider {
-  private view: WebviewView | undefined;
-
-  resolveWebviewView(webviewView: WebviewView): void {
-    this.view = webviewView;
-    webviewView.webview.options = { enableScripts: false };
-    webviewView.webview.html = this.renderHtml(
-      'Model Details',
-      'Select a model in Local, Cloud, or Library to see details.',
-    );
-  }
-
-  setLoading(modelName: string): void {
-    if (!this.view) {
-      return;
-    }
-    this.view.webview.html = this.renderHtml(modelName, 'Loading model details...');
-  }
-
-  setModelPreview(modelName: string, title: string, description: string): void {
-    if (!this.view) {
-      return;
-    }
-
-    const modelUrl = getLibraryModelUrl(modelName);
-    this.view.webview.html = this.renderHtml(title, description, modelName, {
-      href: modelUrl,
-      label: 'Open on ollama.com ↗',
-    });
-  }
-
-  setModelDetails(title: string, modelName: string, description: string): void {
-    if (!this.view) {
-      return;
-    }
-
-    this.view.webview.html = this.renderHtml(title, description, modelName);
-  }
-
-  setError(modelName: string, message: string): void {
-    if (!this.view) {
-      return;
-    }
-
-    const modelUrl = getLibraryModelUrl(modelName);
-    this.view.webview.html = this.renderHtml(modelName, `Could not load model details: ${message}`, modelName, {
-      href: modelUrl,
-      label: 'Open on ollama.com ↗',
-    });
-  }
-
-  private renderHtml(title: string, body: string, _modelName?: string, link?: { href: string; label: string }): string {
-    const cspSource = this.view?.webview.cspSource ?? "'none'";
-    const linkLine = link
-      ? `<p style="margin:0;"><a href="${escapeHtml(link.href)}">${escapeHtml(link.label)}</a></p>`
-      : '';
-
-    return `<!doctype html>
-<html>
-  <head>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'unsafe-inline'; img-src ${cspSource} https:; font-src ${cspSource};">
-  </head>
-  <body style="font-family:var(--vscode-font-family);padding:12px;line-height:1.5;">
-    <h3 style="margin:0 0 8px 0;">${escapeHtml(title)}</h3>
-    <p style="margin:0 0 10px 0;">${escapeHtml(body)}</p>
-    ${linkLine}
-  </body>
-</html>`;
   }
 }
 
@@ -1082,44 +1009,6 @@ export function handleOpenLibraryModelPage(item: ModelTreeItem): void {
 }
 
 /**
- * Command handler: show model details
- */
-export function handleShowModelDetails(
-  item: ModelTreeItem,
-  previewProvider: ModelPreviewViewProvider,
-  _logChannel?: DiagnosticsLogger,
-): void {
-  if (!item || item.type === 'status') {
-    return;
-  }
-
-  if (item.type === 'library-model') {
-    previewProvider.setLoading(item.label);
-    void commands.executeCommand('ollama-model-preview.focus');
-    void fetchModelPagePreview(item.label)
-      .then(preview => {
-        previewProvider.setModelPreview(item.label, preview.title, preview.description);
-      })
-      .catch(error => {
-        const message = error instanceof Error ? error.message : String(error);
-        previewProvider.setError(item.label, message);
-      });
-    return;
-  }
-
-  const location = item.type.startsWith('cloud-') ? 'Cloud' : 'Local';
-  const status = item.type.endsWith('running') ? 'Running' : 'Stopped';
-  const descriptionParts = [`Location: ${location}`, `Status: ${status}`];
-
-  if (item.description) {
-    descriptionParts.push(`Info: ${item.description}`);
-  }
-
-  previewProvider.setModelDetails('Model Details', item.label, descriptionParts.join(' • '));
-  void commands.executeCommand('ollama-model-preview.focus');
-}
-
-/**
  * Command handler: start model
  */
 export function handleStartModel(item: ModelTreeItem, localProvider: LocalModelsProvider): void {
@@ -1162,8 +1051,6 @@ export function registerSidebar(context: ExtensionContext, client: Ollama, logCh
   const localProvider = new LocalModelsProvider(client, logChannel);
   const cloudProvider = new CloudModelsProvider(context, logChannel);
   const libraryProvider = new LibraryModelsProvider(() => cloudProvider.getCloudModelNamesForFilter(), logChannel);
-  const previewProvider = new ModelPreviewViewProvider();
-
   const syncLibrarySortContext = () => {
     const mode = libraryProvider.getSortMode();
     void commands.executeCommand('setContext', 'ollama.librarySortMode', mode);
@@ -1177,7 +1064,6 @@ export function registerSidebar(context: ExtensionContext, client: Ollama, logCh
     window.registerTreeDataProvider('ollama-local-models', localProvider),
     window.registerTreeDataProvider('ollama-library-models', libraryProvider),
     window.registerTreeDataProvider('ollama-cloud-models', cloudProvider),
-    window.registerWebviewViewProvider('ollama-model-preview', previewProvider),
     commands.registerCommand('ollama-copilot.refreshSidebar', () => handleRefreshLocalModels(localProvider)),
     commands.registerCommand('ollama-copilot.refreshLocalModels', () => handleRefreshLocalModels(localProvider)),
     commands.registerCommand('ollama-copilot.refreshLibrary', () => handleRefreshLibrary(libraryProvider)),
@@ -1206,9 +1092,6 @@ export function registerSidebar(context: ExtensionContext, client: Ollama, logCh
     ),
     commands.registerCommand('ollama-copilot.openLibraryModelPage', (item: ModelTreeItem) =>
       handleOpenLibraryModelPage(item),
-    ),
-    commands.registerCommand('ollama-copilot.showModelDetails', (item: ModelTreeItem) =>
-      handleShowModelDetails(item, previewProvider),
     ),
     commands.registerCommand('ollama-copilot.startModel', (item: ModelTreeItem) =>
       handleStartModel(item, localProvider),


### PR DESCRIPTION
Closes bean `ollama-models-vscode-22ff`.

## Summary

Removes the model details webview panel and all associated machinery that is no longer needed.

### Removed from `package.json`
- `ollama-model-preview` webview view declaration
- `ollama-copilot.previewLibraryModel` command declaration
- `previewLibraryModel` entry in `view/item/context` menus

### Removed from `src/sidebar.ts`
- `ModelPreviewViewProvider` class (webview implementation)
- `handleShowModelDetails` function (command handler)
- `WebviewView` / `WebviewViewProvider` imports (no longer needed)
- `previewProvider` instantiation in `registerSidebar()`
- `window.registerWebviewViewProvider('ollama-model-preview', ...)` subscription
- `commands.registerCommand('ollama-copilot.showModelDetails', ...)` subscription

### Kept
- `fetchModelPagePreview` — still used for tooltip descriptions on local and library model tree items

### Tests
- Removed two `handleShowModelDetails` tests from `sidebar.test.ts`
- Removed dead `registerWebviewViewProvider` mock entry from `sidebar.test.ts`
- Added three regression tests to `contributes.test.ts` asserting the view, command, and menu entry are absent from `package.json`
- All 159 tests passing