### PR TITLE
feat(4vps): inline code completion provider

### DIFF
--- a/.beans/ollama-models-vscode-4vps--inline-code-completion-provider-with-configurable.md
+++ b/.beans/ollama-models-vscode-4vps--inline-code-completion-provider-with-configurable.md
@@ -1,12 +1,13 @@
 ---
 # ollama-models-vscode-4vps
 title: Inline code completion provider with configurable model
-status: todo
+status: in-progress
 type: feature
 priority: medium
 created_at: 2026-03-06T05:50:22Z
 updated_at: 2026-03-06T06:30:00Z
 id: ollama-models-vscode-4vps
+branch: feature/4vps-inline-completion-provider
 ---
 
 ## Summary

--- a/.beans/ollama-models-vscode-j7cp--library-recency-sort-should-fetch-newest-first-fro.md
+++ b/.beans/ollama-models-vscode-j7cp--library-recency-sort-should-fetch-newest-first-fro.md
@@ -1,9 +1,9 @@
 ---
 # ollama-models-vscode-j7cp
 title: Library recency sort should fetch newest-first from ollama.com
-status: todo
+status: completed
 type: fix
 priority: medium
 created_at: 2026-03-05T22:03:06Z
-updated_at: 2026-03-05T22:03:06Z
+updated_at: 2026-03-06T06:48:17Z
 ---

--- a/.beans/ollama-models-vscode-u168--move-runstopdownload-icons-to-left-side-of-tree-it.md
+++ b/.beans/ollama-models-vscode-u168--move-runstopdownload-icons-to-left-side-of-tree-it.md
@@ -1,11 +1,11 @@
 ---
 # ollama-models-vscode-u168
 title: Add running/stopped icons to left side of running models
-status: todo
+status: completed
 type: fix
 priority: medium
 created_at: 2026-03-05T22:02:56Z
-updated_at: 2026-03-05T22:02:56Z
+updated_at: 2026-03-06T06:48:21Z
 ---
 
 Use circle-play and stop-circle for the icons and stop and play for the clickable actions

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "MD013": false,
+  "MD033": false
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 - 🧠 **All Ollama Models** - Download and run any model from the [Ollama Library](https://ollama.ai/library), including Cloud models (Requires API key)
 - 🛠️ **Model Management** - Pull, manage, and delete models directly from the sidebar
 - 🏠 **Local Execution** - Models run on your machine with full privacy—no data leaves your computer
+- 🤖 **Code Completions** - Use local models to provide code completions in the editor
 - 🔧 **Tool Calling** - Function calling support for agentic workflows with compatible models
 - 🖼️ **Vision Support** - Image input for models with vision capabilities
 - ⚡ **Streaming** - Real-time response streaming for faster interactions
@@ -49,6 +50,8 @@ Open VS Code Settings (`Ctrl+,` / `Cmd+,`) and search for "Ollama":
 - **`ollama.host`** - Ollama server address (default: `http://localhost:11434`)
 - **`ollama.contextLength`** - Context window size for models (default: `1024`)
 - **`ollama.streamLogs`** - Stream Ollama server logs to output channel (default: `true`)
+- **`ollama.completionModel`** - Model used for inline code completions (e.g. `qwen2.5-coder:1.5b`). Leave empty to disable.
+- **`ollama.enableInlineCompletions`** - Enable or disable inline code completions (default: `true`)
 
 To use a remote Ollama instance, update `ollama.host` to point to your remote server.
 
@@ -73,6 +76,16 @@ Type `@ollama` in any Copilot Chat input to direct the conversation to your loca
 
 The participant is sticky — once invoked, it stays active for the thread.
 
+### Inline Code Completions
+
+Set `ollama.completionModel` to a locally-installed model to get inline code completions as you type. Smaller, fast models work best:
+
+- `qwen2.5-coder:1.5b`
+- `deepseek-coder:1.3b`
+- `starcoder2:3b`
+
+Completions use fill-in-the-middle (FIM) when the model supports it, and can be toggled with `ollama.enableInlineCompletions`.
+
 ### Sidebar: Model Management
 
 The Ollama sidebar provides three sections:
@@ -81,19 +94,14 @@ The Ollama sidebar provides three sections:
 
 - View installed models on your system
 - Right-click to run, stop, or delete models
-- See memory usage of running models
+- Monitor active models in real-time
+- View context window and memory usage
 
 #### Library Models
 
-- Browse 100+ pre-configured models from [ollama.ai/library](https://ollama.ai/library)
+- Browse 200+ pre-configured models from [ollama.ai/library](https://ollama.ai/library)
 - Sort by recency or name
 - Click to view details, preview capabilities, or pull to local system
-
-#### Running Models
-
-- Monitor active models in real-time
-- View context window and memory usage
-- Stop models when done
 
 ### Modelfile Manager
 

--- a/package.json
+++ b/package.json
@@ -421,6 +421,16 @@
           "type": "string",
           "default": "",
           "description": "Path to folder containing Modelfiles. Leave empty to use ~/.ollama/modelfiles"
+        },
+        "ollama.completionModel": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Model used for inline code completions. Leave empty to disable. Smaller, faster models work best (e.g. `qwen2.5-coder:1.5b`, `deepseek-coder:1.3b`)."
+        },
+        "ollama.enableInlineCompletions": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable Ollama inline code completions."
         }
       }
     },

