### PR TITLE
fix(sidebar): prevent deleting a running model [36w3]

### DIFF
--- a/.beans/ollama-models-vscode-36w3--prevent-deleting-a-running-model.md
+++ b/.beans/ollama-models-vscode-36w3--prevent-deleting-a-running-model.md
@@ -1,19 +1,26 @@
 ---
 # ollama-models-vscode-36w3
 title: Prevent deleting a running model
-status: todo
+status: completed
 type: feature
 priority: high
 created_at: 2026-03-07T17:17:45Z
-updated_at: 2026-03-07T17:20:01Z
+updated_at: 2026-03-07T17:55:00Z
+branch: fix/36w3-prevent-delete-running-model
 ---
 
 The delete model button appears in the context menu for running models (`local-running`, `cloud-running`). Deleting a running model can leave the model runner in a bad state.
 
 ## Todo
 
-- [ ] Remove `{"command": "ollama-copilot.deleteModel", "when": "view == ollama-local-models && viewItem == local-running", ...}` from `view/item/context` in `package.json`
-- [ ] Remove `{"command": "ollama-copilot.deleteModel", "when": "view == ollama-cloud-models && viewItem == cloud-running", ...}` from `view/item/context` in `package.json`
-- [ ] In `src/sidebar.ts` `handleDeleteModel()`: add guard — if `item.type === 'local-running' || item.type === 'cloud-running'`, call `vscode.window.showErrorMessage('Stop the model before deleting it.')` and return early
-- [ ] Run `pnpm run compile` to verify TypeScript passes
-- [ ] Run `pnpm run test` to verify unit tests still pass
+- [x] Remove `{"command": "ollama-copilot.deleteModel", "when": "view == ollama-local-models && viewItem == local-running", ...}` from `view/item/context` in `package.json`
+- [x] Remove `{"command": "ollama-copilot.deleteModel", "when": "view == ollama-cloud-models && viewItem == cloud-running", ...}` from `view/item/context` in `package.json`
+- [x] In `src/sidebar.ts` `handleDeleteModel()`: add guard — if `item.type === 'local-running' || item.type === 'cloud-running'`, call `vscode.window.showErrorMessage('Stop the model before deleting it.')` and return early
+- [x] Run `pnpm run compile` to verify TypeScript passes
+- [x] Run `pnpm run test` to verify unit tests still pass
+
+## Summary of Changes
+
+- `package.json`: Removed `deleteModel` context menu entries for `local-running` and `cloud-running` viewItem states.
+- `src/sidebar.ts`: Added early return guard in `handleDeleteModel` that shows an error message and blocks deletion when the model is running.
+- `src/sidebar.test.ts`: Two new tests verify the guard works for both `local-running` and `cloud-running` model types.

--- a/.beans/ollama-models-vscode-7not--increase-unit-test-coverage-to-85.md
+++ b/.beans/ollama-models-vscode-7not--increase-unit-test-coverage-to-85.md
@@ -16,4 +16,3 @@ branch: feat/7not-increase-unit-test-coverage-to-85
 - [x] Add `src/provider.test.ts` `setAuthToken` and capability tests
 - [x] Add `src/extension.test.ts` tool loop and logger tests
 - [x] Fix `src/sidebar.test.ts` — remove deleted `setSortMode`/`handleSortLibraryByRecency`/`handleSortLibraryByName` tests; fix grouping navigation for family-tree layout; fix `LibraryModelsProvider` constructor calls; fix `handleStartCloudModel` mocks
-

