### PR TITLE
fix(provider,sidebar): inject cloud API key for cloud-tagged model requests [6ogy]

### DIFF
--- a/.beans/ollama-models-vscode-36w3--prevent-deleting-a-running-model.md
+++ b/.beans/ollama-models-vscode-36w3--prevent-deleting-a-running-model.md
@@ -1,19 +1,26 @@
 ---
 # ollama-models-vscode-36w3
 title: Prevent deleting a running model
-status: todo
+status: completed
 type: feature
 priority: high
 created_at: 2026-03-07T17:17:45Z
-updated_at: 2026-03-07T17:20:01Z
+updated_at: 2026-03-07T17:55:00Z
+branch: fix/36w3-prevent-delete-running-model
 ---
 
 The delete model button appears in the context menu for running models (`local-running`, `cloud-running`). Deleting a running model can leave the model runner in a bad state.
 
 ## Todo
 
-- [ ] Remove `{"command": "ollama-copilot.deleteModel", "when": "view == ollama-local-models && viewItem == local-running", ...}` from `view/item/context` in `package.json`
-- [ ] Remove `{"command": "ollama-copilot.deleteModel", "when": "view == ollama-cloud-models && viewItem == cloud-running", ...}` from `view/item/context` in `package.json`
-- [ ] In `src/sidebar.ts` `handleDeleteModel()`: add guard — if `item.type === 'local-running' || item.type === 'cloud-running'`, call `vscode.window.showErrorMessage('Stop the model before deleting it.')` and return early
-- [ ] Run `pnpm run compile` to verify TypeScript passes
-- [ ] Run `pnpm run test` to verify unit tests still pass
+- [x] Remove `{"command": "ollama-copilot.deleteModel", "when": "view == ollama-local-models && viewItem == local-running", ...}` from `view/item/context` in `package.json`
+- [x] Remove `{"command": "ollama-copilot.deleteModel", "when": "view == ollama-cloud-models && viewItem == cloud-running", ...}` from `view/item/context` in `package.json`
+- [x] In `src/sidebar.ts` `handleDeleteModel()`: add guard — if `item.type === 'local-running' || item.type === 'cloud-running'`, call `vscode.window.showErrorMessage('Stop the model before deleting it.')` and return early
+- [x] Run `pnpm run compile` to verify TypeScript passes
+- [x] Run `pnpm run test` to verify unit tests still pass
+
+## Summary of Changes
+
+- `package.json`: Removed `deleteModel` context menu entries for `local-running` and `cloud-running` viewItem states.
+- `src/sidebar.ts`: Added early return guard in `handleDeleteModel` that shows an error message and blocks deletion when the model is running.
+- `src/sidebar.test.ts`: Two new tests verify the guard works for both `local-running` and `cloud-running` model types.

--- a/.beans/ollama-models-vscode-6ogy--fix-cloud-models-500-error-inject-cloud-api-key-in.md
+++ b/.beans/ollama-models-vscode-6ogy--fix-cloud-models-500-error-inject-cloud-api-key-in.md
@@ -1,11 +1,11 @@
 ---
 # ollama-models-vscode-6ogy
 title: Fix cloud models 500 error — inject cloud API key in Ollama client
-status: todo
+status: completed
 type: bug
 priority: high
 created_at: 2026-03-07T17:17:38Z
-updated_at: 2026-03-07T17:19:41Z
+updated_at: 2026-03-07T17:35:19Z
 ---
 
 Cloud model chat requests return a 500 error because the Ollama local server requires `Authorization: Bearer <cloudApiKey>` to proxy requests to Ollama's cloud backend. The extension never includes the cloud API key in chat/generate/pull client requests.
@@ -16,8 +16,15 @@ The extension uses the standard `getOllamaClient(context)` for all calls. Cloud 
 
 ## Todo
 
-- [ ] Add `getCloudOllamaClient(context: vscode.ExtensionContext): Promise<Ollama>` export to `src/client.ts` — reads `ollama-cloud-api-key` secret, sets `Authorization: Bearer <key>` header on the Ollama client
-- [ ] In `src/sidebar.ts` `LocalModelsProvider.startModel()`: when `isCloudTaggedModel(modelName)`, use `getCloudOllamaClient` for the pull and generate warmup calls
-- [ ] In `src/provider.ts` `provideLanguageModelChatResponse()`: check if `runtimeModelId` has a cloud tag (`:cloud` suffix or matches `isCloudTaggedModel`); if so, use `getCloudOllamaClient(this.context)` as `perRequestClient`
-- [ ] Run `pnpm run compile` to verify TypeScript passes
-- [ ] Run `pnpm run test` to verify unit tests still pass
+- [x] Add `getCloudOllamaClient(context: vscode.ExtensionContext): Promise<Ollama>` export to `src/client.ts` — reads `ollama-cloud-api-key` secret, sets `Authorization: Bearer <key>` header on the Ollama client
+- [x] In `src/sidebar.ts` `LocalModelsProvider.startModel()`: when `isCloudTaggedModel(modelName)`, use `getCloudOllamaClient` for the pull and generate warmup calls
+- [x] In `src/provider.ts` `provideLanguageModelChatResponse()`: check if `runtimeModelId` has a cloud tag (`:cloud` suffix or matches `isCloudTaggedModel`); if so, use `getCloudOllamaClient(this.context)` as `perRequestClient`
+- [x] Run `pnpm run compile` to verify TypeScript passes
+- [x] Run `pnpm run test` to verify unit tests still pass
+
+## Summary of Changes
+
+- `src/client.ts`: Added `getCloudOllamaClient(context)` — creates an Ollama client with `Authorization: Bearer <ollama-cloud-api-key>` header.
+- `src/sidebar.ts`: `LocalModelsProvider` gains an optional `context: ExtensionContext` constructor param. `startModel()` uses the cloud client when warming a cloud-tagged model.
+- `src/provider.ts`: `provideLanguageModelChatResponse()` detects cloud-tagged `runtimeModelId` and uses `getCloudOllamaClient` as the per-request client.
+- `src/sidebar.test.ts`: Updated one `LocalModelsProvider` call site to reflect the shifted constructor arity.

--- a/.beans/ollama-models-vscode-7not--increase-unit-test-coverage-to-85.md
+++ b/.beans/ollama-models-vscode-7not--increase-unit-test-coverage-to-85.md
@@ -16,4 +16,3 @@ branch: feat/7not-increase-unit-test-coverage-to-85
 - [x] Add `src/provider.test.ts` `setAuthToken` and capability tests
 - [x] Add `src/extension.test.ts` tool loop and logger tests
 - [x] Fix `src/sidebar.test.ts` — remove deleted `setSortMode`/`handleSortLibraryByRecency`/`handleSortLibraryByName` tests; fix grouping navigation for family-tree layout; fix `LibraryModelsProvider` constructor calls; fix `handleStartCloudModel` mocks
-

--- a/.beans/ollama-models-vscode-acrx--fix-cloud-model-stop-using-base-name-instead-of-re.md
+++ b/.beans/ollama-models-vscode-acrx--fix-cloud-model-stop-using-base-name-instead-of-re.md
@@ -1,11 +1,11 @@
 ---
 # ollama-models-vscode-acrx
 title: Fix cloud model stop using base name instead of resolved tag
-status: todo
+status: completed
 type: bug
 priority: high
 created_at: 2026-03-07T17:17:28Z
-updated_at: 2026-03-07T17:19:38Z
+updated_at: 2026-03-07T17:35:04Z
 ---
 
 When stopping a cloud model, Ollama returns "model '{name}' not found" because the stop command uses the base model name (e.g. `kimi-k2-thinking`) instead of the pulled tag name (`kimi-k2-thinking:cloud`).
@@ -16,10 +16,14 @@ When stopping a cloud model, Ollama returns "model '{name}' not found" because t
 
 ## Todo
 
-- [ ] Add `warmedModelResolvedNames: Map<string, string>` private field to `CloudModelsProvider` in `src/sidebar.ts`
-- [ ] Update `markModelWarm(modelName: string, resolvedName?: string)` signature and body to store the resolved name in the map
-- [ ] Add `getWarmedModelName(baseName: string): string` method that returns the stored resolved name or falls back to `baseName:cloud`
-- [ ] Update `handleStartCloudModel` to call `cloudProvider.markModelWarm(item.label, resolvedModel)` passing both args
-- [ ] Update `handleStopCloudModel` to use `cloudProvider.getWarmedModelName(item.label)` for the stop call
-- [ ] Run `pnpm run compile` to verify TypeScript passes
-- [ ] Run `pnpm run test` to verify unit tests still pass
+- [x] Add `warmedModelResolvedNames: Map<string, string>` private field to `CloudModelsProvider` in `src/sidebar.ts`
+- [x] Update `markModelWarm(modelName: string, resolvedName?: string)` signature and body to store the resolved name in the map
+- [x] Add `getWarmedModelName(baseName: string): string` method that returns the stored resolved name or falls back to `baseName:cloud`
+- [x] Update `handleStartCloudModel` to call `cloudProvider.markModelWarm(item.label, resolvedModel)` passing both args
+- [x] Update `handleStopCloudModel` to use `cloudProvider.getWarmedModelName(item.label)` for the stop call
+- [x] Run `pnpm run compile` to verify TypeScript passes
+- [x] Run `pnpm run test` to verify unit tests still pass
+
+## Summary of Changes
+
+Added `warmedModelResolvedNames` map and `getWarmedModelName()` method to `CloudModelsProvider`. Updated `markModelWarm` to accept and store the resolved name. Updated `handleStartCloudModel` to pass `resolvedModel` and `handleStopCloudModel` to use `getWarmedModelName()`. Updated tests accordingly. Commit: `93bbac2`.

--- a/.beans/ollama-models-vscode-bm0h--add-groupedflat-view-toggle-per-sidebar-pane-with.md
+++ b/.beans/ollama-models-vscode-bm0h--add-groupedflat-view-toggle-per-sidebar-pane-with.md
@@ -1,11 +1,11 @@
 ---
 # ollama-models-vscode-bm0h
 title: Add grouped/flat view toggle per sidebar pane with alphabetical sort
-status: todo
+status: completed
 type: feature
 priority: low
 created_at: 2026-03-07T17:30:43Z
-updated_at: 2026-03-07T17:30:43Z
+updated_at: 2026-03-07T18:36:46Z
 ---
 
 Add a toggle button per sidebar pane (Local Models, Cloud Models, Library) that switches between grouped/parented view and a flat alphabetically-sorted list. When parenting is off, all models are shown as a flat list sorted A–Z with no group headers.
@@ -15,17 +15,21 @@ Add a toggle button per sidebar pane (Local Models, Cloud Models, Library) that 
 - **Parenting on** (default): models grouped by family/tag as they are now
 - **Parenting off**: all models shown as a flat, case-insensitive alphabetically sorted list with no group headers
 - Toggle state is persisted per pane in extension global state so it survives reloads
-- Toggle icon: `$(list-tree)` when grouped, `$(list-flat)` when flat (or similar pair — confirm available icons)
+- Toggle icon: `$(list-tree)` when grouped, `$(list-flat)` when flat
 
 ## Todo
 
-- [ ] Add `grouped: boolean` state field (default `true`) to `LocalModelsProvider`, `CloudModelsProvider`, and `LibraryModelsProvider` in `src/sidebar.ts`
-- [ ] In each provider's `getChildren()`: when `grouped === false`, bypass group structure — collect all leaf model items, sort them case-insensitively by label, return the flat array
-- [ ] Persist `grouped` state using `context.globalState.get/update('ollama.localGrouped', true)` (and cloud/library equivalents) so the preference survives restarts
-- [ ] Register command `ollama-copilot.toggleLocalGrouping`: flip `grouped`, update global state, set context var `ollama.localGrouped`, fire refresh
-- [ ] Register command `ollama-copilot.toggleCloudGrouping`: same for cloud provider
-- [ ] Register command `ollama-copilot.toggleLibraryGrouping`: same for library provider
-- [ ] Add 3 commands to `contributes.commands` in `package.json` with appropriate icons and titles
-- [ ] Add `view/title` menu entries with `when` conditionals toggling between grouped/flat icon states
-- [ ] Run `pnpm run compile` to verify TypeScript passes
-- [ ] Run `pnpm run test` to verify unit tests still pass
+- [x] Add `grouped: boolean` state field (default `true`) to all three providers
+- [x] Flat mode in each provider's `getChildren()`: bypass group structure, return flat sorted list
+- [x] Persist `grouped` state in `globalState`
+- [x] Register `toggleLocalGrouping`, `toggleCloudGrouping`, `toggleLibraryGrouping` commands
+- [x] Add 3 commands to `package.json` with `$(list-tree)` icon
+- [x] Add `view/title` menu entries for all three views
+- [x] Compile passes, 228 tests pass
+
+## Summary of Changes
+
+- Added `grouped = true` field to all three sidebar providers
+- Each provider's `getChildren()` top-level checks `!this.grouped` first: returns flat case-insensitive sorted list bypassing group structure
+- Toggle commands registered: flip `grouped`, persist to `globalState`, set context var, call `refresh()`
+- Commit: `4e1c95085287c8e23d78ed7e87af9b7aaf21beaf`, branch: `fix/bm0h-grouped-flat-toggle`