--- a/src/completions.test.ts
+++ b/src/completions.test.ts
@@ -1,0 +1,442 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('OllamaInlineCompletionProvider', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeToken(isCancellationRequested = false) {
+    return { isCancellationRequested };
+  }
+
+  function makeDocument(text: string, offset: number) {
+    return {
+      getText: () => text,
+      offsetAt: (_position: unknown) => offset,
+    };
+  }
+
+  function makeConfigGet(enableInlineCompletions: boolean, completionModel: string) {
+    return vi.fn((key: string) => {
+      if (key === 'enableInlineCompletions') return enableInlineCompletions;
+      if (key === 'completionModel') return completionModel;
+      return undefined;
+    });
+  }
+
+  it('returns null when enableInlineCompletions is false', async () => {
+    vi.doMock('vscode', () => ({
+      workspace: {
+        getConfiguration: vi.fn(() => ({
+          get: makeConfigGet(false, 'llama3.2'),
+        })),
+      },
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
+    }));
+
+    const { OllamaInlineCompletionProvider } = await import('./completions.js');
+    const client = { generate: vi.fn() } as any;
+    const provider = new OllamaInlineCompletionProvider(client);
+    const result = await provider.provideInlineCompletionItems(
+      makeDocument('hello', 5) as any,
+      {} as any,
+      {} as any,
+      makeToken() as any,
+    );
+
+    expect(result).toBeNull();
+    expect(client.generate).not.toHaveBeenCalled();
+  });
+
+  it('returns null when completionModel is empty string', async () => {
+    vi.doMock('vscode', () => ({
+      workspace: {
+        getConfiguration: vi.fn(() => ({
+          get: makeConfigGet(true, ''),
+        })),
+      },
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
+    }));
+
+    const { OllamaInlineCompletionProvider } = await import('./completions.js');
+    const client = { generate: vi.fn() } as any;
+    const provider = new OllamaInlineCompletionProvider(client);
+    const result = await provider.provideInlineCompletionItems(
+      makeDocument('hello', 5) as any,
+      {} as any,
+      {} as any,
+      makeToken() as any,
+    );
+
+    expect(result).toBeNull();
+    expect(client.generate).not.toHaveBeenCalled();
+  });
+
+  it('returns null when completionModel is whitespace', async () => {
+    vi.doMock('vscode', () => ({
+      workspace: {
+        getConfiguration: vi.fn(() => ({
+          get: makeConfigGet(true, '   '),
+        })),
+      },
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
+    }));
+
+    const { OllamaInlineCompletionProvider } = await import('./completions.js');
+    const client = { generate: vi.fn() } as any;
+    const provider = new OllamaInlineCompletionProvider(client);
+    const result = await provider.provideInlineCompletionItems(
+      makeDocument('hello', 5) as any,
+      {} as any,
+      {} as any,
+      makeToken() as any,
+    );
+
+    expect(result).toBeNull();
+    expect(client.generate).not.toHaveBeenCalled();
+  });
+
+  it('calls client.generate with correct prefix and suffix', async () => {
+    const generateMock = vi.fn().mockResolvedValue({ response: 'const x = 1;' });
+
+    vi.doMock('vscode', () => ({
+      workspace: {
+        getConfiguration: vi.fn(() => ({
+          get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
+        })),
+      },
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
+    }));
+
+    const { OllamaInlineCompletionProvider } = await import('./completions.js');
+    const client = { generate: generateMock } as any;
+    const provider = new OllamaInlineCompletionProvider(client);
+
+    const text = 'hello world';
+    const offset = 5; // cursor after 'hello'
+    await provider.provideInlineCompletionItems(
+      makeDocument(text, offset) as any,
+      {} as any,
+      {} as any,
+      makeToken() as any,
+    );
+
+    expect(generateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'qwen2.5-coder:1.5b',
+        prompt: 'hello',
+        suffix: ' world',
+        stream: false,
+      }),
+    );
+  });
+
+  it('returns InlineCompletionItem wrapping the response text', async () => {
+    const completionText = 'const x = 1;';
+    vi.doMock('vscode', () => ({
+      workspace: {
+        getConfiguration: vi.fn(() => ({
+          get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
+        })),
+      },
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
+    }));
+
+    const { OllamaInlineCompletionProvider } = await import('./completions.js');
+    const client = { generate: vi.fn().mockResolvedValue({ response: completionText }) } as any;
+    const provider = new OllamaInlineCompletionProvider(client);
+
+    const result = await provider.provideInlineCompletionItems(
+      makeDocument('hello', 5) as any,
+      {} as any,
+      {} as any,
+      makeToken() as any,
+    );
+
+    expect(result).toHaveLength(1);
+    expect((result as any[])[0].insertText).toBe(completionText);
+  });
+
+  it('returns null for empty response', async () => {
+    vi.doMock('vscode', () => ({
+      workspace: {
+        getConfiguration: vi.fn(() => ({
+          get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
+        })),
+      },
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
+    }));
+
+    const { OllamaInlineCompletionProvider } = await import('./completions.js');
+    const client = { generate: vi.fn().mockResolvedValue({ response: '' }) } as any;
+    const provider = new OllamaInlineCompletionProvider(client);
+
+    const result = await provider.provideInlineCompletionItems(
+      makeDocument('hello', 5) as any,
+      {} as any,
+      {} as any,
+      makeToken() as any,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null for whitespace-only response', async () => {
+    vi.doMock('vscode', () => ({
+      workspace: {
+        getConfiguration: vi.fn(() => ({
+          get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
+        })),
+      },
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
+    }));
+
+    const { OllamaInlineCompletionProvider } = await import('./completions.js');
+    const client = { generate: vi.fn().mockResolvedValue({ response: '   \n  ' }) } as any;
+    const provider = new OllamaInlineCompletionProvider(client);
+
+    const result = await provider.provideInlineCompletionItems(
+      makeDocument('hello', 5) as any,
+      {} as any,
+      {} as any,
+      makeToken() as any,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when cancellation is requested on entry', async () => {
+    vi.doMock('vscode', () => ({
+      workspace: {
+        getConfiguration: vi.fn(() => ({
+          get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
+        })),
+      },
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
+    }));
+
+    const { OllamaInlineCompletionProvider } = await import('./completions.js');
+    const client = { generate: vi.fn() } as any;
+    const provider = new OllamaInlineCompletionProvider(client);
+
+    const result = await provider.provideInlineCompletionItems(
+      makeDocument('hello', 5) as any,
+      {} as any,
+      {} as any,
+      makeToken(true) as any,
+    );
+
+    expect(result).toBeNull();
+    expect(client.generate).not.toHaveBeenCalled();
+  });
+
+  it('returns null when cancellation is requested after generate resolves', async () => {
+    const token = { isCancellationRequested: false };
+
+    vi.doMock('vscode', () => ({
+      workspace: {
+        getConfiguration: vi.fn(() => ({
+          get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
+        })),
+      },
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
+    }));
+
+    const { OllamaInlineCompletionProvider } = await import('./completions.js');
+    const client = {
+      generate: vi.fn().mockImplementation(async () => {
+        token.isCancellationRequested = true;
+        return { response: 'const x = 1;' };
+      }),
+    } as any;
+    const provider = new OllamaInlineCompletionProvider(client);
+
+    const result = await provider.provideInlineCompletionItems(
+      makeDocument('hello', 5) as any,
+      {} as any,
+      {} as any,
+      token as any,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('trims prefix to MAX_COMPLETION_PREFIX_CHARS', async () => {
+    const generateMock = vi.fn().mockResolvedValue({ response: 'x' });
+
+    vi.doMock('vscode', () => ({
+      workspace: {
+        getConfiguration: vi.fn(() => ({
+          get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
+        })),
+      },
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
+    }));
+
+    const { OllamaInlineCompletionProvider, MAX_COMPLETION_PREFIX_CHARS } = await import('./completions.js');
+    const client = { generate: generateMock } as any;
+    const provider = new OllamaInlineCompletionProvider(client);
+
+    const longPrefix = 'a'.repeat(MAX_COMPLETION_PREFIX_CHARS + 100);
+    const suffix = 'end';
+    const text = longPrefix + suffix;
+    const offset = longPrefix.length;
+
+    await provider.provideInlineCompletionItems(
+      makeDocument(text, offset) as any,
+      {} as any,
+      {} as any,
+      makeToken() as any,
+    );
+
+    const call = generateMock.mock.calls[0][0];
+    expect(call.prompt).toHaveLength(MAX_COMPLETION_PREFIX_CHARS);
+    expect(call.prompt).toBe('a'.repeat(MAX_COMPLETION_PREFIX_CHARS));
+  });
+
+  it('trims suffix to MAX_COMPLETION_SUFFIX_CHARS', async () => {
+    const generateMock = vi.fn().mockResolvedValue({ response: 'x' });
+
+    vi.doMock('vscode', () => ({
+      workspace: {
+        getConfiguration: vi.fn(() => ({
+          get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
+        })),
+      },
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
+    }));
+
+    const { OllamaInlineCompletionProvider, MAX_COMPLETION_SUFFIX_CHARS } = await import('./completions.js');
+    const client = { generate: generateMock } as any;
+    const provider = new OllamaInlineCompletionProvider(client);
+
+    const prefix = 'start';
+    const longSuffix = 'b'.repeat(MAX_COMPLETION_SUFFIX_CHARS + 100);
+    const text = prefix + longSuffix;
+    const offset = prefix.length;
+
+    await provider.provideInlineCompletionItems(
+      makeDocument(text, offset) as any,
+      {} as any,
+      {} as any,
+      makeToken() as any,
+    );
+
+    const call = generateMock.mock.calls[0][0];
+    expect(call.suffix).toHaveLength(MAX_COMPLETION_SUFFIX_CHARS);
+    expect(call.suffix).toBe('b'.repeat(MAX_COMPLETION_SUFFIX_CHARS));
+  });
+
+  it('omits suffix field when suffix is empty', async () => {
+    const generateMock = vi.fn().mockResolvedValue({ response: 'x' });
+
+    vi.doMock('vscode', () => ({
+      workspace: {
+        getConfiguration: vi.fn(() => ({
+          get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
+        })),
+      },
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
+    }));
+
+    const { OllamaInlineCompletionProvider } = await import('./completions.js');
+    const client = { generate: generateMock } as any;
+    const provider = new OllamaInlineCompletionProvider(client);
+
+    const text = 'hello';
+    const offset = text.length; // cursor at end, no suffix
+
+    await provider.provideInlineCompletionItems(
+      makeDocument(text, offset) as any,
+      {} as any,
+      {} as any,
+      makeToken() as any,
+    );
+
+    const call = generateMock.mock.calls[0][0];
+    expect(call.suffix).toBeUndefined();
+  });
+
+  it('catches generate errors and returns null', async () => {
+    const logChannel = { error: vi.fn(), info: vi.fn(), warn: vi.fn() };
+
+    vi.doMock('vscode', () => ({
+      workspace: {
+        getConfiguration: vi.fn(() => ({
+          get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
+        })),
+      },
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
+    }));
+
+    const { OllamaInlineCompletionProvider } = await import('./completions.js');
+    const client = { generate: vi.fn().mockRejectedValue(new Error('Connection refused')) } as any;
+    const provider = new OllamaInlineCompletionProvider(client, logChannel as any);
+
+    const result = await provider.provideInlineCompletionItems(
+      makeDocument('hello', 5) as any,
+      {} as any,
+      {} as any,
+      makeToken() as any,
+    );
+
+    expect(result).toBeNull();
+    expect(logChannel.error).toHaveBeenCalledWith(expect.stringContaining('Connection refused'));
+  });
+
+  it('does not call logChannel.error when no logChannel provided', async () => {
+    vi.doMock('vscode', () => ({
+      workspace: {
+        getConfiguration: vi.fn(() => ({
+          get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
+        })),
+      },
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
+    }));
+
+    const { OllamaInlineCompletionProvider } = await import('./completions.js');
+    const client = { generate: vi.fn().mockRejectedValue(new Error('oops')) } as any;
+    const provider = new OllamaInlineCompletionProvider(client);
+
+    await expect(
+      provider.provideInlineCompletionItems(
+        makeDocument('hello', 5) as any,
+        {} as any,
+        {} as any,
+        makeToken() as any,
+      ),
+    ).resolves.toBeNull();
+  });
+});

--- a/src/completions.test.ts
+++ b/src/completions.test.ts
@@ -14,9 +14,28 @@ describe('OllamaInlineCompletionProvider', () => {
   }
 
   function makeDocument(text: string, offset: number) {
+    const positionAt = (off: number) => ({ _off: Math.min(Math.max(0, off), text.length) });
     return {
-      getText: () => text,
-      offsetAt: (_position: unknown) => offset,
+      getText: (range?: unknown) => {
+        if (!range) return text;
+        const r = range as { start: { _off?: number }; end: { _off?: number } };
+        // When `position` (passed as `{}`) is used as a range boundary it has no
+        // `_off`, so fall back to the cursor offset so slicing stays correct.
+        const start = r.start._off ?? offset;
+        const end = r.end._off ?? offset;
+        return text.slice(start, end);
+      },
+      offsetAt: (pos: unknown) => {
+        if (typeof pos === 'object' && pos !== null) {
+          if ('_off' in (pos as object)) return (pos as { _off: number })._off;
+          // Sentinel: vscode.Position(lineCount - 1, MAX_SAFE_INTEGER) → document end
+          if ('character' in (pos as object) && (pos as { character: number }).character === Number.MAX_SAFE_INTEGER)
+            return text.length;
+        }
+        return offset;
+      },
+      positionAt,
+      lineCount: text.split('\n').length || 1,
     };
   }
 
@@ -34,6 +53,18 @@ describe('OllamaInlineCompletionProvider', () => {
         getConfiguration: vi.fn(() => ({
           get: makeConfigGet(false, 'llama3.2'),
         })),
+      },
+      Position: class {
+        constructor(
+          public readonly line: number,
+          public readonly character: number,
+        ) {}
+      },
+      Range: class {
+        constructor(
+          public readonly start: unknown,
+          public readonly end: unknown,
+        ) {}
       },
       InlineCompletionItem: class {
         constructor(public readonly insertText: string) {}
@@ -61,6 +92,18 @@ describe('OllamaInlineCompletionProvider', () => {
           get: makeConfigGet(true, ''),
         })),
       },
+      Position: class {
+        constructor(
+          public readonly line: number,
+          public readonly character: number,
+        ) {}
+      },
+      Range: class {
+        constructor(
+          public readonly start: unknown,
+          public readonly end: unknown,
+        ) {}
+      },
       InlineCompletionItem: class {
         constructor(public readonly insertText: string) {}
       },
@@ -86,6 +129,18 @@ describe('OllamaInlineCompletionProvider', () => {
         getConfiguration: vi.fn(() => ({
           get: makeConfigGet(true, '   '),
         })),
+      },
+      Position: class {
+        constructor(
+          public readonly line: number,
+          public readonly character: number,
+        ) {}
+      },
+      Range: class {
+        constructor(
+          public readonly start: unknown,
+          public readonly end: unknown,
+        ) {}
       },
       InlineCompletionItem: class {
         constructor(public readonly insertText: string) {}
@@ -114,6 +169,18 @@ describe('OllamaInlineCompletionProvider', () => {
         getConfiguration: vi.fn(() => ({
           get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
         })),
+      },
+      Position: class {
+        constructor(
+          public readonly line: number,
+          public readonly character: number,
+        ) {}
+      },
+      Range: class {
+        constructor(
+          public readonly start: unknown,
+          public readonly end: unknown,
+        ) {}
       },
       InlineCompletionItem: class {
         constructor(public readonly insertText: string) {}
@@ -151,6 +218,18 @@ describe('OllamaInlineCompletionProvider', () => {
           get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
         })),
       },
+      Position: class {
+        constructor(
+          public readonly line: number,
+          public readonly character: number,
+        ) {}
+      },
+      Range: class {
+        constructor(
+          public readonly start: unknown,
+          public readonly end: unknown,
+        ) {}
+      },
       InlineCompletionItem: class {
         constructor(public readonly insertText: string) {}
       },
@@ -178,6 +257,18 @@ describe('OllamaInlineCompletionProvider', () => {
           get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
         })),
       },
+      Position: class {
+        constructor(
+          public readonly line: number,
+          public readonly character: number,
+        ) {}
+      },
+      Range: class {
+        constructor(
+          public readonly start: unknown,
+          public readonly end: unknown,
+        ) {}
+      },
       InlineCompletionItem: class {
         constructor(public readonly insertText: string) {}
       },
@@ -204,6 +295,18 @@ describe('OllamaInlineCompletionProvider', () => {
           get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
         })),
       },
+      Position: class {
+        constructor(
+          public readonly line: number,
+          public readonly character: number,
+        ) {}
+      },
+      Range: class {
+        constructor(
+          public readonly start: unknown,
+          public readonly end: unknown,
+        ) {}
+      },
       InlineCompletionItem: class {
         constructor(public readonly insertText: string) {}
       },
@@ -229,6 +332,18 @@ describe('OllamaInlineCompletionProvider', () => {
         getConfiguration: vi.fn(() => ({
           get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
         })),
+      },
+      Position: class {
+        constructor(
+          public readonly line: number,
+          public readonly character: number,
+        ) {}
+      },
+      Range: class {
+        constructor(
+          public readonly start: unknown,
+          public readonly end: unknown,
+        ) {}
       },
       InlineCompletionItem: class {
         constructor(public readonly insertText: string) {}
@@ -258,6 +373,18 @@ describe('OllamaInlineCompletionProvider', () => {
         getConfiguration: vi.fn(() => ({
           get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
         })),
+      },
+      Position: class {
+        constructor(
+          public readonly line: number,
+          public readonly character: number,
+        ) {}
+      },
+      Range: class {
+        constructor(
+          public readonly start: unknown,
+          public readonly end: unknown,
+        ) {}
       },
       InlineCompletionItem: class {
         constructor(public readonly insertText: string) {}
@@ -291,6 +418,18 @@ describe('OllamaInlineCompletionProvider', () => {
         getConfiguration: vi.fn(() => ({
           get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
         })),
+      },
+      Position: class {
+        constructor(
+          public readonly line: number,
+          public readonly character: number,
+        ) {}
+      },
+      Range: class {
+        constructor(
+          public readonly start: unknown,
+          public readonly end: unknown,
+        ) {}
       },
       InlineCompletionItem: class {
         constructor(public readonly insertText: string) {}
@@ -327,6 +466,18 @@ describe('OllamaInlineCompletionProvider', () => {
           get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
         })),
       },
+      Position: class {
+        constructor(
+          public readonly line: number,
+          public readonly character: number,
+        ) {}
+      },
+      Range: class {
+        constructor(
+          public readonly start: unknown,
+          public readonly end: unknown,
+        ) {}
+      },
       InlineCompletionItem: class {
         constructor(public readonly insertText: string) {}
       },
@@ -362,6 +513,18 @@ describe('OllamaInlineCompletionProvider', () => {
           get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
         })),
       },
+      Position: class {
+        constructor(
+          public readonly line: number,
+          public readonly character: number,
+        ) {}
+      },
+      Range: class {
+        constructor(
+          public readonly start: unknown,
+          public readonly end: unknown,
+        ) {}
+      },
       InlineCompletionItem: class {
         constructor(public readonly insertText: string) {}
       },
@@ -394,6 +557,18 @@ describe('OllamaInlineCompletionProvider', () => {
           get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
         })),
       },
+      Position: class {
+        constructor(
+          public readonly line: number,
+          public readonly character: number,
+        ) {}
+      },
+      Range: class {
+        constructor(
+          public readonly start: unknown,
+          public readonly end: unknown,
+        ) {}
+      },
       InlineCompletionItem: class {
         constructor(public readonly insertText: string) {}
       },
@@ -421,6 +596,18 @@ describe('OllamaInlineCompletionProvider', () => {
           get: makeConfigGet(true, 'qwen2.5-coder:1.5b'),
         })),
       },