--- a/package.json
+++ b/package.json
@@ -301,11 +301,6 @@
           "group": "inline@1"
         },
         {
-          "command": "ollama-copilot.deleteModel",
-          "when": "view == ollama-local-models && viewItem == local-running",
-          "group": "inline@3"
-        },
-        {
           "command": "ollama-copilot.pullModelFromLibrary",
           "when": "view == ollama-library-models && viewItem == library-model-variant",
           "group": "inline@1"
@@ -344,11 +339,6 @@
           "command": "ollama-copilot.stopCloudModel",
           "when": "view == ollama-cloud-models && viewItem == cloud-running",
           "group": "inline@2"
-        },
-        {
-          "command": "ollama-copilot.deleteModel",
-          "when": "view == ollama-cloud-models && viewItem == cloud-running",
-          "group": "inline@3"
         },
         {
           "command": "ollama-copilot.editModelfile",

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1472,14 +1472,22 @@ describe('handleChatRequest model selection', () => {
       constructor(public value: string) {}
     };
     const LMToolCallPart = class {
-      constructor(public callId: string, public name: string, public input: Record<string, unknown>) {}
+      constructor(
+        public callId: string,
+        public name: string,
+        public input: Record<string, unknown>,
+      ) {}
     };
     const LMToolResultPart = class {
-      constructor(public callId: string, public content: unknown) {}
+      constructor(
+        public callId: string,
+        public content: unknown,
+      ) {}
     };
 
     // Round 1: stream yields a tool call; Round 2: stream yields the final text
-    const mockSendRequest = vi.fn()
+    const mockSendRequest = vi
+      .fn()
       .mockResolvedValueOnce({
         stream: (async function* () {
           yield new LMToolCallPart('call-1', 'search', { query: 'vitest' });
@@ -1492,10 +1500,12 @@ describe('handleChatRequest model selection', () => {
       });
 
     const mockInvokeTool = vi.fn().mockResolvedValue({ content: [new LMTextPart('tool-result')] });
-    const mockSelectChatModels = vi.fn().mockResolvedValue([{
-      vendor: 'selfagency-ollama',
-      sendRequest: mockSendRequest,
-    }]);
+    const mockSelectChatModels = vi.fn().mockResolvedValue([
+      {
+        vendor: 'selfagency-ollama',
+        sendRequest: mockSendRequest,
+      },
+    ]);
 
     vi.doMock('vscode', () => ({
       LanguageModelTextPart: LMTextPart,
@@ -1547,13 +1557,21 @@ describe('handleChatRequest model selection', () => {
       constructor(public value: string) {}
     };
     const LMToolCallPart = class {
-      constructor(public callId: string, public name: string, public input: Record<string, unknown>) {}
+      constructor(
+        public callId: string,
+        public name: string,
+        public input: Record<string, unknown>,
+      ) {}
     };
     const LMToolResultPart = class {
-      constructor(public callId: string, public content: unknown) {}
+      constructor(
+        public callId: string,
+        public content: unknown,
+      ) {}
     };
 
-    const mockSendRequest = vi.fn()
+    const mockSendRequest = vi
+      .fn()
       .mockResolvedValueOnce({
         stream: (async function* () {
           yield new LMToolCallPart('call-err', 'broken_tool', {});
@@ -1566,10 +1584,12 @@ describe('handleChatRequest model selection', () => {
       });
 
     const mockInvokeTool = vi.fn().mockRejectedValue(new Error('tool crashed'));
-    const mockSelectChatModels = vi.fn().mockResolvedValue([{
-      vendor: 'selfagency-ollama',
-      sendRequest: mockSendRequest,
-    }]);
+    const mockSelectChatModels = vi.fn().mockResolvedValue([
+      {
+        vendor: 'selfagency-ollama',
+        sendRequest: mockSendRequest,
+      },
+    ]);
 
     vi.doMock('vscode', () => ({
       LanguageModelTextPart: LMTextPart,

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -841,6 +841,45 @@ describe('LocalModelsProvider', () => {
 });
 
 describe('Extracted command handlers', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.doMock('vscode', () => ({
+      TreeItem: class {
+        label: string;
+        description?: string;
+        contextValue?: string;
+        collapsibleState?: number;
+        tooltip?: string;
+        command?: unknown;
+        constructor(label: string) {
+          this.label = label;
+        }
+      },
+      ThemeIcon: class {},
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      EventEmitter: class {
+        event = {};
+        fire = vi.fn();
+      },
+      window: {
+        showWarningMessage: vi.fn().mockResolvedValue('Delete'),
+        showInformationMessage: vi.fn(),
+        showErrorMessage: vi.fn(),
+      },
+      env: {
+        openExternal: vi.fn(),
+      },
+      Uri: {
+        parse: vi.fn((value: string) => ({ value })),
+      },
+      workspace: {
+        getConfiguration: vi.fn(() => ({ get: vi.fn() })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+      ProgressLocation: { Notification: 15 },
+    }));
+  });
+
   it('handleRefreshLocalModels refreshes provider and shows message', async () => {
     const { handleRefreshLocalModels } = await import('./sidebar.js');
 

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -810,11 +810,33 @@ describe('Extracted command handlers', () => {
       deleteModel: vi.fn(),
     } as any;
 
-    const item = new ModelTreeItem('test-model', 'local-running', 1000);
+    const item = new ModelTreeItem('test-model', 'local-stopped', 1000);
 
     await handleDeleteModel(item, mockProvider);
 
     expect(mockProvider.deleteModel).toHaveBeenCalledWith('test-model');
+  });
+
+  it('handleDeleteModel blocks deletion of a running local model', async () => {
+    const { handleDeleteModel, ModelTreeItem } = await import('./sidebar.js');
+
+    const mockProvider = { deleteModel: vi.fn() } as any;
+    const item = new ModelTreeItem('test-model', 'local-running', 1000);
+
+    await handleDeleteModel(item, mockProvider);
+
+    expect(mockProvider.deleteModel).not.toHaveBeenCalled();
+  });
+
+  it('handleDeleteModel blocks deletion of a running cloud model', async () => {
+    const { handleDeleteModel, ModelTreeItem } = await import('./sidebar.js');
+
+    const mockProvider = { deleteModel: vi.fn() } as any;
+    const item = new ModelTreeItem('cloud-model', 'cloud-running', 1000);
+
+    await handleDeleteModel(item, mockProvider);
+
+    expect(mockProvider.deleteModel).not.toHaveBeenCalled();
   });
 
   it('handleDeleteModel does not delete when cancelled', async () => {

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1306,11 +1306,13 @@ export function handleOpenCloudModel(item: ModelTreeItem): void {
  * Command handler: delete model
  */
 export async function handleDeleteModel(item: ModelTreeItem, localProvider: LocalModelsProvider): Promise<void> {
+  if (item && (item.type === 'local-running' || item.type === 'cloud-running')) {
+    void window.showErrorMessage('Stop the model before deleting it.');
+    return;
+  }
   if (
     item &&
-    (item.type === 'local-running' ||
-      item.type === 'local-stopped' ||
-      item.type === 'cloud-running' ||
+    (item.type === 'local-stopped' ||
       item.type === 'cloud-stopped')
   ) {
     const answer = await window.showWarningMessage(`Delete model "${item.label}"?`, 'Delete', 'Cancel');


### PR DESCRIPTION
## Summary

Prevents deletion of a model that is currently running.

- Blocks the delete action when a model is in a running state with a user-facing warning
- Bean: `ollama-models-vscode-36w3`

## Test Plan

- Unit tests pass (`pnpm run test`)
- Compile clean (`pnpm run compile`)

**Stacked on:** #27