--- a/.beans/ollama-models-vscode-cfab--surface-alert-and-stop-model-when-model-runner-cra.md
+++ b/.beans/ollama-models-vscode-cfab--surface-alert-and-stop-model-when-model-runner-cra.md
@@ -1,20 +1,28 @@
 ---
 # ollama-models-vscode-cfab
 title: Surface alert and stop model when model runner crashes (SIGSEGV)
-status: todo
+status: completed
 type: feature
 priority: medium
 created_at: 2026-03-07T17:17:53Z
 updated_at: 2026-03-07T17:19:57Z
+branch: fix/cfab-surface-crash-alert
 ---
 
 When the Ollama model runner crashes (SIGSEGV), the chat API throws an error with message "model runner has unexpectedly stopped...". Currently this is caught silently — no UI alert is shown and the model is not unloaded.
 
 ## Todo
 
-- [ ] In `src/provider.ts` catch block of `provideLanguageModelChatResponse()`: detect `error.message.includes('model runner has unexpectedly stopped')`. If detected:
+- [x] In `src/provider.ts` catch block of `provideLanguageModelChatResponse()`: detect `error.message.includes('model runner has unexpectedly stopped')`. If detected:
   - Attempt `perRequestClient.generate({ model: runtimeModelId, prompt: '', keep_alive: 0, stream: false })` to force-unload (ignore failure)
-  - Call `vscode.window.showErrorMessage('The Ollama model runner crashed. Please check the Ollama server logs and restart if needed.', 'Open Logs')` and handle the button action
-- [ ] In `src/extension.ts` catch block of `handleChatRequest()`: same detection + `vscode.window.showErrorMessage(...)` with guidance
-- [ ] Run `pnpm run compile` to verify TypeScript passes
-- [ ] Run `pnpm run test` to verify unit tests still pass
+  - Call `vscode.window.showErrorMessage('The Ollama model runner crashed. Please check the Ollama server logs and restart if needed.', 'Open Logs')`
+- [x] In `src/extension.ts` catch block of `handleChatRequest()`: same detection + `vscode.window.showErrorMessage(...)` with guidance
+- [x] Run `pnpm run compile` to verify TypeScript passes
+- [x] Run `pnpm run test` to verify unit tests still pass
+
+## Summary of Changes
+
+- `src/provider.ts`: crash detection in `provideLanguageModelChatResponse()` catch block — forces model unload and shows error message
+- `src/extension.ts`: same crash detection in the chat participant catch block
+- `src/provider.test.ts`: new `describe('OllamaChatModelProvider crash handling')` with a test verifying `showErrorMessage` is called and `generate` is called with `keep_alive: 0`
+- `src/test/vscode.mock.ts`: added `showErrorMessage: vi.fn()` to the `window` mock

--- a/.beans/ollama-models-vscode-fjgt--fix-non-agentic-llm-response-formatting-extract-xm.md
+++ b/.beans/ollama-models-vscode-fjgt--fix-non-agentic-llm-response-formatting-extract-xm.md
@@ -1,11 +1,12 @@
 ---
 # ollama-models-vscode-fjgt
 title: Fix non-agentic LLM response formatting — extract XML context into system message
-status: todo
+status: completed
 type: bug
 priority: medium
 created_at: 2026-03-07T17:18:02Z
 updated_at: 2026-03-07T17:30:17Z
+branch: fix/fjgt-xml-context-extraction
 ---
 
 VS Code Copilot injects `<environment_info>`, `<workspace_info>`, `<selection>`, and `<file_context>` XML blocks as raw text inside user messages. These are not extracted before sending to Ollama. Small/non-agentic models echo the raw XML back in their responses instead of treating it as context.

--- a/.beans/ollama-models-vscode-h9yi--fix-modelfiles-view-crash-on-refresh-iconpath-type.md
+++ b/.beans/ollama-models-vscode-h9yi--fix-modelfiles-view-crash-on-refresh-iconpath-type.md
@@ -1,11 +1,11 @@
 ---
 # ollama-models-vscode-h9yi
 title: Fix modelfiles view crash on refresh (iconPath TypeError)
-status: todo
+status: completed
 type: bug
 priority: high
 created_at: 2026-03-07T17:17:20Z
-updated_at: 2026-03-07T17:19:46Z
+updated_at: 2026-03-07T17:33:36Z
 ---
 
 After creating a modelfile, the modelfiles view crashes on refresh with `TypeError: Cannot read properties of undefined reading '0'`.