+      Position: class {
+        constructor(
+          public readonly line: number,
+          public readonly character: number,
+        ) {}
+      },
+      Range: class {
+        constructor(
+          public readonly start: unknown,
+          public readonly end: unknown,
+        ) {}
+      },
       InlineCompletionItem: class {
         constructor(public readonly insertText: string) {}
       },
@@ -431,12 +618,7 @@ describe('OllamaInlineCompletionProvider', () => {
     const provider = new OllamaInlineCompletionProvider(client);
 
     await expect(
-      provider.provideInlineCompletionItems(
-        makeDocument('hello', 5) as any,
-        {} as any,
-        {} as any,
-        makeToken() as any,
-      ),
+      provider.provideInlineCompletionItems(makeDocument('hello', 5) as any, {} as any, {} as any, makeToken() as any),
     ).resolves.toBeNull();
   });
 });

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -25,11 +25,16 @@ export class OllamaInlineCompletionProvider implements vscode.InlineCompletionIt
     const modelId = config.get<string>('completionModel')?.trim() ?? '';
     if (!modelId) return null;
 
-    const fullText = document.getText();
     const offset = document.offsetAt(position);
-    const prefix = fullText.slice(0, offset).slice(-MAX_COMPLETION_PREFIX_CHARS);
-    const rawSuffix = fullText.slice(offset);
-    const suffix = rawSuffix.slice(0, MAX_COMPLETION_SUFFIX_CHARS);
+    // Compute prefix window using a range instead of materializing the entire document.
+    const prefixStartOffset = Math.max(0, offset - MAX_COMPLETION_PREFIX_CHARS);
+    const prefixStartPosition = document.positionAt(prefixStartOffset);
+    const prefix = document.getText(new vscode.Range(prefixStartPosition, position));
+    // Compute suffix window using a range limited by MAX_COMPLETION_SUFFIX_CHARS.
+    const documentLength = document.offsetAt(new vscode.Position(document.lineCount - 1, Number.MAX_SAFE_INTEGER));
+    const suffixEndOffset = Math.min(documentLength, offset + MAX_COMPLETION_SUFFIX_CHARS);
+    const suffixEndPosition = document.positionAt(suffixEndOffset);
+    const suffix = document.getText(new vscode.Range(position, suffixEndPosition));
 
     try {
       const response = await this.client.generate({

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -1,0 +1,55 @@
+import type { Ollama } from 'ollama';
+import * as vscode from 'vscode';
+import type { DiagnosticsLogger } from './diagnostics.js';
+
+export const MAX_COMPLETION_PREFIX_CHARS = 2000;
+export const MAX_COMPLETION_SUFFIX_CHARS = 500;
+
+export class OllamaInlineCompletionProvider implements vscode.InlineCompletionItemProvider {
+  constructor(
+    private readonly client: Ollama,
+    private readonly logChannel?: DiagnosticsLogger,
+  ) {}
+
+  async provideInlineCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    _context: vscode.InlineCompletionContext,
+    token: vscode.CancellationToken,
+  ): Promise<vscode.InlineCompletionItem[] | null> {
+    if (token.isCancellationRequested) return null;
+
+    const config = vscode.workspace.getConfiguration('ollama');
+    if (!config.get<boolean>('enableInlineCompletions', true)) return null;
+
+    const modelId = config.get<string>('completionModel')?.trim() ?? '';
+    if (!modelId) return null;
+
+    const fullText = document.getText();
+    const offset = document.offsetAt(position);
+    const prefix = fullText.slice(0, offset).slice(-MAX_COMPLETION_PREFIX_CHARS);
+    const rawSuffix = fullText.slice(offset);
+    const suffix = rawSuffix.slice(0, MAX_COMPLETION_SUFFIX_CHARS);
+
+    try {
+      const response = await this.client.generate({
+        model: modelId,
+        prompt: prefix,
+        suffix: suffix.length > 0 ? suffix : undefined,
+        stream: false,
+        options: { num_predict: 128, temperature: 0.1, stop: ['\n\n'] },
+      });
+
+      if (token.isCancellationRequested) return null;
+
+      const text = response.response;
+      if (!text?.trim()) return null;
+
+      return [new vscode.InlineCompletionItem(text)];
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logChannel?.error(`[Ollama] Inline completion failed: ${message}`);
+      return null;
+    }
+  }
+}

--- a/src/contributes.test.ts
+++ b/src/contributes.test.ts
@@ -14,6 +14,12 @@ type PackageJson = {
       'view/item/context'?: Array<{ command: string; when?: string; group?: string }>;
     };
     languageModelChatProviders?: Array<{ vendor: string }>;
+    configuration?: {
+      properties?: Record<
+        string,
+        { type?: string; default?: unknown; description?: string; markdownDescription?: string }
+      >;
+    };
   };
   activationEvents?: string[];
 };
@@ -103,5 +109,20 @@ describe('package contributes integrity', () => {
     );
     const missingIcon = navMenuEntries.filter(entry => !commandIconMap.get(entry.command)).map(entry => entry.command);
     expect(missingIcon).toEqual([]);
+  });
+
+  it('declares ollama.completionModel configuration property', () => {
+    const pkg = loadPackageJson();
+    const prop = pkg.contributes?.configuration?.properties?.['ollama.completionModel'];
+    expect(prop).toBeDefined();
+    expect(prop?.type).toBe('string');
+  });
+
+  it('declares ollama.enableInlineCompletions configuration property', () => {
+    const pkg = loadPackageJson();
+    const prop = pkg.contributes?.configuration?.properties?.['ollama.enableInlineCompletions'];
+    expect(prop).toBeDefined();
+    expect(prop?.type).toBe('boolean');
+    expect(prop?.default).toBe(true);
   });
 });

--- a/src/contributes.test.ts
+++ b/src/contributes.test.ts
@@ -124,6 +124,8 @@ describe('package contributes integrity', () => {
     expect(prop).toBeDefined();
     expect(prop?.type).toBe('boolean');
     expect(prop?.default).toBe(true);
+  });
+
   it('does not declare the ollama-model-preview webview view', () => {
     const pkg = loadPackageJson();
     const explorerViews = pkg.contributes?.views?.['ollama-explorer'] ?? [];

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -59,6 +59,9 @@ describe('activate', () => {
       lm: {
         registerLanguageModelChatProvider,
       },
+      languages: {
+        registerInlineCompletionItemProvider: vi.fn(() => ({ dispose: vi.fn() })),
+      },
       chat: {
         createChatParticipant: vi.fn(() => ({
           iconPath: undefined,
@@ -77,6 +80,9 @@ describe('activate', () => {
       },
       LanguageModelTextPart: class {},
       CancellationToken: class {},
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
     }));
 
     vi.doMock('./client.js', () => ({
@@ -161,6 +167,9 @@ describe('activate', () => {
       lm: {
         registerLanguageModelChatProvider,
       },
+      languages: {
+        registerInlineCompletionItemProvider: vi.fn(() => ({ dispose: vi.fn() })),
+      },
       chat: {
         createChatParticipant: vi.fn(() => ({
           iconPath: undefined,
@@ -179,6 +188,9 @@ describe('activate', () => {
       },
       LanguageModelTextPart: class {},
       CancellationToken: class {},
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
     }));
 
     vi.doMock('./client.js', () => ({
@@ -267,6 +279,9 @@ describe('activate', () => {
       lm: {
         registerLanguageModelChatProvider: vi.fn(() => ({ dispose: vi.fn() })),
       },
+      languages: {
+        registerInlineCompletionItemProvider: vi.fn(() => ({ dispose: vi.fn() })),
+      },
       chat: {
         createChatParticipant: vi.fn(() => ({
           iconPath: undefined,
@@ -285,6 +300,9 @@ describe('activate', () => {
       },
       LanguageModelTextPart: class {},
       CancellationToken: class {},
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
     }));
 
     vi.doMock('./client.js', () => ({
@@ -386,6 +404,9 @@ describe('activate', () => {
       lm: {
         registerLanguageModelChatProvider: vi.fn(() => ({ dispose: vi.fn() })),
       },
+      languages: {
+        registerInlineCompletionItemProvider: vi.fn(() => ({ dispose: vi.fn() })),
+      },
       chat: {
         createChatParticipant: vi.fn(() => ({
           iconPath: undefined,
@@ -404,6 +425,9 @@ describe('activate', () => {
       },
       LanguageModelTextPart: class {},
       CancellationToken: class {},
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
     }));
 
     vi.doMock('./client.js', () => ({
@@ -494,6 +518,9 @@ describe('activate', () => {
       lm: {
         registerLanguageModelChatProvider: vi.fn(() => ({ dispose: vi.fn() })),
       },
+      languages: {
+        registerInlineCompletionItemProvider: vi.fn(() => ({ dispose: vi.fn() })),
+      },
       chat: {
         createChatParticipant: vi.fn(() => ({
           iconPath: undefined,
@@ -512,6 +539,9 @@ describe('activate', () => {
       },
       LanguageModelTextPart: class {},
       CancellationToken: class {},
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
     }));
 
     vi.doMock('./client.js', () => ({
@@ -607,6 +637,9 @@ describe('activate', () => {
       lm: {
         registerLanguageModelChatProvider,
       },
+      languages: {
+        registerInlineCompletionItemProvider: vi.fn(() => ({ dispose: vi.fn() })),
+      },
       chat: {
         createChatParticipant: vi.fn(() => ({
           iconPath: undefined,
@@ -625,6 +658,9 @@ describe('activate', () => {
       },
       LanguageModelTextPart: class {},
       CancellationToken: class {},
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
     }));
 
     vi.doMock('./client.js', () => ({
@@ -705,6 +741,9 @@ describe('activate', () => {
       lm: {
         registerLanguageModelChatProvider: vi.fn(() => ({ dispose: vi.fn() })),
       },
+      languages: {
+        registerInlineCompletionItemProvider: vi.fn(() => ({ dispose: vi.fn() })),
+      },
       chat: {
         createChatParticipant: vi.fn(() => ({
           iconPath: undefined,
@@ -723,6 +762,9 @@ describe('activate', () => {
       },
       LanguageModelTextPart: class {},
       CancellationToken: class {},
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
     }));
 
     vi.doMock('./client.js', () => ({
@@ -811,6 +853,9 @@ describe('activate', () => {
       lm: {
         registerLanguageModelChatProvider: vi.fn(() => ({ dispose: vi.fn() })),
       },
+      languages: {
+        registerInlineCompletionItemProvider: vi.fn(() => ({ dispose: vi.fn() })),
+      },
       chat: {
         createChatParticipant: vi.fn(() => ({
           iconPath: undefined,
@@ -829,6 +874,9 @@ describe('activate', () => {
       },
       LanguageModelTextPart: class {},
       CancellationToken: class {},
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
     }));
 
     vi.doMock('./client.js', () => ({
@@ -876,6 +924,118 @@ describe('activate', () => {
     }
 
     expect(mockInfo).toHaveBeenCalledWith(expect.stringContaining('Auto-start log streaming setting changed'));
+  });
+
+  it('registers inline completion provider during activation', async () => {
+    const registerInlineCompletionItemProvider = vi.fn(() => ({ dispose: vi.fn() }));
+
+    vi.doMock('vscode', () => ({
+      TreeItem: class {
+        constructor(public label: string) {}
+      },
+      TreeItemCollapsibleState: {
+        None: 0,
+        Collapsed: 1,
+        Expanded: 2,
+      },
+      EventEmitter: class {
+        event = {};
+        fire = vi.fn();
+      },
+      window: {
+        registerTreeDataProvider: vi.fn(() => ({ dispose: vi.fn() })),
+        registerWebviewViewProvider: vi.fn(() => ({ dispose: vi.fn() })),
+        createOutputChannel: vi.fn(() => ({
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+          log: vi.fn(),
+          show: vi.fn(),
+        })),
+        showInputBox: vi.fn(),
+        showErrorMessage: vi.fn(),
+        showInformationMessage: vi.fn(),
+        withProgress: vi.fn(async (_options: any, callback: any) => callback({})),
+      },
+      commands: {
+        registerCommand: vi.fn(() => ({ dispose: vi.fn() })),
+        executeCommand: vi.fn(),
+      },
+      workspace: {
+        getConfiguration: vi.fn(() => ({
+          get: vi.fn((key: string) => {
+            if (key === 'autoStartLogStreaming') return false;
+            if (key === 'localModelRefreshInterval') return 0;
+            if (key === 'libraryRefreshInterval') return 0;
+            return undefined;
+          }),
+        })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+      lm: {
+        registerLanguageModelChatProvider: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+      languages: {
+        registerInlineCompletionItemProvider,
+      },
+      chat: {
+        createChatParticipant: vi.fn(() => ({
+          iconPath: undefined,
+          dispose: vi.fn(),
+        })),
+      },
+      Uri: {
+        joinPath: vi.fn((_base: any, _path: string) => ({ fsPath: _path })),
+      },
+      ChatResponseMarkdownPart: class {
+        value: any = {};
+      },
+      LanguageModelChatMessage: {
+        User: vi.fn(),
+        Assistant: vi.fn(),
+      },
+      LanguageModelTextPart: class {},
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
+      CancellationToken: class {},
+      InlineCompletionItem: class {
+        constructor(public readonly insertText: string) {}
+      },
+    }));
+
+    vi.doMock('./client.js', () => ({
+      getOllamaClient: vi.fn().mockResolvedValue({
+        list: vi.fn().mockResolvedValue({ models: [] }),
+        ps: vi.fn().mockResolvedValue({ models: [] }),
+        show: vi.fn().mockResolvedValue({ template: '' }),
+      }),
+      testConnection: vi.fn().mockResolvedValue(true),
+    }));
+
+    vi.doMock('./provider.js', () => ({
+      OllamaChatModelProvider: class {
+        setAuthToken = vi.fn();
+      },
+    }));
+
+    vi.doMock('./sidebar.js', () => ({
+      registerSidebar: vi.fn(),
+    }));
+
+    vi.doMock('./modelfiles.js', () => ({
+      registerModelfileManager: vi.fn(),
+    }));
+
+    const ext = await import('./extension.js');
+    await ext.activate({ subscriptions: [], extensionUri: {} } as any);
+
+    expect(registerInlineCompletionItemProvider).toHaveBeenCalledOnce();
+    expect(registerInlineCompletionItemProvider).toHaveBeenCalledWith(
+      { pattern: '**' },
+      expect.objectContaining({ provideInlineCompletionItems: expect.any(Function) }),
+    );
   });
 });
 

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1000,9 +1000,6 @@ describe('activate', () => {
         constructor(public readonly insertText: string) {}
       },
       CancellationToken: class {},
-      InlineCompletionItem: class {
-        constructor(public readonly insertText: string) {}
-      },
     }));
 
     vi.doMock('./client.js', () => ({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path';
 import type { ChatResponse, Ollama } from 'ollama';
 import * as vscode from 'vscode';
 import { getOllamaClient, testConnection } from './client.js';
+import { OllamaInlineCompletionProvider } from './completions.js';
 import { createDiagnosticsLogger, getConfiguredLogLevel, type DiagnosticsLogger } from './diagnostics.js';
 import { registerModelfileManager } from './modelfiles.js';
 import { isThinkingModelId, OllamaChatModelProvider } from './provider.js';
@@ -512,6 +513,12 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Register modelfile manager
   registerModelfileManager(context, client, diagnostics);
+
+  // Register inline completion provider
+  const completionProvider = new OllamaInlineCompletionProvider(client, diagnostics);
+  context.subscriptions.push(
+    vscode.languages.registerInlineCompletionItemProvider({ pattern: '**' }, completionProvider),
+  );
 
   // Test connection to Ollama server on startup (non-blocking)
   void (async () => {

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -322,7 +322,7 @@ describe('LocalModelsProvider', () => {
     const modelsAfterSortChange = await libraryProvider.getChildren();
 
     const libraryFetchUrls = mockFetch.mock.calls
-      .map(([url]: [string]) => url)
+      .map(call => String(call[0]))
       .filter(
         (url: string) => url === 'https://ollama.com/library' || url === 'https://ollama.com/library?sort=newest',
       );

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -810,7 +810,7 @@ describe('Extracted command handlers', () => {
     const item = new ModelTreeItem('mistral:7b', 'library-model');
 
     // Should not throw
-    handlePullModelFromLibrary(item, _mockClient, mockProvider);
+    await handlePullModelFromLibrary(item, _mockClient, mockProvider);
 
     // Since it's async with promise handling, pull should be called eventually
     // Verify the function exists and is callable
@@ -830,7 +830,7 @@ describe('Extracted command handlers', () => {
 
     const item = new ModelTreeItem('test-model', 'local-running');
 
-    handlePullModelFromLibrary(item, mockClient, mockProvider);
+    await handlePullModelFromLibrary(item, mockClient, mockProvider);
 
     // Pull should not be called for non-library models
     expect(mockClient.pull).not.toHaveBeenCalled();

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -134,15 +134,6 @@ function getLibraryModelUrl(modelName: string): string {
   return `https://ollama.com/library/${encoded}`;
 }
 
-function escapeHtml(input: string): string {
-  return input
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
-}
-
 async function fetchModelPagePreview(
   modelName: string,
   timeoutMs = 8000,

--- a/src/test/vscode.mock.ts
+++ b/src/test/vscode.mock.ts
@@ -157,3 +157,7 @@ export const Uri = {
 export const chat = {
   createChatParticipant: vi.fn().mockReturnValue({ iconPath: undefined, dispose: vi.fn() }),
 };
+
+export class InlineCompletionItem {
+  constructor(public readonly insertText: string) {}
+}


### PR DESCRIPTION
## Summary

Implements bean 4vps — an inline code completion provider that uses a locally-configured Ollama model to provide fill-in-the-middle (FIM) completions as you type.

## Changes

### New files
- `src/completions.ts` — `OllamaInlineCompletionProvider` class implementing `vscode.InlineCompletionItemProvider`
- `src/completions.test.ts` — 14 unit tests covering all guard conditions, happy path, cancellation, trimming, and error handling

### Modified files
- `package.json` — adds `ollama.completionModel` (string) and `ollama.enableInlineCompletions` (boolean, default `true`) settings
- `src/extension.ts` — imports provider, registers it for all files in `activate()`
- `src/test/vscode.mock.ts` — adds `InlineCompletionItem` class stub
- `src/contributes.test.ts` — 2 new tests for the new settings; extends `PackageJson` type
- `src/extension.test.ts` — 1 new test asserting `registerInlineCompletionItemProvider` is called; `languages` mock added to all existing activate tests
- `README.md` — documents the two new settings and adds inline completions usage section

## Design decisions

- Uses `client.generate()` (not `client.chat()`) — only `/api/generate` exposes the `suffix` field for FIM
- Suffix omitted when empty (not passed as `""`) so models without FIM support silently ignore it
- `stream: false` with `num_predict: 128, temperature: 0.1, stop: ['\n\n']`
- Cancellation checked on entry AND after `generate()` resolves to handle keystroke debouncing
- Empty/whitespace response → `null` (no ghost text)
- Errors are caught, logged via `logChannel?.error`, and return `null` (non-fatal)
- `MAX_COMPLETION_PREFIX_CHARS = 2000`, `MAX_COMPLETION_SUFFIX_CHARS = 500`

## Test plan

175 tests passing (17 new).