@@ -16,7 +16,11 @@ After creating a modelfile, the modelfiles view crashes on refresh with `TypeErr
 
 ## Todo
 
-- [ ] Add `createThemeIcon(id)` helper function to `src/modelfiles.ts` (same pattern as sidebar.ts)
-- [ ] Replace `this.iconPath = { id: 'file-code' } as unknown as vscode.ThemeIcon` with `this.iconPath = createThemeIcon('file-code')` in `ModelfileItem` constructor (~line 109)
-- [ ] Run `pnpm run compile` to verify TypeScript passes
-- [ ] Run `pnpm run test` to verify unit tests still pass
+- [x] Add `createThemeIcon(id)` helper function to `src/modelfiles.ts` (same pattern as sidebar.ts)
+- [x] Replace `this.iconPath = { id: 'file-code' } as unknown as vscode.ThemeIcon` with `this.iconPath = createThemeIcon('file-code')` in `ModelfileItem` constructor (~line 109)
+- [x] Run `pnpm run compile` to verify TypeScript passes
+- [x] Run `pnpm run test` to verify unit tests still pass
+
+## Summary of Changes
+
+Added a `createThemeIcon(id)` helper to `src/modelfiles.ts` using the same pattern as `sidebar.ts`. Replaced the broken plain-object `iconPath` assignment with a proper ThemeIcon instance. Commit: `2b3d334`.

--- a/.beans/ollama-models-vscode-q1wb--fix-agentic-tool-loop-silently-discarding-final-ro.md
+++ b/.beans/ollama-models-vscode-q1wb--fix-agentic-tool-loop-silently-discarding-final-ro.md
@@ -1,0 +1,30 @@
+---
+# ollama-models-vscode-q1wb
+title: Fix agentic tool loop silently discarding final-round text when MAX_TOOL_ROUNDS exhausted
+status: completed
+type: fix
+priority: normal
+created_at: 2026-03-07T18:38:10Z
+updated_at: 2026-03-07T18:42:45Z
+---
+
+When the VS Code LM tool loop exhausts all MAX_TOOL_ROUNDS iterations (11 rounds, 0–10), the loop exits naturally without hitting the `break` branch that flushes `assistantTextParts`. Any text the model produced in the final round is silently discarded and never rendered via `stream.markdown()`.
+
+## Root Cause
+
+In `handleChatRequest` (`src/extension.ts`), `assistantTextParts` is only flushed inside the `break` branch (`pendingToolCalls.length === 0`). If the loop runs all 11 rounds and each round has pending tool calls, the loop exits by falling off the end — the last round's text is lost.
+
+## Todo
+
+- [x] Write failing test: model always returns tool calls for MAX_TOOL_ROUNDS+1 rounds — verify final-round text is still rendered
+- [x] Declare `lastRoundTextParts` outside the for loop, assign in each iteration, clear when flushed in break branch
+- [x] After the for loop, flush `lastRoundTextParts` unconditionally
+- [x] Compile passes, all tests pass
+
+## Summary of Changes
+
+- Added `lastRoundTextParts` variable outside the `for` loop
+- Each iteration assigns `lastRoundTextParts = assistantTextParts`
+- The `break` path clears `lastRoundTextParts = []` to avoid double-flush
+- After the loop, flush any remaining `lastRoundTextParts` via `stream.markdown()`
+- Commit: `3f30404b40ca2152b670b79016778f1ca973beeb`, branch: `fix/q1wb-tool-loop-flush-final-round-text`

--- a/.beans/ollama-models-vscode-r0ji--add-filter-buttons-to-sidebar-panes-with-clear-all.md
+++ b/.beans/ollama-models-vscode-r0ji--add-filter-buttons-to-sidebar-panes-with-clear-all.md
@@ -1,24 +1,33 @@
 ---
 # ollama-models-vscode-r0ji
 title: Add filter buttons to sidebar panes with clear-all toggle
-status: todo
+status: completed
 type: feature
 priority: low
 created_at: 2026-03-07T17:18:22Z
-updated_at: 2026-03-07T17:19:06Z
+updated_at: 2026-03-07T18:30:46Z
 ---
 
 Add a filter toolbar button to each sidebar pane (Local Models, Cloud Models, Library) that opens a search input. While a filter is active, the button changes to a clear-all icon. Filtering matches against item labels including children.
 
 ## Todo
 
-- [ ] Add `filterText: string` field to `LocalModelsProvider`, `CloudModelsProvider`, and `LibraryModelsProvider` in `src/sidebar.ts`
-- [ ] In each provider's `getChildren()`: apply case-insensitive include filter — if a group has no matching children hide it; if any child matches, include the group with only matching children
-- [ ] Register command `ollama-copilot.filterLocalModels`: call `vscode.window.showInputBox({ prompt: 'Filter local models', value: existing })`. On value: set `filterText`, set context `ollama.localFilterActive = true`, fire refresh. On cancel/empty: clear filter
-- [ ] Register command `ollama-copilot.clearLocalFilter`: clear `filterText`, set `ollama.localFilterActive = false`, fire refresh
-- [ ] Register command `ollama-copilot.filterCloudModels` / `ollama-copilot.clearCloudFilter`: same pattern for cloud provider
-- [ ] Register command `ollama-copilot.filterLibraryModels` / `ollama-copilot.clearLibraryFilter`: same pattern for library provider
-- [ ] Add 6 commands to `contributes.commands` in `package.json` with icons `$(filter)` and `$(clear-all)`
-- [ ] Add `view/title` menu entries with `when` conditionals: show filter button when `!ollama.localFilterActive`, show clear-all when `ollama.localFilterActive` (same for cloud and library)
-- [ ] Run `pnpm run compile` to verify TypeScript passes
-- [ ] Run `pnpm run test` to verify unit tests still pass
+- [x] Add `filterText: string` field to `LocalModelsProvider`, `CloudModelsProvider`, and `LibraryModelsProvider` in `src/sidebar.ts`
+- [x] In each provider's `getChildren()`: apply case-insensitive include filter — if a group has no matching children hide it; if any child matches, include the group with only matching children
+- [x] Register command `ollama-copilot.filterLocalModels`: call `vscode.window.showInputBox({ prompt: 'Filter local models', value: existing })`. On value: set `filterText`, set context `ollama.localFilterActive = true`, fire refresh. On cancel/empty: clear filter
+- [x] Register command `ollama-copilot.clearLocalFilter`: clear `filterText`, set `ollama.localFilterActive = false`, fire refresh
+- [x] Register command `ollama-copilot.filterCloudModels` / `ollama-copilot.clearCloudFilter`: same pattern for cloud provider
+- [x] Register command `ollama-copilot.filterLibraryModels` / `ollama-copilot.clearLibraryFilter`: same pattern for library provider
+- [x] Add 6 commands to `contributes.commands` in `package.json` with icons `$(filter)` and `$(clear-all)`
+- [x] Add `view/title` menu entries with `when` conditionals: show filter button when `!ollama.localFilterActive`, show clear-all when `ollama.localFilterActive` (same for cloud and library)
+- [x] Run `pnpm run compile` to verify TypeScript passes
+- [x] Run `pnpm run test` to verify unit tests still pass (225/225 passed)
+
+## Summary of Changes
+
+- `src/sidebar.ts`: added `filterText = ''` to all three providers; filter top-level family groups in `getChildren()` by family name or child label (case-insensitive); registered 6 filter/clear commands delegating to `showInputBox` and `setContext`
+- `package.json`: added 6 commands with `$(filter)` and `$(clear-all)` icons; added `view/title` menu entries with `when` conditionals toggling between filter and clear-filter icons
+- `src/sidebar.test.ts`: added tests verifying all 6 commands are registered, and `LocalModelsProvider` correctly filters/unfilters family groups when `filterText` is set
+
+Commit: ade843361178c69d9e1a95d88b63a9cf4f0f65d6
+Branch: fix/r0ji-filter-buttons

--- a/.beans/ollama-models-vscode-wp85--add-collapseexpand-all-buttons-to-sidebar-views.md
+++ b/.beans/ollama-models-vscode-wp85--add-collapseexpand-all-buttons-to-sidebar-views.md
@@ -1,22 +1,32 @@
 ---
 # ollama-models-vscode-wp85
 title: Add collapse/expand all buttons to sidebar views
-status: todo
+status: completed
 type: feature
 priority: low
 created_at: 2026-03-07T17:18:13Z
-updated_at: 2026-03-07T17:30:27Z
+updated_at: 2026-03-07T18:25:38Z
 ---
 
 Add a collapse-all toolbar button to the Local Models, Cloud Models, and Library sidebar views. No expand-all button — VS Code's native tree expand-all is sufficient, and triggering it programmatically is not reliably supported.
 
 ## Todo
 
-- [ ] In `src/sidebar.ts` `registerSidebar()`: switch `registerTreeDataProvider` to `createTreeView` for local, cloud, and library views to obtain `TreeView` references
-- [ ] Register command `ollama-copilot.collapseLocalModels`: call `localTreeView.collapseAll()`
-- [ ] Register command `ollama-copilot.collapseCloudModels`: call `cloudTreeView.collapseAll()`
-- [ ] Register command `ollama-copilot.collapseLibrary`: call `libraryTreeView.collapseAll()`
-- [ ] Add 3 commands to `contributes.commands` in `package.json` with icon `$(collapse-all)` and appropriate titles
-- [ ] Add `view/title` menu entries in `package.json` for each view pointing to the collapse command
-- [ ] Run `pnpm run compile` to verify TypeScript passes
-- [ ] Run `pnpm run test` to verify unit tests still pass
+- [x] In `src/sidebar.ts` `registerSidebar()`: switch `registerTreeDataProvider` to `createTreeView` for local, cloud, and library views to obtain `TreeView` references
+- [x] Register command `ollama-copilot.collapseLocalModels`: delegates to built-in `workbench.actions.treeView.ollama-local-models.collapseAll` via `commands.executeCommand`
+- [x] Register command `ollama-copilot.collapseCloudModels`: delegates to built-in `workbench.actions.treeView.ollama-cloud-models.collapseAll`
+- [x] Register command `ollama-copilot.collapseLibrary`: delegates to built-in `workbench.actions.treeView.ollama-library-models.collapseAll`
+- [x] Add 3 commands to `contributes.commands` in `package.json` with icon `$(collapse-all)` and appropriate titles
+- [x] Add `view/title` menu entries in `package.json` for each view pointing to the collapse command
+- [x] Run `pnpm run compile` to verify TypeScript passes
+- [x] Run `pnpm run test` to verify unit tests still pass (221/221 passed)
+
+## Summary of Changes
+
+- `src/sidebar.ts`: switched 3 `registerTreeDataProvider` calls to `createTreeView`; registered 3 collapse commands using `commands.executeCommand('workbench.actions.treeView.{id}.collapseAll')` (note: `TreeView<T>.collapseAll()` is not exposed in `@types/vscode`, so the built-in command is used instead)
+- `src/test/vscode.mock.ts`: added `createTreeView: vi.fn(() => ({ dispose: vi.fn() }))` to window mock
+- `package.json`: added 3 commands (`collapseLocalModels`, `collapseCloudModels`, `collapseLibrary`) and 3 `view/title` menu entries with `navigation@0` group
+- `src/sidebar.test.ts`: added test verifying all three commands are registered and call the correct built-in `executeCommand` target
+
+Commit: c8297300ad4d73aac0894bf9ef7fab49ec42ad3b
+Branch: fix/wp85-collapse-all-buttons

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+  "recommendations": [
+    "selfagency.beans-vscode",
+    "oxc.oxc-vscode",
+    "vitest.explorer",
+    "github.copilot-chat",
+    "davidanson.vscode-markdownlint",
+    "github.vscode-codeql",
+    "task.vscode-task",
+    "typescriptteam.native-preview"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -301,11 +301,6 @@
           "group": "inline@1"
         },
         {
-          "command": "ollama-copilot.deleteModel",
-          "when": "view == ollama-local-models && viewItem == local-running",
-          "group": "inline@3"
-        },
-        {
           "command": "ollama-copilot.pullModelFromLibrary",
           "when": "view == ollama-library-models && viewItem == library-model-variant",
           "group": "inline@1"
@@ -344,11 +339,6 @@
           "command": "ollama-copilot.stopCloudModel",
           "when": "view == ollama-cloud-models && viewItem == cloud-running",
           "group": "inline@2"
-        },
-        {
-          "command": "ollama-copilot.deleteModel",
-          "when": "view == ollama-cloud-models && viewItem == cloud-running",
-          "group": "inline@3"
         },
         {
           "command": "ollama-copilot.editModelfile",

--- a/package.json
+++ b/package.json
@@ -127,6 +127,78 @@
         "category": "Ollama"
       },
       {
+        "command": "ollama-copilot.filterLocalModels",
+        "title": "Filter Local Models",
+        "icon": "$(filter)",
+        "category": "Ollama"
+      },
+      {
+        "command": "ollama-copilot.clearLocalFilter",
+        "title": "Clear Local Models Filter",
+        "icon": "$(clear-all)",
+        "category": "Ollama"
+      },
+      {
+        "command": "ollama-copilot.filterCloudModels",
+        "title": "Filter Cloud Models",
+        "icon": "$(filter)",
+        "category": "Ollama"
+      },
+      {
+        "command": "ollama-copilot.clearCloudFilter",
+        "title": "Clear Cloud Models Filter",
+        "icon": "$(clear-all)",
+        "category": "Ollama"
+      },
+      {
+        "command": "ollama-copilot.filterLibraryModels",
+        "title": "Filter Library Models",
+        "icon": "$(filter)",
+        "category": "Ollama"
+      },
+      {
+        "command": "ollama-copilot.clearLibraryFilter",
+        "title": "Clear Library Models Filter",
+        "icon": "$(clear-all)",
+        "category": "Ollama"
+      },
+      {
+        "command": "ollama-copilot.toggleLocalGrouping",
+        "title": "Toggle Local Models Grouping",
+        "icon": "$(list-tree)",
+        "category": "Ollama"
+      },
+      {
+        "command": "ollama-copilot.toggleCloudGrouping",
+        "title": "Toggle Cloud Models Grouping",
+        "icon": "$(list-tree)",
+        "category": "Ollama"
+      },
+      {
+        "command": "ollama-copilot.toggleLibraryGrouping",
+        "title": "Toggle Library Models Grouping",
+        "icon": "$(list-tree)",
+        "category": "Ollama"
+      },
+      {
+        "command": "ollama-copilot.collapseLocalModels",
+        "title": "Collapse All Local Models",
+        "icon": "$(collapse-all)",
+        "category": "Ollama"
+      },
+      {
+        "command": "ollama-copilot.collapseCloudModels",
+        "title": "Collapse All Cloud Models",
+        "icon": "$(collapse-all)",
+        "category": "Ollama"
+      },
+      {
+        "command": "ollama-copilot.collapseLibrary",
+        "title": "Collapse All Library Models",
+        "icon": "$(collapse-all)",
+        "category": "Ollama"
+      },
+      {
         "command": "ollama-copilot.refreshSidebar",
         "title": "Refresh Local Ollama Models",
         "icon": "$(refresh)",
@@ -244,6 +316,26 @@
     "menus": {
       "view/title": [
         {
+          "command": "ollama-copilot.collapseLocalModels",
+          "when": "view == ollama-local-models",
+          "group": "navigation@0"
+        },
+        {
+          "command": "ollama-copilot.filterLocalModels",
+          "when": "view == ollama-local-models && !ollama.localFilterActive",
+          "group": "navigation@1"
+        },
+        {
+          "command": "ollama-copilot.clearLocalFilter",
+          "when": "view == ollama-local-models && ollama.localFilterActive",
+          "group": "navigation@1"
+        },
+        {
+          "command": "ollama-copilot.toggleLocalGrouping",
+          "when": "view == ollama-local-models",
+          "group": "navigation@2"
+        },
+        {
           "command": "ollama-copilot.refreshLocalModels",
           "when": "view == ollama-local-models",
           "group": "navigation"
@@ -254,9 +346,49 @@
           "group": "navigation@9"
         },
         {
+          "command": "ollama-copilot.collapseLibrary",
+          "when": "view == ollama-library-models",
+          "group": "navigation@0"
+        },
+        {
+          "command": "ollama-copilot.filterLibraryModels",
+          "when": "view == ollama-library-models && !ollama.libraryFilterActive",
+          "group": "navigation@1"
+        },
+        {
+          "command": "ollama-copilot.clearLibraryFilter",
+          "when": "view == ollama-library-models && ollama.libraryFilterActive",
+          "group": "navigation@1"
+        },
+        {
+          "command": "ollama-copilot.toggleLibraryGrouping",
+          "when": "view == ollama-library-models",
+          "group": "navigation@2"
+        },
+        {
           "command": "ollama-copilot.refreshLibrary",
           "when": "view == ollama-library-models",
           "group": "navigation"
+        },
+        {
+          "command": "ollama-copilot.collapseCloudModels",
+          "when": "view == ollama-cloud-models",
+          "group": "navigation@0"
+        },
+        {
+          "command": "ollama-copilot.filterCloudModels",
+          "when": "view == ollama-cloud-models && !ollama.cloudFilterActive",
+          "group": "navigation@1"
+        },
+        {
+          "command": "ollama-copilot.clearCloudFilter",
+          "when": "view == ollama-cloud-models && ollama.cloudFilterActive",
+          "group": "navigation@1"
+        },
+        {
+          "command": "ollama-copilot.toggleCloudGrouping",
+          "when": "view == ollama-cloud-models",
+          "group": "navigation@2"
         },
         {
           "command": "ollama-copilot.refreshCloudModels",

--- a/src/client.ts
+++ b/src/client.ts
@@ -23,6 +23,28 @@ export async function getOllamaClient(context: ExtensionContext): Promise<Ollama
 }
 
 /**
+ * Get an Ollama client configured with the cloud API key as the Bearer token.
+ * Required for proxying requests to Ollama's cloud backend through the local server.
+ */
+export async function getCloudOllamaClient(context: ExtensionContext): Promise<Ollama> {
+  const config = workspace.getConfiguration('ollama');
+  const host = config.get<string>('host') || 'http://localhost:11434';
+  const cloudApiKey = await context.secrets.get('ollama-cloud-api-key');
+
+  const clientConfig: { host: string; headers?: Record<string, string> } = {
+    host,
+  };
+
+  if (cloudApiKey) {
+    clientConfig.headers = {
+      Authorization: `Bearer ${cloudApiKey}`,
+    };
+  }
+
+  return new Ollama(clientConfig);
+}
+
+/**
  * Model capabilities detected from Ollama model metadata
  */
 export interface ModelCapabilities {

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1472,14 +1472,22 @@ describe('handleChatRequest model selection', () => {
       constructor(public value: string) {}
     };
     const LMToolCallPart = class {
-      constructor(public callId: string, public name: string, public input: Record<string, unknown>) {}
+      constructor(
+        public callId: string,
+        public name: string,
+        public input: Record<string, unknown>,
+      ) {}
     };
     const LMToolResultPart = class {
-      constructor(public callId: string, public content: unknown) {}
+      constructor(
+        public callId: string,
+        public content: unknown,
+      ) {}
     };
 
     // Round 1: stream yields a tool call; Round 2: stream yields the final text
-    const mockSendRequest = vi.fn()
+    const mockSendRequest = vi
+      .fn()
       .mockResolvedValueOnce({
         stream: (async function* () {
           yield new LMToolCallPart('call-1', 'search', { query: 'vitest' });
@@ -1492,10 +1500,12 @@ describe('handleChatRequest model selection', () => {
       });
 
     const mockInvokeTool = vi.fn().mockResolvedValue({ content: [new LMTextPart('tool-result')] });
-    const mockSelectChatModels = vi.fn().mockResolvedValue([{
-      vendor: 'selfagency-ollama',
-      sendRequest: mockSendRequest,
-    }]);
+    const mockSelectChatModels = vi.fn().mockResolvedValue([
+      {
+        vendor: 'selfagency-ollama',
+        sendRequest: mockSendRequest,
+      },
+    ]);
 
     vi.doMock('vscode', () => ({
       LanguageModelTextPart: LMTextPart,
@@ -1547,13 +1557,21 @@ describe('handleChatRequest model selection', () => {
       constructor(public value: string) {}
     };
     const LMToolCallPart = class {
-      constructor(public callId: string, public name: string, public input: Record<string, unknown>) {}
+      constructor(
+        public callId: string,
+        public name: string,
+        public input: Record<string, unknown>,
+      ) {}
     };
     const LMToolResultPart = class {
-      constructor(public callId: string, public content: unknown) {}
+      constructor(
+        public callId: string,
+        public content: unknown,
+      ) {}
     };
 
-    const mockSendRequest = vi.fn()
+    const mockSendRequest = vi
+      .fn()
       .mockResolvedValueOnce({
         stream: (async function* () {
           yield new LMToolCallPart('call-err', 'broken_tool', {});
@@ -1566,10 +1584,12 @@ describe('handleChatRequest model selection', () => {
       });
 
     const mockInvokeTool = vi.fn().mockRejectedValue(new Error('tool crashed'));
-    const mockSelectChatModels = vi.fn().mockResolvedValue([{
-      vendor: 'selfagency-ollama',
-      sendRequest: mockSendRequest,
-    }]);
+    const mockSelectChatModels = vi.fn().mockResolvedValue([
+      {
+        vendor: 'selfagency-ollama',
+        sendRequest: mockSendRequest,
+      },
+    ]);
 
     vi.doMock('vscode', () => ({
       LanguageModelTextPart: LMTextPart,

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1266,6 +1266,80 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
     const allCalls = mockMarkdown.mock.calls.map((c: any[]) => c[0] as string);
     expect(allCalls.some((v: string) => v.includes('get_weather'))).toBe(true);
   });
+
+  it('shows error dialog and attempts model unload when model runner crashes', async () => {
+    vi.doMock('./client.js', () => ({ getOllamaClient: vi.fn(), testConnection: vi.fn() }));
+    vi.doMock('./diagnostics.js', () => ({
+      createDiagnosticsLogger: () => ({
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+        exception: vi.fn(),
+      }),
+      getConfiguredLogLevel: vi.fn(() => 'info'),
+    }));
+    vi.doMock('./provider.js', () => ({
+      OllamaChatModelProvider: class {
+        setAuthToken = vi.fn();
+      },
+      isThinkingModelId: () => false,
+    }));
+    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
+    vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
+
+    const showErrorMessage = vi.fn().mockResolvedValue(undefined);
+    vi.doMock('vscode', () => ({
+      LanguageModelTextPart: class {
+        constructor(public value: string) {}
+      },
+      LanguageModelChatMessageRole: { User: 1, Assistant: 2 },
+      ChatRequestTurn: class {},
+      ChatResponseTurn: class {},
+      ChatResponseMarkdownPart: class {},
+      LanguageModelChatMessage: {
+        User: (content: string) => ({ role: 1, content }),
+        Assistant: (content: string) => ({ role: 2, content }),
+      },
+      lm: { selectChatModels: vi.fn().mockResolvedValue([]) },
+      workspace: { getConfiguration: vi.fn().mockReturnValue({ get: vi.fn() }) },
+      Uri: {
+        file: vi.fn((path: string) => ({ fsPath: path })),
+        joinPath: vi.fn((_base: any, p: string) => ({ fsPath: p })),
+      },
+      chat: { createChatParticipant: vi.fn(() => ({ iconPath: undefined, dispose: vi.fn() })) },
+      commands: { registerCommand: vi.fn(() => ({ dispose: vi.fn() })), executeCommand: vi.fn() },
+      window: { showErrorMessage },
+    }));
+
+    const ext = await import('./extension.js');
+
+    const mockMarkdown = vi.fn();
+    const stream = { markdown: mockMarkdown };
+    const token = { isCancellationRequested: false };
+
+    const mockChatFn = vi
+      .fn()
+      .mockRejectedValue(new Error('model runner has unexpectedly stopped, please check ollama server logs'));
+    const mockGenerateFn = vi.fn().mockResolvedValue({});
+    const mockClient = {
+      chat: mockChatFn,
+      generate: mockGenerateFn,
+    };
+
+    const request = {
+      prompt: 'hello',
+      model: { vendor: 'selfagency-ollama', id: 'llama3.2:latest' },
+    };
+
+    await ext.handleChatRequest(request as any, { history: [] } as any, stream as any, token as any, mockClient as any);
+
+    expect(showErrorMessage).toHaveBeenCalledWith(expect.stringContaining('model runner crashed'), 'Open Logs');
+    // Best-effort unload via generate with keep_alive=0.
+    expect(mockGenerateFn).toHaveBeenCalledWith(expect.objectContaining({ model: 'llama3.2:latest', keep_alive: 0 }));
+    // Error text streamed back to the participant response.
+    expect(mockMarkdown).toHaveBeenCalledWith(expect.stringContaining('model runner has unexpectedly stopped'));
+  });
 });
 
 describe('handleConnectionTestFailure', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -292,13 +292,81 @@ export async function handleChatRequest(
 
     try {
       // Convert VS Code messages to the plain Ollama format expected by the client.
-      const ollamaMessages: (Message & { tool_call_id?: string })[] = messages.map(msg => ({
-        role: (msg.role === vscode.LanguageModelChatMessageRole.User ? 'user' : 'assistant') as 'user' | 'assistant',
-        content: (Array.isArray(msg.content) ? msg.content : [])
+      const XML_CONTEXT_TAG_RE = /<(environment_info|workspace_info|selection|file_context)[^>]*>[\s\S]*?<\/\1>/gi;
+      const systemContextParts: string[] = [];
+
+      const ollamaMessages: (Message & { tool_call_id?: string })[] = messages.map(msg => {
+        const isUser = msg.role === vscode.LanguageModelChatMessageRole.User;
+        let content = (Array.isArray(msg.content) ? msg.content : [])
           .filter((p): p is vscode.LanguageModelTextPart => p instanceof vscode.LanguageModelTextPart)
           .map(p => p.value)
-          .join(''),
-      }));
+          .join('');
+        if (isUser) {
+          let remainingText = content;
+          let hadLeadingContext = false;
+
+          if (remainingText.trimStart().startsWith('<')) {
+            remainingText = remainingText.trimStart();
+            // Iteratively consume XML_CONTEXT_TAG_RE matches only when they appear at the very start
+            // of the remaining text. As soon as a match is not at index 0, we stop extracting.
+            XML_CONTEXT_TAG_RE.lastIndex = 0;
+            // eslint-disable-next-line no-constant-condition
+            while (true) {
+              const match = XML_CONTEXT_TAG_RE.exec(remainingText);
+              if (!match || match.index !== 0) {
+                break;
+              }
+              const matchedText = match[0];
+              systemContextParts.push(matchedText.trim());
+              remainingText = remainingText.slice(matchedText.length).trimStart();
+              hadLeadingContext = true;
+              // Reset lastIndex because we've sliced the string.
+              XML_CONTEXT_TAG_RE.lastIndex = 0;
+            }
+          }
+
+          content = hadLeadingContext ? remainingText : content.trim();
+        }
+        return {
+          role: (isUser ? 'user' : 'assistant') as 'user' | 'assistant',
+          content,
+        };
+      });
+
+      // Deduplicate context blocks by tag type, keeping only the most recent occurrence
+      const latestByTag = new Map<string, string>();
+      for (let i = systemContextParts.length - 1; i >= 0; i--) {
+        const part = systemContextParts[i];
+        XML_CONTEXT_TAG_RE.lastIndex = 0;
+        let match: RegExpExecArray | null;
+        // Use a loop in case a single part contains multiple context blocks
+        // (we still only keep the latest block per tag type).
+        while ((match = XML_CONTEXT_TAG_RE.exec(part)) !== null) {
+          const tagName = match[1];
+          if (!latestByTag.has(tagName)) {
+            latestByTag.set(tagName, match[0]);
+          }
+        }
+      }
+
+      const tagOrder: Array<'environment_info' | 'workspace_info' | 'selection' | 'file_context'> = [
+        'environment_info',
+        'workspace_info',
+        'selection',
+        'file_context',
+      ];
+
+      const dedupedContextParts: string[] = [];
+      for (const tag of tagOrder) {
+        const block = latestByTag.get(tag);
+        if (block) {
+          dedupedContextParts.push(block);
+        }
+      }
+
+      if (dedupedContextParts.length > 0) {
+        ollamaMessages.unshift({ role: 'system', content: dedupedContextParts.join('\n\n') });
+      }
 
       // Tool invocation loop — only when VS Code tools and an invocation token are available.
       const vscodeLmTools = vscode.lm.tools ?? [];
@@ -439,6 +507,26 @@ export async function handleChatRequest(
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       outputChannel?.exception('[Ollama] Chat participant request failed', error);
+      const isCrashError = error instanceof Error && error.message.includes('model runner has unexpectedly stopped');
+      if (isCrashError) {
+        // Best-effort unload to keep behaviour consistent with the provider path.
+        void client.generate({ model: modelId, prompt: '', keep_alive: 0, stream: false }).catch(() => {});
+        const selection = await vscode.window.showErrorMessage(
+          'The Ollama model runner crashed. Please check the Ollama server logs and restart if needed.',
+          'Open Logs',
+        );
+        if (selection === 'Open Logs') {
+          const logsPath = join(homedir(), '.ollama', 'logs', 'server.log');
+          try {
+            const document = await vscode.workspace.openTextDocument(vscode.Uri.file(logsPath));
+            await vscode.window.showTextDocument(document, { preview: false });
+          } catch {
+            void vscode.window.showWarningMessage(
+              `Could not open Ollama logs at ${logsPath}. Please check that the Ollama server is installed and logging is enabled.`,
+            );
+          }
+        }
+      }
       stream.markdown(`Error: ${message}`);
     }
     return;

--- a/src/modelfiles.ts
+++ b/src/modelfiles.ts
@@ -80,11 +80,16 @@ export async function ensureModelfilesFolder(folderPath: string): Promise<void> 
 // Tree item
 // ---------------------------------------------------------------------------
 
+function createThemeIcon(id: string): vscode.ThemeIcon {
+  const ThemeIconCtor = vscode.ThemeIcon as unknown as { new (iconId: string): vscode.ThemeIcon };
+  return new ThemeIconCtor(id);
+}
+
 export class ModelfileItem extends vscode.TreeItem {
   constructor(public readonly uri: vscode.Uri) {
     super(basename(uri.fsPath), vscode.TreeItemCollapsibleState.None);
     this.contextValue = 'modelfile';
-    this.iconPath = { id: 'file-code' } as unknown as vscode.ThemeIcon;
+    this.iconPath = createThemeIcon('file-code');
     this.tooltip = uri.fsPath;
     this.command = { command: 'vscode.open', title: 'Open Modelfile', arguments: [uri] };
   }

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -5,6 +5,7 @@ import {
   LanguageModelTextPart,
   LanguageModelToolCallPart,
   LanguageModelToolResultPart,
+  window,
 } from 'vscode';
 import { getOllamaClient } from './client.js';
 import { formatModelName, isThinkingModelId, OllamaChatModelProvider } from './provider.js';
@@ -12,6 +13,7 @@ import { formatModelName, isThinkingModelId, OllamaChatModelProvider } from './p
 vi.mock('./client.js', () => ({
   getContextLengthOverride: vi.fn(() => 0),
   getOllamaClient: vi.fn(),
+  getCloudOllamaClient: vi.fn(),
 }));
 
 // Mock vscode
@@ -42,6 +44,7 @@ vi.doMock('vscode', () => ({
   window: {
     showQuickPick: vi.fn(),
     showInputBox: vi.fn(),
+    showErrorMessage: vi.fn(),
   },
 }));
 
@@ -957,6 +960,60 @@ describe('OllamaChatModelProvider chat response', () => {
   });
 });
 
+describe('OllamaChatModelProvider crash handling', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows error message when model runner crashes', async () => {
+    const generate = vi.fn().mockResolvedValue({});
+    const chat = vi
+      .fn()
+      .mockRejectedValue(new Error('model runner has unexpectedly stopped, please check ollama server logs'));
+
+    vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, generate, abort: vi.fn() } as any);
+
+    const provider = new OllamaChatModelProvider(
+      { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
+      { list: vi.fn(), show: vi.fn() } as any,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
+    );
+
+    const progress = { report: vi.fn() };
+    const token = { isCancellationRequested: false };
+    const model = {
+      id: 'ollama:test-model',
+      name: 'Test',
+      family: '🦙 Ollama',
+      version: '1.0.0',
+      maxInputTokens: 100,
+      maxOutputTokens: 100,
+      capabilities: { imageInput: false, toolCalling: false },
+    };
+    const message = {
+      role: LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new LanguageModelTextPart('hello')],
+    };
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [message as any],
+      { tools: [], toolMode: 'auto' } as any,
+      progress as any,
+      token as any,
+    );
+
+    expect(vi.mocked(window.showErrorMessage)).toHaveBeenCalledWith(
+      expect.stringContaining('model runner crashed'),
+      'Open Logs',
+    );
+    expect(generate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'test-model', keep_alive: 0 }),
+    );
+  });
+});
+
 describe('isThinkingModelId', () => {
   it('returns true for qwen3 models', () => {
     expect(isThinkingModelId('qwen3:8b')).toBe(true);
@@ -989,5 +1046,221 @@ describe('isThinkingModelId', () => {
     expect(isThinkingModelId('mistral:7b')).toBe(false);
     expect(isThinkingModelId('gemma3:latest')).toBe(false);
     expect(isThinkingModelId('codellama:latest')).toBe(false);
+  });
+});
+
+describe('XML context extraction in message conversion', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('extracts XML context blocks from user messages into a system message', async () => {
+    const chat = vi.fn().mockImplementation(async function* () {
+      yield { message: { content: 'response' } };
+    });
+
+    vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as any);
+
+    const provider = new OllamaChatModelProvider(
+      { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
+      { list: vi.fn(), show: vi.fn() } as any,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
+    );
+
+    const progress = { report: vi.fn() };
+    const token = { isCancellationRequested: false };
+    const model = {
+      id: 'test-model',
+      name: 'Test',
+      family: '🦙 Ollama',
+      version: '1.0.0',
+      maxInputTokens: 100,
+      maxOutputTokens: 100,
+      capabilities: { imageInput: false, toolCalling: false },
+    };
+
+    const userText = '<environment_info>\nOS: macOS\n</environment_info>\nWhat is 2+2?';
+    const message = {
+      role: LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new LanguageModelTextPart(userText)],
+    };
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [message as any],
+      { tools: [], toolMode: 'auto' } as any,
+      progress as any,
+      token as any,
+    );
+
+    const messages = chat.mock.calls[0]?.[0]?.messages;
+
+    expect(messages?.[0]?.role).toBe('system');
+    expect(messages?.[0]?.content).toContain('OS: macOS');
+
+    expect(messages?.[1]?.role).toBe('user');
+    expect(messages?.[1]?.content).not.toContain('<environment_info>');
+    expect(messages?.[1]?.content).toContain('What is 2+2?');
+  });
+
+  it('does not promote non-leading XML context tags to system message', async () => {
+    const chat = vi.fn().mockImplementation(async function* () {
+      yield { message: { content: 'response' } };
+    });
+
+    vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as any);
+
+    const provider = new OllamaChatModelProvider(
+      { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
+      { list: vi.fn(), show: vi.fn() } as any,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
+    );
+
+    // Context tag appears mid-message, not at the start — must NOT be promoted to system
+    const userText = 'What is 2+2? <environment_info>\nOS: macOS\n</environment_info>';
+    const message = {
+      role: LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new LanguageModelTextPart(userText)],
+    };
+
+    await provider.provideLanguageModelChatResponse(
+      {
+        id: 'test-model',
+        name: 'Test',
+        family: '🦙 Ollama',
+        version: '1.0.0',
+        maxInputTokens: 100,
+        maxOutputTokens: 100,
+        capabilities: { imageInput: false, toolCalling: false },
+      },
+      [message as any],
+      { tools: [], toolMode: 'auto' } as any,
+      { report: vi.fn() } as any,
+      { isCancellationRequested: false } as any,
+    );
+
+    const messages = chat.mock.calls[0]?.[0]?.messages;
+
+    // No system message should be injected
+    expect(messages?.[0]?.role).toBe('user');
+    // The user message content should be unchanged (including the tag)
+    expect(messages?.[0]?.content).toContain('<environment_info>');
+  });
+
+  it('deduplicates context blocks across turns, keeping only the most recent per tag', async () => {
+    const chat = vi.fn().mockImplementation(async function* () {
+      yield { message: { content: 'response' } };
+    });
+
+    vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as any);
+
+    const provider = new OllamaChatModelProvider(
+      { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
+      { list: vi.fn(), show: vi.fn() } as any,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
+    );
+
+    // Simulate a two-turn conversation where both turns inject an environment_info block
+    const turn1 = {
+      role: LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new LanguageModelTextPart('<environment_info>\nenv v1\n</environment_info>\nFirst question')],
+    };
+    const turn1Reply = {
+      role: LanguageModelChatMessageRole.Assistant,
+      name: undefined,
+      content: [new LanguageModelTextPart('First answer')],
+    };
+    const turn2 = {
+      role: LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new LanguageModelTextPart('<environment_info>\nenv v2\n</environment_info>\nSecond question')],
+    };
+
+    await provider.provideLanguageModelChatResponse(
+      {
+        id: 'test-model',
+        name: 'Test',
+        family: '🦙 Ollama',
+        version: '1.0.0',
+        maxInputTokens: 100,
+        maxOutputTokens: 100,
+        capabilities: { imageInput: false, toolCalling: false },
+      },
+      [turn1 as any, turn1Reply as any, turn2 as any],
+      { tools: [], toolMode: 'auto' } as any,
+      { report: vi.fn() } as any,
+      { isCancellationRequested: false } as any,
+    );
+
+    const messages = chat.mock.calls[0]?.[0]?.messages;
+
+    // There should be exactly one system message
+    const systemMessages = messages?.filter((m: { role: string }) => m.role === 'system');
+    expect(systemMessages).toHaveLength(1);
+
+    // The system message should contain only the most recent environment_info (v2)
+    expect(systemMessages?.[0]?.content).toContain('env v2');
+    expect(systemMessages?.[0]?.content).not.toContain('env v1');
+  });
+
+  it('strips all four known context tag types', async () => {
+    const chat = vi.fn().mockImplementation(async function* () {
+      yield { message: { content: 'ok' } };
+    });
+
+    vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as any);
+
+    const provider = new OllamaChatModelProvider(
+      { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
+      { list: vi.fn(), show: vi.fn() } as any,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
+    );
+
+    const userText = [
+      '<environment_info>\nenv data\n</environment_info>',
+      '<workspace_info>\nws data\n</workspace_info>',
+      '<selection>\nsel data\n</selection>',
+      '<file_context>\nfile data\n</file_context>',
+      'User question',
+    ].join('\n');
+
+    const message = {
+      role: LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new LanguageModelTextPart(userText)],
+    };
+
+    await provider.provideLanguageModelChatResponse(
+      {
+        id: 'test-model',
+        name: 'Test',
+        family: '🦙 Ollama',
+        version: '1.0.0',
+        maxInputTokens: 100,
+        maxOutputTokens: 100,
+        capabilities: { imageInput: false, toolCalling: false },
+      },
+      [message as any],
+      { tools: [], toolMode: 'auto' } as any,
+      { report: vi.fn() } as any,
+      { isCancellationRequested: false } as any,
+    );
+
+    const messages = chat.mock.calls[0]?.[0]?.messages;
+
+    expect(messages?.[0]?.role).toBe('system');
+    expect(messages?.[0]?.content).toContain('env data');
+    expect(messages?.[0]?.content).toContain('ws data');
+    expect(messages?.[0]?.content).toContain('sel data');
+    expect(messages?.[0]?.content).toContain('file data');
+
+    expect(messages?.[1]?.content).not.toContain('<environment_info>');
+    expect(messages?.[1]?.content).not.toContain('<workspace_info>');
+    expect(messages?.[1]?.content).not.toContain('<selection>');
+    expect(messages?.[1]?.content).not.toContain('<file_context>');
+    expect(messages?.[1]?.content).toContain('User question');
   });
 });

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -16,7 +16,7 @@ import {
   ProvideLanguageModelChatResponseOptions,
   window,
 } from 'vscode';
-import { getContextLengthOverride, getOllamaClient } from './client';
+import { getCloudOllamaClient, getContextLengthOverride, getOllamaClient } from './client';
 import type { DiagnosticsLogger } from './diagnostics.js';
 
 const MODEL_LIST_REFRESH_MIN_INTERVAL_MS = 5_000;
@@ -441,7 +441,11 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     // Do NOT call abort() on cancellation — abruptly closing the HTTP connection
     // mid-generation destabilises Ollama. The isCancellationRequested check in the
     // loop below provides safe cooperative cancellation instead.
-    const perRequestClient = await getOllamaClient(this.context);
+    const cloudModelTag = runtimeModelId.split(':')[1] ?? '';
+    const isCloudModel = cloudModelTag === 'cloud' || cloudModelTag.endsWith('-cloud');
+    const perRequestClient = isCloudModel
+      ? await getCloudOllamaClient(this.context)
+      : await getOllamaClient(this.context);
 
     let shouldThink =
       (this.thinkingModels.has(runtimeModelId) || isThinkingModelId(runtimeModelId)) &&

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,3 +1,5 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { Ollama, type ChatResponse, type ShowResponse } from 'ollama';
 import {
   CancellationToken,
@@ -14,7 +16,9 @@ import {
   LanguageModelToolResultPart,
   Progress,
   ProvideLanguageModelChatResponseOptions,
+  Uri,
   window,
+  workspace,
 } from 'vscode';
 import { getCloudOllamaClient, getContextLengthOverride, getOllamaClient } from './client';
 import type { DiagnosticsLogger } from './diagnostics.js';
@@ -532,6 +536,28 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       }
     } catch (error) {
       this.outputChannel.exception('[Ollama] Chat response failed', error);
+
+      const isCrashError = error instanceof Error && error.message.includes('model runner has unexpectedly stopped');
+      if (isCrashError) {
+        // Best-effort unload so Ollama housekeeps the dead runner — ignore any failure
+        perRequestClient.generate({ model: runtimeModelId, prompt: '', keep_alive: 0, stream: false }).catch(() => {});
+        const selection = await window.showErrorMessage(
+          'The Ollama model runner crashed. Please check the Ollama server logs and restart if needed.',
+          'Open Logs',
+        );
+        if (selection === 'Open Logs') {
+          const logsPath = join(homedir(), '.ollama', 'logs', 'server.log');
+          try {
+            const document = await workspace.openTextDocument(Uri.file(logsPath));
+            await window.showTextDocument(document, { preview: false });
+          } catch {
+            void window.showWarningMessage(
+              `Could not open Ollama logs at ${logsPath}. Please check that the Ollama server is installed and logging is enabled.`,
+            );
+          }
+        }
+      }
+
       const isConnectionError = error instanceof TypeError && error.message.includes('fetch failed');
       const message = isConnectionError
         ? 'Cannot reach Ollama server — check that it is running and accessible.'
@@ -549,6 +575,8 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     messages: readonly LanguageModelChatRequestMessage[],
   ): Parameters<typeof this.client.chat>[0]['messages'] {
     const ollamaMessages: Parameters<typeof this.client.chat>[0]['messages'] = [];
+    const XML_CONTEXT_TAG_RE = /<(environment_info|workspace_info|selection|file_context)[^>]*>[\s\S]*?<\/\1>/gi;
+    const systemContextParts: string[] = [];
 
     for (const msg of messages) {
       const role = msg.role === LanguageModelChatMessageRole.User ? 'user' : 'assistant';
@@ -591,6 +619,34 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       }
 
       // Ollama requires content to be a string (images are separate field)
+      if (role === 'user') {
+        // Strip only *leading* VS Code-injected XML context blocks; accumulate for system message.
+        // This avoids treating arbitrary user-provided tags as privileged system context.
+        let remainingText = textContent;
+        let hadLeadingContext = false;
+
+        if (remainingText.trimStart().startsWith('<')) {
+          remainingText = remainingText.trimStart();
+          // Iteratively consume XML_CONTEXT_TAG_RE matches only when they appear at the very start
+          // of the remaining text. As soon as a match is not at index 0, we stop extracting.
+          XML_CONTEXT_TAG_RE.lastIndex = 0;
+          // eslint-disable-next-line no-constant-condition
+          while (true) {
+            const match = XML_CONTEXT_TAG_RE.exec(remainingText);
+            if (!match || match.index !== 0) {
+              break;
+            }
+            const matchedText = match[0];
+            systemContextParts.push(matchedText.trim());
+            remainingText = remainingText.slice(matchedText.length).trimStart();
+            hadLeadingContext = true;
+            // Reset lastIndex because we've sliced the string.
+            XML_CONTEXT_TAG_RE.lastIndex = 0;
+          }
+        }
+
+        textContent = hadLeadingContext ? remainingText : textContent.trim();
+      }
       if (textContent || images.length > 0) {
         ollamaMsg.content = textContent;
       }
@@ -601,6 +657,44 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       if (ollamaMsg.content || ollamaMsg.tool_calls) {
         ollamaMessages.push(ollamaMsg as never);
       }
+    }
+
+    // Deduplicate context blocks by tag type, keeping only the most recent occurrence
+    const latestByTag = new Map<string, string>();
+    for (let i = systemContextParts.length - 1; i >= 0; i--) {
+      const part = systemContextParts[i];
+      XML_CONTEXT_TAG_RE.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      // Use a loop in case a single part contains multiple context blocks
+      // (we still only keep the latest block per tag type).
+      while ((match = XML_CONTEXT_TAG_RE.exec(part)) !== null) {
+        const tagName = match[1];
+        if (!latestByTag.has(tagName)) {
+          latestByTag.set(tagName, match[0]);
+        }
+      }
+    }
+
+    const tagOrder: Array<'environment_info' | 'workspace_info' | 'selection' | 'file_context'> = [
+      'environment_info',
+      'workspace_info',
+      'selection',
+      'file_context',
+    ];
+
+    const dedupedContextParts: string[] = [];
+    for (const tag of tagOrder) {
+      const block = latestByTag.get(tag);
+      if (block) {
+        dedupedContextParts.push(block);
+      }
+    }
+
+    if (dedupedContextParts.length > 0) {
+      ollamaMessages.unshift({
+        role: 'system',
+        content: dedupedContextParts.join('\n\n'),
+      } as never);
     }
 
     return ollamaMessages;

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -207,7 +207,7 @@ describe('LocalModelsProvider', () => {
 
   it('invokes onLocalModelsChanged callback when local models are refreshed', async () => {
     const onLocalModelsChanged = vi.fn();
-    const callbackProvider = new LocalModelsProvider(mockClient, undefined, onLocalModelsChanged);
+    const callbackProvider = new LocalModelsProvider(mockClient, undefined, undefined, onLocalModelsChanged);
 
     callbackProvider.refresh();
 

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -403,6 +403,80 @@ describe('LocalModelsProvider', () => {
     localProvider.dispose();
   });
 
+  it('stopModel uses cloud-authenticated client for cloud-tagged model', async () => {
+    vi.resetModules();
+
+    const cloudGenerate = vi.fn().mockResolvedValue(undefined);
+    const regularGenerate = vi.fn().mockResolvedValue(undefined);
+
+    vi.doMock('./client.js', () => ({
+      getCloudOllamaClient: vi.fn().mockResolvedValue({
+        generate: cloudGenerate,
+        ps: vi.fn().mockResolvedValue({ models: [] }),
+      }),
+      fetchModelCapabilities: vi.fn().mockResolvedValue({
+        toolCalling: false,
+        imageInput: false,
+        maxInputTokens: 2048,
+        maxOutputTokens: 2048,
+      }),
+    }));
+
+    vi.doMock('vscode', () => ({
+      TreeItem: class {
+        label: string;
+        constructor(label: string) {
+          this.label = label;
+        }
+      },
+      ThemeIcon: class {},
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      EventEmitter: class {
+        event = {};
+        fire = vi.fn();
+      },
+      window: {
+        showInformationMessage: vi.fn(),
+        showErrorMessage: vi.fn(),
+        withProgress: vi.fn(async (_options: unknown, callback: (progress: any, token: any) => Promise<void>) => {
+          return callback({ report: vi.fn() }, { isCancellationRequested: false, onCancellationRequested: vi.fn() });
+        }),
+      },
+      workspace: {
+        getConfiguration: vi.fn(() => ({
+          get: vi.fn((key: string) => {
+            if (key === 'localModelRefreshInterval') return 0;
+            return undefined;
+          }),
+        })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+      ProgressLocation: { Notification: 15 },
+    }));
+
+    const { LocalModelsProvider } = await import('./sidebar.js');
+
+    const mockRegularClient = {
+      list: vi.fn().mockResolvedValue({ models: [] }),
+      ps: vi.fn().mockResolvedValue({ models: [] }),
+      generate: regularGenerate,
+    } as any;
+
+    const mockContext = {
+      secrets: {
+        get: vi.fn().mockResolvedValue('test-cloud-api-key'),
+      },
+    } as any;
+
+    const localProvider = new LocalModelsProvider(mockRegularClient, mockContext);
+    await localProvider.stopModel('llama2:cloud');
+
+    expect(cloudGenerate).toHaveBeenCalledWith({ model: 'llama2:cloud', prompt: '', stream: false, keep_alive: 0 });
+    expect(regularGenerate).not.toHaveBeenCalled();
+
+    localProvider.dispose();
+  });
+
   it('cloud provider handles empty API key', async () => {
     const cloudProvider = new CloudModelsProvider(
       {

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -1951,7 +1951,6 @@ describe('LocalModelsProvider filter', () => {
 
   it('clears filter when filterText is set to empty string', async () => {
     const provider = new LocalModelsProvider(mockClient);
-    provider.filterText = 'llama';
     provider.filterText = '';
     const children = await provider.getChildren();
     const labels = children.map((c: any) => c.label);

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -1064,7 +1064,7 @@ describe('Extracted command handlers', () => {
 
     const item = new ModelTreeItem('test-model', 'cloud-running');
 
-    await handleStopCloudModel(item, mockProvider);
+    await handleStopCloudModel(item, mockProvider, mockCloudProvider);
 
     expect(mockCloudProvider.getWarmedModelName).toHaveBeenCalledWith('test-model');
     expect(mockProvider.stopModel).toHaveBeenCalledWith('test-model:cloud');

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -1504,7 +1504,7 @@ describe('Extracted command handlers', () => {
 
     expect(mockCloudProvider.resolveRunnableCloudModelName).toHaveBeenCalledWith('cogito-2.1');
     expect(mockProvider.startModel).toHaveBeenCalledWith('cogito-2.1:671b-cloud');
-    expect(mockCloudProvider.markModelWarm).toHaveBeenCalledWith('cogito-2.1');
+    expect(mockCloudProvider.markModelWarm).toHaveBeenCalledWith('cogito-2.1', 'cogito-2.1:671b-cloud');
     expect(mockCloudProvider.refresh).toHaveBeenCalled();
   });
 
@@ -1516,6 +1516,7 @@ describe('Extracted command handlers', () => {
     } as any;
 
     const mockCloudProvider = {
+      getWarmedModelName: vi.fn().mockReturnValue('test-model:cloud'),
       markModelStopped: vi.fn(),
       refresh: vi.fn(),
     } as any;
@@ -1524,7 +1525,8 @@ describe('Extracted command handlers', () => {
 
     await handleStopCloudModel(item, mockProvider, mockCloudProvider);
 
-    expect(mockProvider.stopModel).toHaveBeenCalledWith('test-model');
+    expect(mockCloudProvider.getWarmedModelName).toHaveBeenCalledWith('test-model');
+    expect(mockProvider.stopModel).toHaveBeenCalledWith('test-model:cloud');
     expect(mockCloudProvider.markModelStopped).toHaveBeenCalledWith('test-model');
     expect(mockCloudProvider.refresh).toHaveBeenCalled();
   });

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -841,6 +841,45 @@ describe('LocalModelsProvider', () => {
 });
 
 describe('Extracted command handlers', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doMock('vscode', () => ({
+      TreeItem: class {
+        label: string;
+        description?: string;
+        contextValue?: string;
+        collapsibleState?: number;
+        tooltip?: string;
+        command?: unknown;
+        constructor(label: string) {
+          this.label = label;
+        }
+      },
+      ThemeIcon: class {},
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      EventEmitter: class {
+        event = {};
+        fire = vi.fn();
+      },
+      window: {
+        showWarningMessage: vi.fn().mockResolvedValue('Delete'),
+        showInformationMessage: vi.fn(),
+        showErrorMessage: vi.fn(),
+      },
+      env: {
+        openExternal: vi.fn(),
+      },
+      Uri: {
+        parse: vi.fn((value: string) => ({ value })),
+      },
+      workspace: {
+        getConfiguration: vi.fn(() => ({ get: vi.fn() })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+      ProgressLocation: { Notification: 15 },
+    }));
+  });
+
   it('handleRefreshLocalModels refreshes provider and shows message', async () => {
     const { handleRefreshLocalModels } = await import('./sidebar.js');
 
@@ -884,11 +923,33 @@ describe('Extracted command handlers', () => {
       deleteModel: vi.fn(),
     } as any;
 
-    const item = new ModelTreeItem('test-model', 'local-running', 1000);
+    const item = new ModelTreeItem('test-model', 'local-stopped', 1000);
 
     await handleDeleteModel(item, mockProvider);
 
     expect(mockProvider.deleteModel).toHaveBeenCalledWith('test-model');
+  });
+
+  it('handleDeleteModel blocks deletion of a running local model', async () => {
+    const { handleDeleteModel, ModelTreeItem } = await import('./sidebar.js');
+
+    const mockProvider = { deleteModel: vi.fn() } as any;
+    const item = new ModelTreeItem('test-model', 'local-running', 1000);
+
+    await handleDeleteModel(item, mockProvider);
+
+    expect(mockProvider.deleteModel).not.toHaveBeenCalled();
+  });
+
+  it('handleDeleteModel blocks deletion of a running cloud model', async () => {
+    const { handleDeleteModel, ModelTreeItem } = await import('./sidebar.js');
+
+    const mockProvider = { deleteModel: vi.fn() } as any;
+    const item = new ModelTreeItem('cloud-model', 'cloud-running', 1000);
+
+    await handleDeleteModel(item, mockProvider);
+
+    expect(mockProvider.deleteModel).not.toHaveBeenCalled();
   });
 
   it('handleDeleteModel does not delete when cancelled', async () => {

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -1756,4 +1756,331 @@ describe('Extracted command handlers', () => {
 
     expect(mockPull).not.toHaveBeenCalled();
   });
+
+  it('registerSidebar registers collapse commands for all three views', async () => {
+    vi.resetModules();
+
+    vi.doMock('vscode', () => ({
+      TreeItem: class {
+        label: string;
+        constructor(label: string) { this.label = label; }
+      },
+      ThemeIcon: class {},
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      EventEmitter: class { event = {}; fire = vi.fn(); },
+      window: {
+        createTreeView: vi.fn(() => ({ dispose: vi.fn() })),
+        withProgress: vi.fn(),
+        showInputBox: vi.fn(),
+        showErrorMessage: vi.fn(),
+        showInformationMessage: vi.fn(),
+        showWarningMessage: vi.fn(),
+      },
+      commands: {
+        registerCommand: vi.fn(() => ({ dispose: vi.fn() })),
+        executeCommand: vi.fn(),
+      },
+      env: { openExternal: vi.fn() },
+      Uri: { parse: vi.fn((v: string) => ({ value: v })) },
+      ProgressLocation: { Notification: 15 },
+      workspace: {
+        getConfiguration: vi.fn(() => ({ get: vi.fn(), update: vi.fn() })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+    }));
+
+    const vscode = await import('vscode');
+    const { registerSidebar } = await import('./sidebar.js');
+
+    const mockContext = {
+      subscriptions: { push: vi.fn() },
+      secrets: { get: vi.fn().mockResolvedValue(undefined), store: vi.fn(), delete: vi.fn() },
+      globalState: { get: vi.fn(), update: vi.fn() },
+    } as any;
+
+    const mockClient = {
+      list: vi.fn().mockResolvedValue({ models: [] }),
+      generate: vi.fn(),
+    } as any;
+
+    registerSidebar(mockContext, mockClient);
+
+    const registerCommandMock = vi.mocked(vscode.commands.registerCommand);
+    const registeredIds = registerCommandMock.mock.calls.map(([id]) => id);
+
+    expect(registeredIds).toContain('ollama-copilot.collapseLocalModels');
+    expect(registeredIds).toContain('ollama-copilot.collapseCloudModels');
+    expect(registeredIds).toContain('ollama-copilot.collapseLibrary');
+
+    // Invoke each collapse command handler and verify it delegates to the built-in VS Code command
+    const executeCommandMock = vi.mocked(vscode.commands.executeCommand);
+    const callHandler = (id: string) => {
+      const entry = registerCommandMock.mock.calls.find(([cmd]) => cmd === id);
+      return (entry?.[1] as (() => void) | undefined)?.();
+    };
+
+    callHandler('ollama-copilot.collapseLocalModels');
+    expect(executeCommandMock).toHaveBeenCalledWith('workbench.actions.treeView.ollama-local-models.collapseAll');
+
+    callHandler('ollama-copilot.collapseCloudModels');
+    expect(executeCommandMock).toHaveBeenCalledWith('workbench.actions.treeView.ollama-cloud-models.collapseAll');
+
+    callHandler('ollama-copilot.collapseLibrary');
+    expect(executeCommandMock).toHaveBeenCalledWith('workbench.actions.treeView.ollama-library-models.collapseAll');
+  });
+
+  it('registerSidebar registers filter and clear-filter commands for all three views', async () => {
+    vi.resetModules();
+    vi.doMock('vscode', () => ({
+      TreeItem: class { label: string; constructor(label: string) { this.label = label; } },
+      ThemeIcon: class {},
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      EventEmitter: class { event = {}; fire = vi.fn(); },
+      window: {
+        createTreeView: vi.fn(() => ({ dispose: vi.fn() })),
+        withProgress: vi.fn(),
+        showInputBox: vi.fn(),
+        showErrorMessage: vi.fn(),
+        showInformationMessage: vi.fn(),
+        showWarningMessage: vi.fn(),
+      },
+      commands: {
+        registerCommand: vi.fn(() => ({ dispose: vi.fn() })),
+        executeCommand: vi.fn(),
+      },
+      env: { openExternal: vi.fn() },
+      Uri: { parse: vi.fn((v: string) => ({ value: v })) },
+      ProgressLocation: { Notification: 15 },
+      workspace: {
+        getConfiguration: vi.fn(() => ({ get: vi.fn(), update: vi.fn() })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+    }));
+
+    const vscode = await import('vscode');
+    const { registerSidebar } = await import('./sidebar.js');
+
+    const mockContext = {
+      subscriptions: { push: vi.fn() },
+      secrets: { get: vi.fn().mockResolvedValue(undefined), store: vi.fn(), delete: vi.fn() },
+      globalState: { get: vi.fn(), update: vi.fn() },
+    } as any;
+    const mockClient = { list: vi.fn().mockResolvedValue({ models: [] }), generate: vi.fn() } as any;
+
+    registerSidebar(mockContext, mockClient);
+
+    const registeredIds = vi.mocked(vscode.commands.registerCommand).mock.calls.map(([id]) => id);
+    expect(registeredIds).toContain('ollama-copilot.filterLocalModels');
+    expect(registeredIds).toContain('ollama-copilot.clearLocalFilter');
+    expect(registeredIds).toContain('ollama-copilot.filterCloudModels');
+    expect(registeredIds).toContain('ollama-copilot.clearCloudFilter');
+    expect(registeredIds).toContain('ollama-copilot.filterLibraryModels');
+    expect(registeredIds).toContain('ollama-copilot.clearLibraryFilter');
+  });
+});
+
+describe('LocalModelsProvider filter', () => {
+  let LocalModelsProvider: any;
+  let mockClient: any;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.doMock('vscode', () => ({
+      TreeItem: class {
+        label: string;
+        description?: string;
+        contextValue?: string;
+        collapsibleState?: number;
+        iconPath?: unknown;
+        tooltip?: string;
+        constructor(label: string) { this.label = label; }
+      },
+      ThemeIcon: class { constructor(public id: string) {} },
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      EventEmitter: class { event = {}; fire = vi.fn(); },
+      window: {
+        registerTreeDataProvider: vi.fn(() => ({ dispose: vi.fn() })),
+        showInputBox: vi.fn(),
+        showErrorMessage: vi.fn(),
+        showInformationMessage: vi.fn(),
+        showWarningMessage: vi.fn(),
+      },
+      commands: { registerCommand: vi.fn(() => ({ dispose: vi.fn() })), executeCommand: vi.fn() },
+      env: { openExternal: vi.fn() },
+      Uri: { parse: vi.fn((v: string) => ({ value: v })) },
+      ProgressLocation: { Notification: 15 },
+      workspace: {
+        getConfiguration: vi.fn(() => ({ get: vi.fn(() => 0), update: vi.fn() })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+    }));
+
+    const mod = await import('./sidebar.js');
+    LocalModelsProvider = mod.LocalModelsProvider;
+
+    mockClient = {
+      list: vi.fn().mockResolvedValue({
+        models: [
+          { name: 'llama2:latest', size: 1000, digest: 'a1', details: {} },
+          { name: 'llama3:latest', size: 1000, digest: 'a2', details: {} },
+          { name: 'mistral:latest', size: 1000, digest: 'b1', details: {} },
+        ],
+      }),
+      ps: vi.fn().mockResolvedValue({ models: [] }),
+    };
+  });
+
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it('returns all family groups when filterText is empty', async () => {
+    const provider = new LocalModelsProvider(mockClient);
+    const children = await provider.getChildren();
+    const labels = children.map((c: any) => c.label);
+    expect(labels).toContain('llama');
+    expect(labels).toContain('mistral');
+  });
+
+  it('filters family groups to only matching families when filterText is set', async () => {
+    const provider = new LocalModelsProvider(mockClient);
+    provider.filterText = 'llama';
+    const children = await provider.getChildren();
+    const labels = children.map((c: any) => c.label);
+    expect(labels).toContain('llama');
+    expect(labels).not.toContain('mistral');
+  });
+
+  it('clears filter when filterText is set to empty string', async () => {
+    const provider = new LocalModelsProvider(mockClient);
+    provider.filterText = 'llama';
+    provider.filterText = '';
+    const children = await provider.getChildren();
+    const labels = children.map((c: any) => c.label);
+    expect(labels).toContain('llama');
+    expect(labels).toContain('mistral');
+  });
+});
+
+describe('LocalModelsProvider grouped/flat toggle', () => {
+  let LocalModelsProvider: any;
+  let mockClient: any;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.doMock('vscode', () => ({
+      TreeItem: class {
+        label: string;
+        description?: string;
+        contextValue?: string;
+        collapsibleState?: number;
+        iconPath?: unknown;
+        tooltip?: string;
+        constructor(label: string) { this.label = label; }
+      },
+      ThemeIcon: class { constructor(public id: string) {} },
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      EventEmitter: class { event = {}; fire = vi.fn(); },
+      window: {
+        registerTreeDataProvider: vi.fn(() => ({ dispose: vi.fn() })),
+        showInputBox: vi.fn(),
+        showErrorMessage: vi.fn(),
+        showInformationMessage: vi.fn(),
+        showWarningMessage: vi.fn(),
+      },
+      commands: { registerCommand: vi.fn(() => ({ dispose: vi.fn() })), executeCommand: vi.fn() },
+      env: { openExternal: vi.fn() },
+      Uri: { parse: vi.fn((v: string) => ({ value: v })) },
+      ProgressLocation: { Notification: 15 },
+      workspace: {
+        getConfiguration: vi.fn(() => ({ get: vi.fn(() => 0), update: vi.fn() })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+    }));
+
+    const mod = await import('./sidebar.js');
+    LocalModelsProvider = mod.LocalModelsProvider;
+
+    mockClient = {
+      list: vi.fn().mockResolvedValue({
+        models: [
+          { name: 'llama2:latest', size: 1000, digest: 'a1', details: {} },
+          { name: 'mistral:latest', size: 1000, digest: 'b1', details: {} },
+          { name: 'gemma:latest', size: 1000, digest: 'c1', details: {} },
+        ],
+      }),
+      ps: vi.fn().mockResolvedValue({ models: [] }),
+    };
+  });
+
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it('defaults to grouped mode returning family groups', async () => {
+    const provider = new LocalModelsProvider(mockClient);
+    const children = await provider.getChildren();
+    // grouped: should return family-group items, not raw model items
+    const hasGroup = children.some((c: any) => c.label === 'llama' || c.label === 'mistral');
+    expect(hasGroup).toBe(true);
+  });
+
+  it('returns flat alphabetical list when grouped is false', async () => {
+    const provider = new LocalModelsProvider(mockClient);
+    provider.grouped = false;
+    const children = await provider.getChildren();
+    const labels = children.map((c: any) => c.label);
+    // All model labels present (not family groups)
+    expect(labels).toContain('llama2:latest');
+    expect(labels).toContain('mistral:latest');
+    expect(labels).toContain('gemma:latest');
+    // Alphabetically sorted
+    expect(labels[0]).toBe('gemma:latest');
+    expect(labels[1]).toBe('llama2:latest');
+    expect(labels[2]).toBe('mistral:latest');
+  });
+});
+
+describe('registerSidebar grouped/flat toggle commands', () => {
+  it('registers toggleLocalGrouping, toggleCloudGrouping, toggleLibraryGrouping commands', async () => {
+    vi.resetModules();
+    vi.doMock('vscode', () => ({
+      TreeItem: class { label: string; constructor(label: string) { this.label = label; } },
+      ThemeIcon: class {},
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      EventEmitter: class { event = {}; fire = vi.fn(); },
+      window: {
+        createTreeView: vi.fn(() => ({ dispose: vi.fn() })),
+        withProgress: vi.fn(),
+        showInputBox: vi.fn(),
+        showErrorMessage: vi.fn(),
+        showInformationMessage: vi.fn(),
+        showWarningMessage: vi.fn(),
+      },
+      commands: {
+        registerCommand: vi.fn(() => ({ dispose: vi.fn() })),
+        executeCommand: vi.fn(),
+      },
+      env: { openExternal: vi.fn() },
+      Uri: { parse: vi.fn((v: string) => ({ value: v })) },
+      ProgressLocation: { Notification: 15 },
+      workspace: {
+        getConfiguration: vi.fn(() => ({ get: vi.fn(() => 0), update: vi.fn() })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+    }));
+
+    const vscode = await import('vscode');
+    const { registerSidebar } = await import('./sidebar.js');
+
+    const mockContext = {
+      subscriptions: { push: vi.fn() },
+      secrets: { get: vi.fn().mockResolvedValue(undefined), store: vi.fn(), delete: vi.fn() },
+      globalState: { get: vi.fn().mockReturnValue(undefined), update: vi.fn() },
+    } as any;
+    const mockClient = { list: vi.fn().mockResolvedValue({ models: [] }), generate: vi.fn() } as any;
+
+    registerSidebar(mockContext, mockClient);
+
+    const registeredIds = vi.mocked(vscode.commands.registerCommand).mock.calls.map(([id]) => id);
+    expect(registeredIds).toContain('ollama-copilot.toggleLocalGrouping');
+    expect(registeredIds).toContain('ollama-copilot.toggleCloudGrouping');
+    expect(registeredIds).toContain('ollama-copilot.toggleLibraryGrouping');
+  });
 });

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -15,7 +15,7 @@ import {
   window,
   workspace,
 } from 'vscode';
-import { fetchModelCapabilities, type ModelCapabilities } from './client.js';
+import { fetchModelCapabilities, getCloudOllamaClient, type ModelCapabilities } from './client.js';
 import type { DiagnosticsLogger } from './diagnostics.js';
 
 /**
@@ -264,6 +264,7 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
 
   constructor(
     private client: Ollama,
+    private context: ExtensionContext,
     private logChannel?: DiagnosticsLogger,
     private onLocalModelsChanged?: () => void,
   ) {
@@ -501,12 +502,13 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
       this.logChannel?.debug(`[Ollama] Starting local model: ${modelName}`);
       await window.withProgress({ location: 15, title: `Starting ${modelName}...` }, async () => {
         const isCloudModel = this.isCloudTaggedModel(modelName);
-        if (this.isCloudTaggedModel(modelName)) {
+        const activeClient = (isCloudModel && this.context) ? await getCloudOllamaClient(this.context) : this.client;
+        if (isCloudModel) {
           // Cloud models should be pulled first (same behavior as `ollama run`).
           this.logChannel?.info(`[Ollama] Pulling cloud model before start: ${modelName}`);
-          await this.client.pull({ model: modelName, stream: false });
+          await activeClient.pull({ model: modelName, stream: false });
         }
-        await this.client.generate({ model: modelName, prompt: '', stream: false, keep_alive: '10m' });
+        await activeClient.generate({ model: modelName, prompt: '', stream: false, keep_alive: '10m' });
 
         let running = false;
         try {
@@ -1488,7 +1490,7 @@ export function registerSidebar(
   onLocalModelsChanged?: () => void,
 ): void {
   let libraryProvider: LibraryModelsProvider | undefined;
-  const localProvider = new LocalModelsProvider(client, logChannel, () => {
+  const localProvider = new LocalModelsProvider(client, context, logChannel, () => {
     onLocalModelsChanged?.();
     libraryProvider?.refreshVariantStates();
   });

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -502,7 +502,7 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
       this.logChannel?.debug(`[Ollama] Starting local model: ${modelName}`);
       await window.withProgress({ location: 15, title: `Starting ${modelName}...` }, async () => {
         const isCloudModel = this.isCloudTaggedModel(modelName);
-        const activeClient = (isCloudModel && this.context) ? await getCloudOllamaClient(this.context) : this.client;
+        const activeClient = isCloudModel && this.context ? await getCloudOllamaClient(this.context) : this.client;
         if (isCloudModel) {
           // Cloud models should be pulled first (same behavior as `ollama run`).
           this.logChannel?.info(`[Ollama] Pulling cloud model before start: ${modelName}`);
@@ -558,7 +558,9 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
       await window.withProgress(
         { location: ProgressLocation.Notification, title: `Stopping ${modelName}…`, cancellable: false },
         async () => {
-          await this.client.generate({ model: modelName, prompt: '', stream: false, keep_alive: 0 });
+          const isCloudModel = this.isCloudTaggedModel(modelName);
+          const activeClient = isCloudModel && this.context ? await getCloudOllamaClient(this.context) : this.client;
+          await activeClient.generate({ model: modelName, prompt: '', stream: false, keep_alive: 0 });
           // Poll until the model disappears from the running process list (max 30 s)
           for (let i = 0; i < 30; i++) {
             await new Promise<void>(resolve => setTimeout(resolve, 1000));

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -264,7 +264,7 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
 
   constructor(
     private client: Ollama,
-    private context: ExtensionContext,
+    private context?: ExtensionContext,
     private logChannel?: DiagnosticsLogger,
     private onLocalModelsChanged?: () => void,
   ) {

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -937,6 +937,7 @@ export class CloudModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
   private refreshIntervals: NodeJS.Timeout[] = [];
   private cachedNames = new Set<string>();
   private warmedModelNames = new Set<string>();
+  private warmedModelResolvedNames = new Map<string, string>();
 
   constructor(
     private context: ExtensionContext,
@@ -997,13 +998,24 @@ export class CloudModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
     return new Set(this.cachedNames);
   }
 
-  markModelWarm(modelName: string): void {
-    this.warmedModelNames.add(modelName.split(':')[0]);
+  markModelWarm(modelName: string, resolvedName?: string): void {
+    const baseName = modelName.split(':')[0];
+    this.warmedModelNames.add(baseName);
+    if (resolvedName) {
+      this.warmedModelResolvedNames.set(baseName, resolvedName);
+    }
     this.treeChangeEmitter.fire(null);
   }
 
+  getWarmedModelName(baseName: string): string {
+    const base = baseName.split(':')[0];
+    return this.warmedModelResolvedNames.get(base) ?? `${base}:cloud`;
+  }
+
   markModelStopped(modelName: string): void {
-    this.warmedModelNames.delete(modelName.split(':')[0]);
+    const baseName = modelName.split(':')[0];
+    this.warmedModelNames.delete(baseName);
+    this.warmedModelResolvedNames.delete(baseName);
     this.treeChangeEmitter.fire(null);
   }
 
@@ -1445,7 +1457,7 @@ export async function handleStartCloudModel(
         ? item.label
         : `${item.label}:cloud`;
     await localProvider.startModel(resolvedModel);
-    cloudProvider?.markModelWarm(item.label);
+    cloudProvider?.markModelWarm(item.label, resolvedModel);
     cloudProvider?.refresh();
   }
 }
@@ -1459,7 +1471,8 @@ export async function handleStopCloudModel(
   cloudProvider?: CloudModelsProvider,
 ): Promise<void> {
   if (item && item.type === 'cloud-running') {
-    await localProvider.stopModel(item.label);
+    const resolvedName = cloudProvider?.getWarmedModelName(item.label) ?? item.label;
+    await localProvider.stopModel(resolvedName);
     cloudProvider?.markModelStopped(item.label);
     cloudProvider?.refresh();
   }

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1308,11 +1308,13 @@ export function handleOpenCloudModel(item: ModelTreeItem): void {
  * Command handler: delete model
  */
 export async function handleDeleteModel(item: ModelTreeItem, localProvider: LocalModelsProvider): Promise<void> {
+  if (item && (item.type === 'local-running' || item.type === 'cloud-running')) {
+    void window.showErrorMessage('Stop the model before deleting it.');
+    return;
+  }
   if (
     item &&
-    (item.type === 'local-running' ||
-      item.type === 'local-stopped' ||
-      item.type === 'cloud-running' ||
+    (item.type === 'local-stopped' ||
       item.type === 'cloud-stopped')
   ) {
     const answer = await window.showWarningMessage(`Delete model "${item.label}"?`, 'Delete', 'Cancel');

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -257,6 +257,9 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
   private treeChangeEmitter = new EventEmitter<ModelTreeItem | null>();
   readonly onDidChangeTreeData: Event<ModelTreeItem | null> = this.treeChangeEmitter.event;
 
+  filterText = '';
+  grouped = true;
+
   private refreshIntervals: NodeJS.Timeout[] = [];
   private localModelCapabilitiesCache = new Map<string, ModelCapabilities>();
   private localModelCapabilitiesInFlight = new Set<string>();
@@ -286,12 +289,30 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
         return models;
       }
 
+      // Flat mode: return all models sorted A-Z
+      if (!this.grouped) {
+        const filterLower = this.filterText.toLowerCase();
+        return models
+          .filter(m => m.type !== 'status' && (!filterLower || m.label.toLowerCase().includes(filterLower)))
+          .sort((a, b) => a.label.toLowerCase().localeCompare(b.label.toLowerCase()));
+      }
+
       // Group models by family
       const groups = groupModelsByFamily(models);
 
+      // Apply filter: keep only families where the family name or any child matches
+      const filterLower = this.filterText.toLowerCase();
+      const filteredEntries = Array.from(groups.entries())
+        .filter(([familyName, familyModels]) =>
+          !filterLower ||
+          familyName.toLowerCase().includes(filterLower) ||
+          familyModels.some(m => m.label.toLowerCase().includes(filterLower)),
+        )
+        .sort((a, b) => a[0].localeCompare(b[0]));
+
       // Always create explicit family parent groups.
       const result: ModelTreeItem[] = [];
-      for (const [familyName, familyModels] of Array.from(groups.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
+      for (const [familyName, familyModels] of filteredEntries) {
         const groupItem = new ModelTreeItem(familyName, 'model-group');
         groupItem.tooltip = `${familyName} family (${familyModels.length} models)`;
         result.push(groupItem);
@@ -594,6 +615,9 @@ export class LibraryModelsProvider implements TreeDataProvider<ModelTreeItem>, D
   private treeChangeEmitter = new EventEmitter<ModelTreeItem | null>();
   readonly onDidChangeTreeData: Event<ModelTreeItem | null> = this.treeChangeEmitter.event;
 
+  filterText = '';
+  grouped = true;
+
   private cache: string[] = [];
   private cacheTimeMs = 0;
   private cacheGeneration = 0;
@@ -686,12 +710,30 @@ export class LibraryModelsProvider implements TreeDataProvider<ModelTreeItem>, D
       return models;
     }
 
+    // Flat mode: return all library models sorted A-Z
+    if (!this.grouped) {
+      const filterLower = this.filterText.toLowerCase();
+      return models
+        .filter(m => m.type !== 'status' && (!filterLower || m.label.toLowerCase().includes(filterLower)))
+        .sort((a, b) => a.label.toLowerCase().localeCompare(b.label.toLowerCase()));
+    }
+
     // Group models by family
     const groups = groupModelsByFamily(models);
 
+    // Apply filter: keep only families where the family name or any child matches
+    const filterLower = this.filterText.toLowerCase();
+    const filteredEntries = Array.from(groups.entries())
+      .filter(([familyName, familyModels]) =>
+        !filterLower ||
+        familyName.toLowerCase().includes(filterLower) ||
+        familyModels.some(m => m.label.toLowerCase().includes(filterLower)),
+      )
+      .sort((a, b) => a[0].localeCompare(b[0]));
+
     // Always create explicit family parent groups.
     const result: ModelTreeItem[] = [];
-    for (const [familyName, familyModels] of Array.from(groups.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
+    for (const [familyName, familyModels] of filteredEntries) {
       const groupItem = new ModelTreeItem(familyName, 'model-group');
       groupItem.tooltip = `${familyName} family (${familyModels.length} models)`;
       result.push(groupItem);
@@ -935,6 +977,9 @@ export class CloudModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
   private treeChangeEmitter = new EventEmitter<ModelTreeItem | null>();
   readonly onDidChangeTreeData: Event<ModelTreeItem | null> = this.treeChangeEmitter.event;
 
+  filterText = '';
+  grouped = true;
+
   private cache: ModelTreeItem[] = [];
   private cacheTimeMs = 0;
   private loadPromise: Promise<ModelTreeItem[]> | null = null;
@@ -968,12 +1013,30 @@ export class CloudModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
         return [makeStatusItem('No cloud models found')];
       }
 
+      // Flat mode: return all cloud models sorted A-Z
+      if (!this.grouped) {
+        const filterLower = this.filterText.toLowerCase();
+        return models
+          .filter(m => m.type !== 'status' && (!filterLower || m.label.toLowerCase().includes(filterLower)))
+          .sort((a, b) => a.label.toLowerCase().localeCompare(b.label.toLowerCase()));
+      }
+
       // Group models by family
       const groups = groupModelsByFamily(models);
 
+      // Apply filter: keep only families where the family name or any child matches
+      const filterLower = this.filterText.toLowerCase();
+      const filteredEntries = Array.from(groups.entries())
+        .filter(([familyName, familyModels]) =>
+          !filterLower ||
+          familyName.toLowerCase().includes(filterLower) ||
+          familyModels.some(m => m.label.toLowerCase().includes(filterLower)),
+        )
+        .sort((a, b) => a[0].localeCompare(b[0]));
+
       // Always create explicit family parent groups.
       const result: ModelTreeItem[] = [];
-      for (const [familyName, familyModels] of Array.from(groups.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
+      for (const [familyName, familyModels] of filteredEntries) {
         const groupItem = new ModelTreeItem(familyName, 'model-group');
         groupItem.tooltip = `${familyName} family (${familyModels.length} models)`;
         result.push(groupItem);
@@ -1504,10 +1567,95 @@ export function registerSidebar(
 
   logChannel?.info('[Ollama] Sidebar providers initialized');
 
+  const localTreeView = window.createTreeView('ollama-local-models', { treeDataProvider: localProvider });
+  const libraryTreeView = window.createTreeView('ollama-library-models', { treeDataProvider: libraryProvider });
+  const cloudTreeView = window.createTreeView('ollama-cloud-models', { treeDataProvider: cloudProvider });
+
   context.subscriptions.push(
-    window.registerTreeDataProvider('ollama-local-models', localProvider),
-    window.registerTreeDataProvider('ollama-library-models', libraryProvider),
-    window.registerTreeDataProvider('ollama-cloud-models', cloudProvider),
+    localTreeView,
+    libraryTreeView,
+    cloudTreeView,
+    commands.registerCommand('ollama-copilot.collapseLocalModels', () =>
+      commands.executeCommand('workbench.actions.treeView.ollama-local-models.collapseAll'),
+    ),
+    commands.registerCommand('ollama-copilot.collapseCloudModels', () =>
+      commands.executeCommand('workbench.actions.treeView.ollama-cloud-models.collapseAll'),
+    ),
+    commands.registerCommand('ollama-copilot.collapseLibrary', () =>
+      commands.executeCommand('workbench.actions.treeView.ollama-library-models.collapseAll'),
+    ),
+    commands.registerCommand('ollama-copilot.filterLocalModels', async () => {
+      const value = await window.showInputBox({ prompt: 'Filter local models', value: localProvider.filterText });
+      if (value !== undefined) {
+        localProvider.filterText = value;
+        void commands.executeCommand('setContext', 'ollama.localFilterActive', value.length > 0);
+        localProvider.refresh();
+      }
+    }),
+    commands.registerCommand('ollama-copilot.clearLocalFilter', () => {
+      localProvider.filterText = '';
+      void commands.executeCommand('setContext', 'ollama.localFilterActive', false);
+      localProvider.refresh();
+    }),
+    commands.registerCommand('ollama-copilot.filterCloudModels', async () => {
+      const value = await window.showInputBox({ prompt: 'Filter cloud models', value: cloudProvider.filterText });
+      if (value !== undefined) {
+        cloudProvider.filterText = value;
+        void commands.executeCommand('setContext', 'ollama.cloudFilterActive', value.length > 0);
+        cloudProvider.refresh();
+      }
+    }),
+    commands.registerCommand('ollama-copilot.clearCloudFilter', () => {
+      cloudProvider.filterText = '';
+      void commands.executeCommand('setContext', 'ollama.cloudFilterActive', false);
+      cloudProvider.refresh();
+    }),
+    commands.registerCommand('ollama-copilot.filterLibraryModels', async () => {
+      const value = await window.showInputBox({ prompt: 'Filter library models', value: libraryProvider.filterText });
+      if (value !== undefined) {
+        libraryProvider.filterText = value;
+        void commands.executeCommand('setContext', 'ollama.libraryFilterActive', value.length > 0);
+        libraryProvider.refresh();
+      }
+    }),
+    commands.registerCommand('ollama-copilot.clearLibraryFilter', () => {
+      libraryProvider.filterText = '';
+      void commands.executeCommand('setContext', 'ollama.libraryFilterActive', false);
+      libraryProvider.refresh();
+    }),
+    (() => {
+      const initialLocalGrouped = context.globalState.get<boolean>('ollama.localGrouped', true);
+      localProvider.grouped = initialLocalGrouped;
+      void commands.executeCommand('setContext', 'ollama.localGrouped', initialLocalGrouped);
+      return commands.registerCommand('ollama-copilot.toggleLocalGrouping', () => {
+        localProvider.grouped = !localProvider.grouped;
+        void context.globalState.update('ollama.localGrouped', localProvider.grouped);
+        void commands.executeCommand('setContext', 'ollama.localGrouped', localProvider.grouped);
+        localProvider.refresh();
+      });
+    })(),
+    (() => {
+      const initialCloudGrouped = context.globalState.get<boolean>('ollama.cloudGrouped', true);
+      cloudProvider.grouped = initialCloudGrouped;
+      void commands.executeCommand('setContext', 'ollama.cloudGrouped', initialCloudGrouped);
+      return commands.registerCommand('ollama-copilot.toggleCloudGrouping', () => {
+        cloudProvider.grouped = !cloudProvider.grouped;
+        void context.globalState.update('ollama.cloudGrouped', cloudProvider.grouped);
+        void commands.executeCommand('setContext', 'ollama.cloudGrouped', cloudProvider.grouped);
+        cloudProvider.refresh();
+      });
+    })(),
+    (() => {
+      const initialLibraryGrouped = context.globalState.get<boolean>('ollama.libraryGrouped', true);
+      libraryProvider.grouped = initialLibraryGrouped;
+      void commands.executeCommand('setContext', 'ollama.libraryGrouped', initialLibraryGrouped);
+      return commands.registerCommand('ollama-copilot.toggleLibraryGrouping', () => {
+        libraryProvider.grouped = !libraryProvider.grouped;
+        void context.globalState.update('ollama.libraryGrouped', libraryProvider.grouped);
+        void commands.executeCommand('setContext', 'ollama.libraryGrouped', libraryProvider.grouped);
+        libraryProvider.refresh();
+      });
+    })(),
     commands.registerCommand('ollama-copilot.refreshSidebar', () => handleRefreshLocalModels(localProvider)),
     commands.registerCommand('ollama-copilot.refreshLocalModels', () => handleRefreshLocalModels(localProvider)),
     commands.registerCommand('ollama-copilot.refreshLibrary', () => handleRefreshLibrary(libraryProvider)),

--- a/src/test/vscode.mock.ts
+++ b/src/test/vscode.mock.ts
@@ -107,12 +107,20 @@ export const window = {
   showQuickPick: vi.fn(),
   showWarningMessage: vi.fn(),
   showInformationMessage: vi.fn(),
+  showErrorMessage: vi.fn(),
+  createTreeView: vi.fn(() => ({ dispose: vi.fn() })),
+  showTextDocument: vi.fn(),
 };
 
 export const lm = {
   registerLanguageModelChatProvider: vi.fn().mockReturnValue({ dispose: vi.fn() }),
   selectChatModels: vi.fn().mockResolvedValue([]),
   onDidChangeChatModels: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+};
+
+export const workspace = {
+  openTextDocument: vi.fn().mockResolvedValue({}),
+  getConfiguration: vi.fn().mockReturnValue({ get: vi.fn() }),
 };
 
 export const commands = {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -13,6 +13,9 @@ export default defineConfig({
   test: {
     environment: 'node',
     restoreMocks: true,
-    exclude: ['node_modules/**', 'dist/**', 'out/**', 'scripts/**', 'test/integration/**']
+    exclude: ['node_modules/**', 'dist/**', 'out/**', 'scripts/**', 'test/integration/**'],
+    coverage: {
+      exclude: ['scripts/**', '**/test/**'],
+    }
   },
 });


### PR DESCRIPTION
## Summary

Fixes cloud model requests failing when no API key header is injected.

- Injects the cloud API key into outgoing requests for models tagged as cloud models
- Bean: `ollama-models-vscode-6ogy`

## Test Plan

- Unit tests pass (`pnpm run test`)
- Compile clean (`pnpm run compile`)