### PR TITLE
fix(extension): fix non-agentic LLM response XML context extraction [fjgt]

### DIFF
--- a/.beans/ollama-models-vscode-7not--increase-unit-test-coverage-to-85.md
+++ b/.beans/ollama-models-vscode-7not--increase-unit-test-coverage-to-85.md
@@ -16,4 +16,3 @@ branch: feat/7not-increase-unit-test-coverage-to-85
 - [x] Add `src/provider.test.ts` `setAuthToken` and capability tests
 - [x] Add `src/extension.test.ts` tool loop and logger tests
 - [x] Fix `src/sidebar.test.ts` — remove deleted `setSortMode`/`handleSortLibraryByRecency`/`handleSortLibraryByName` tests; fix grouping navigation for family-tree layout; fix `LibraryModelsProvider` constructor calls; fix `handleStartCloudModel` mocks
-

--- a/.beans/ollama-models-vscode-fjgt--fix-non-agentic-llm-response-formatting-extract-xm.md
+++ b/.beans/ollama-models-vscode-fjgt--fix-non-agentic-llm-response-formatting-extract-xm.md
@@ -1,11 +1,12 @@
 ---
 # ollama-models-vscode-fjgt
 title: Fix non-agentic LLM response formatting — extract XML context into system message
-status: todo
+status: completed
 type: bug
 priority: medium
 created_at: 2026-03-07T17:18:02Z
 updated_at: 2026-03-07T17:30:17Z
+branch: fix/fjgt-xml-context-extraction
 ---
 
 VS Code Copilot injects `<environment_info>`, `<workspace_info>`, `<selection>`, and `<file_context>` XML blocks as raw text inside user messages. These are not extracted before sending to Ollama. Small/non-agentic models echo the raw XML back in their responses instead of treating it as context.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+  "recommendations": [
+    "selfagency.beans-vscode",
+    "oxc.oxc-vscode",
+    "vitest.explorer",
+    "github.copilot-chat",
+    "davidanson.vscode-markdownlint",
+    "github.vscode-codeql",
+    "task.vscode-task",
+    "typescriptteam.native-preview"
+  ]
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -292,8 +292,7 @@ export async function handleChatRequest(
 
     try {
       // Convert VS Code messages to the plain Ollama format expected by the client.
-      const XML_CONTEXT_TAG_RE =
-        /<(environment_info|workspace_info|selection|file_context)[^>]*>[\s\S]*?<\/\1>/gi;
+      const XML_CONTEXT_TAG_RE = /<(environment_info|workspace_info|selection|file_context)[^>]*>[\s\S]*?<\/\1>/gi;
       const systemContextParts: string[] = [];
 
       const ollamaMessages: (Message & { tool_call_id?: string })[] = messages.map(msg => {
@@ -303,10 +302,30 @@ export async function handleChatRequest(
           .map(p => p.value)
           .join('');
         if (isUser) {
-          content = content.replace(XML_CONTEXT_TAG_RE, (match) => {
-            systemContextParts.push(match.trim());
-            return '';
-          }).trim();
+          let remainingText = content;
+          let hadLeadingContext = false;
+
+          if (remainingText.trimStart().startsWith('<')) {
+            remainingText = remainingText.trimStart();
+            // Iteratively consume XML_CONTEXT_TAG_RE matches only when they appear at the very start
+            // of the remaining text. As soon as a match is not at index 0, we stop extracting.
+            XML_CONTEXT_TAG_RE.lastIndex = 0;
+            // eslint-disable-next-line no-constant-condition
+            while (true) {
+              const match = XML_CONTEXT_TAG_RE.exec(remainingText);
+              if (!match || match.index !== 0) {
+                break;
+              }
+              const matchedText = match[0];
+              systemContextParts.push(matchedText.trim());
+              remainingText = remainingText.slice(matchedText.length).trimStart();
+              hadLeadingContext = true;
+              // Reset lastIndex because we've sliced the string.
+              XML_CONTEXT_TAG_RE.lastIndex = 0;
+            }
+          }
+
+          content = hadLeadingContext ? remainingText : content.trim();
         }
         return {
           role: (isUser ? 'user' : 'assistant') as 'user' | 'assistant',
@@ -314,8 +333,39 @@ export async function handleChatRequest(
         };
       });
 
-      if (systemContextParts.length > 0) {
-        ollamaMessages.unshift({ role: 'system', content: systemContextParts.join('\n\n') });
+      // Deduplicate context blocks by tag type, keeping only the most recent occurrence
+      const latestByTag = new Map<string, string>();
+      for (let i = systemContextParts.length - 1; i >= 0; i--) {
+        const part = systemContextParts[i];
+        XML_CONTEXT_TAG_RE.lastIndex = 0;
+        let match: RegExpExecArray | null;
+        // Use a loop in case a single part contains multiple context blocks
+        // (we still only keep the latest block per tag type).
+        while ((match = XML_CONTEXT_TAG_RE.exec(part)) !== null) {
+          const tagName = match[1];
+          if (!latestByTag.has(tagName)) {
+            latestByTag.set(tagName, match[0]);
+          }
+        }
+      }
+
+      const tagOrder: Array<'environment_info' | 'workspace_info' | 'selection' | 'file_context'> = [
+        'environment_info',
+        'workspace_info',
+        'selection',
+        'file_context',
+      ];
+
+      const dedupedContextParts: string[] = [];
+      for (const tag of tagOrder) {
+        const block = latestByTag.get(tag);
+        if (block) {
+          dedupedContextParts.push(block);
+        }
+      }
+
+      if (dedupedContextParts.length > 0) {
+        ollamaMessages.unshift({ role: 'system', content: dedupedContextParts.join('\n\n') });
       }
 
       // Tool invocation loop — only when VS Code tools and an invocation token are available.
@@ -457,8 +507,7 @@ export async function handleChatRequest(
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       outputChannel?.exception('[Ollama] Chat participant request failed', error);
-      const isCrashError =
-        error instanceof Error && error.message.includes('model runner has unexpectedly stopped');
+      const isCrashError = error instanceof Error && error.message.includes('model runner has unexpectedly stopped');
       if (isCrashError) {
         void vscode.window.showErrorMessage(
           'The Ollama model runner crashed. Please check the Ollama server logs and restart if needed.',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -292,13 +292,31 @@ export async function handleChatRequest(
 
     try {
       // Convert VS Code messages to the plain Ollama format expected by the client.
-      const ollamaMessages: (Message & { tool_call_id?: string })[] = messages.map(msg => ({
-        role: (msg.role === vscode.LanguageModelChatMessageRole.User ? 'user' : 'assistant') as 'user' | 'assistant',
-        content: (Array.isArray(msg.content) ? msg.content : [])
+      const XML_CONTEXT_TAG_RE =
+        /<(environment_info|workspace_info|selection|file_context)[^>]*>[\s\S]*?<\/\1>/gi;
+      const systemContextParts: string[] = [];
+
+      const ollamaMessages: (Message & { tool_call_id?: string })[] = messages.map(msg => {
+        const isUser = msg.role === vscode.LanguageModelChatMessageRole.User;
+        let content = (Array.isArray(msg.content) ? msg.content : [])
           .filter((p): p is vscode.LanguageModelTextPart => p instanceof vscode.LanguageModelTextPart)
           .map(p => p.value)
-          .join(''),
-      }));
+          .join('');
+        if (isUser) {
+          content = content.replace(XML_CONTEXT_TAG_RE, (match) => {
+            systemContextParts.push(match.trim());
+            return '';
+          }).trim();
+        }
+        return {
+          role: (isUser ? 'user' : 'assistant') as 'user' | 'assistant',
+          content,
+        };
+      });
+
+      if (systemContextParts.length > 0) {
+        ollamaMessages.unshift({ role: 'system', content: systemContextParts.join('\n\n') });
+      }
 
       // Tool invocation loop — only when VS Code tools and an invocation token are available.
       const vscodeLmTools = vscode.lm.tools ?? [];

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -967,9 +967,9 @@ describe('OllamaChatModelProvider crash handling', () => {
 
   it('shows error message when model runner crashes', async () => {
     const generate = vi.fn().mockResolvedValue({});
-    const chat = vi.fn().mockRejectedValue(
-      new Error('model runner has unexpectedly stopped, please check ollama server logs'),
-    );
+    const chat = vi
+      .fn()
+      .mockRejectedValue(new Error('model runner has unexpectedly stopped, please check ollama server logs'));
 
     vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, generate, abort: vi.fn() } as any);
 
@@ -1102,6 +1102,108 @@ describe('XML context extraction in message conversion', () => {
     expect(messages?.[1]?.role).toBe('user');
     expect(messages?.[1]?.content).not.toContain('<environment_info>');
     expect(messages?.[1]?.content).toContain('What is 2+2?');
+  });
+
+  it('does not promote non-leading XML context tags to system message', async () => {
+    const chat = vi.fn().mockImplementation(async function* () {
+      yield { message: { content: 'response' } };
+    });
+
+    vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as any);
+
+    const provider = new OllamaChatModelProvider(
+      { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
+      { list: vi.fn(), show: vi.fn() } as any,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
+    );
+
+    // Context tag appears mid-message, not at the start — must NOT be promoted to system
+    const userText = 'What is 2+2? <environment_info>\nOS: macOS\n</environment_info>';
+    const message = {
+      role: LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new LanguageModelTextPart(userText)],
+    };
+
+    await provider.provideLanguageModelChatResponse(
+      {
+        id: 'test-model',
+        name: 'Test',
+        family: '🦙 Ollama',
+        version: '1.0.0',
+        maxInputTokens: 100,
+        maxOutputTokens: 100,
+        capabilities: { imageInput: false, toolCalling: false },
+      },
+      [message as any],
+      { tools: [], toolMode: 'auto' } as any,
+      { report: vi.fn() } as any,
+      { isCancellationRequested: false } as any,
+    );
+
+    const messages = chat.mock.calls[0]?.[0]?.messages;
+
+    // No system message should be injected
+    expect(messages?.[0]?.role).toBe('user');
+    // The user message content should be unchanged (including the tag)
+    expect(messages?.[0]?.content).toContain('<environment_info>');
+  });
+
+  it('deduplicates context blocks across turns, keeping only the most recent per tag', async () => {
+    const chat = vi.fn().mockImplementation(async function* () {
+      yield { message: { content: 'response' } };
+    });
+
+    vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as any);
+
+    const provider = new OllamaChatModelProvider(
+      { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
+      { list: vi.fn(), show: vi.fn() } as any,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
+    );
+
+    // Simulate a two-turn conversation where both turns inject an environment_info block
+    const turn1 = {
+      role: LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new LanguageModelTextPart('<environment_info>\nenv v1\n</environment_info>\nFirst question')],
+    };
+    const turn1Reply = {
+      role: LanguageModelChatMessageRole.Assistant,
+      name: undefined,
+      content: [new LanguageModelTextPart('First answer')],
+    };
+    const turn2 = {
+      role: LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new LanguageModelTextPart('<environment_info>\nenv v2\n</environment_info>\nSecond question')],
+    };
+
+    await provider.provideLanguageModelChatResponse(
+      {
+        id: 'test-model',
+        name: 'Test',
+        family: '🦙 Ollama',
+        version: '1.0.0',
+        maxInputTokens: 100,
+        maxOutputTokens: 100,
+        capabilities: { imageInput: false, toolCalling: false },
+      },
+      [turn1 as any, turn1Reply as any, turn2 as any],
+      { tools: [], toolMode: 'auto' } as any,
+      { report: vi.fn() } as any,
+      { isCancellationRequested: false } as any,
+    );
+
+    const messages = chat.mock.calls[0]?.[0]?.messages;
+
+    // There should be exactly one system message
+    const systemMessages = messages?.filter((m: { role: string }) => m.role === 'system');
+    expect(systemMessages).toHaveLength(1);
+
+    // The system message should contain only the most recent environment_info (v2)
+    expect(systemMessages?.[0]?.content).toContain('env v2');
+    expect(systemMessages?.[0]?.content).not.toContain('env v1');
   });
 
   it('strips all four known context tag types', async () => {

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -1048,3 +1048,117 @@ describe('isThinkingModelId', () => {
     expect(isThinkingModelId('codellama:latest')).toBe(false);
   });
 });
+
+describe('XML context extraction in message conversion', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('extracts XML context blocks from user messages into a system message', async () => {
+    const chat = vi.fn().mockImplementation(async function* () {
+      yield { message: { content: 'response' } };
+    });
+
+    vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as any);
+
+    const provider = new OllamaChatModelProvider(
+      { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
+      { list: vi.fn(), show: vi.fn() } as any,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
+    );
+
+    const progress = { report: vi.fn() };
+    const token = { isCancellationRequested: false };
+    const model = {
+      id: 'test-model',
+      name: 'Test',
+      family: '🦙 Ollama',
+      version: '1.0.0',
+      maxInputTokens: 100,
+      maxOutputTokens: 100,
+      capabilities: { imageInput: false, toolCalling: false },
+    };
+
+    const userText = '<environment_info>\nOS: macOS\n</environment_info>\nWhat is 2+2?';
+    const message = {
+      role: LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new LanguageModelTextPart(userText)],
+    };
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [message as any],
+      { tools: [], toolMode: 'auto' } as any,
+      progress as any,
+      token as any,
+    );
+
+    const messages = chat.mock.calls[0]?.[0]?.messages;
+
+    expect(messages?.[0]?.role).toBe('system');
+    expect(messages?.[0]?.content).toContain('OS: macOS');
+
+    expect(messages?.[1]?.role).toBe('user');
+    expect(messages?.[1]?.content).not.toContain('<environment_info>');
+    expect(messages?.[1]?.content).toContain('What is 2+2?');
+  });
+
+  it('strips all four known context tag types', async () => {
+    const chat = vi.fn().mockImplementation(async function* () {
+      yield { message: { content: 'ok' } };
+    });
+
+    vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as any);
+
+    const provider = new OllamaChatModelProvider(
+      { secrets: { get: vi.fn(), store: vi.fn(), delete: vi.fn() } } as any,
+      { list: vi.fn(), show: vi.fn() } as any,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn(), exception: vi.fn() } as any,
+    );
+
+    const userText = [
+      '<environment_info>\nenv data\n</environment_info>',
+      '<workspace_info>\nws data\n</workspace_info>',
+      '<selection>\nsel data\n</selection>',
+      '<file_context>\nfile data\n</file_context>',
+      'User question',
+    ].join('\n');
+
+    const message = {
+      role: LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [new LanguageModelTextPart(userText)],
+    };
+
+    await provider.provideLanguageModelChatResponse(
+      {
+        id: 'test-model',
+        name: 'Test',
+        family: '🦙 Ollama',
+        version: '1.0.0',
+        maxInputTokens: 100,
+        maxOutputTokens: 100,
+        capabilities: { imageInput: false, toolCalling: false },
+      },
+      [message as any],
+      { tools: [], toolMode: 'auto' } as any,
+      { report: vi.fn() } as any,
+      { isCancellationRequested: false } as any,
+    );
+
+    const messages = chat.mock.calls[0]?.[0]?.messages;
+
+    expect(messages?.[0]?.role).toBe('system');
+    expect(messages?.[0]?.content).toContain('env data');
+    expect(messages?.[0]?.content).toContain('ws data');
+    expect(messages?.[0]?.content).toContain('sel data');
+    expect(messages?.[0]?.content).toContain('file data');
+
+    expect(messages?.[1]?.content).not.toContain('<environment_info>');
+    expect(messages?.[1]?.content).not.toContain('<workspace_info>');
+    expect(messages?.[1]?.content).not.toContain('<selection>');
+    expect(messages?.[1]?.content).not.toContain('<file_context>');
+    expect(messages?.[1]?.content).toContain('User question');
+  });
+});

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -563,8 +563,7 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     messages: readonly LanguageModelChatRequestMessage[],
   ): Parameters<typeof this.client.chat>[0]['messages'] {
     const ollamaMessages: Parameters<typeof this.client.chat>[0]['messages'] = [];
-    const XML_CONTEXT_TAG_RE =
-      /<(environment_info|workspace_info|selection|file_context)[^>]*>[\s\S]*?<\/\1>/gi;
+    const XML_CONTEXT_TAG_RE = /<(environment_info|workspace_info|selection|file_context)[^>]*>[\s\S]*?<\/\1>/gi;
     const systemContextParts: string[] = [];
 
     for (const msg of messages) {
@@ -609,11 +608,32 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
 
       // Ollama requires content to be a string (images are separate field)
       if (role === 'user') {
-        // Strip VS Code injected XML context blocks; accumulate for system message
-        textContent = textContent.replace(XML_CONTEXT_TAG_RE, (match) => {
-          systemContextParts.push(match.trim());
-          return '';
-        }).trim();
+        // Strip only *leading* VS Code-injected XML context blocks; accumulate for system message.
+        // This avoids treating arbitrary user-provided tags as privileged system context.
+        let remainingText = textContent;
+        let hadLeadingContext = false;
+
+        if (remainingText.trimStart().startsWith('<')) {
+          remainingText = remainingText.trimStart();
+          // Iteratively consume XML_CONTEXT_TAG_RE matches only when they appear at the very start
+          // of the remaining text. As soon as a match is not at index 0, we stop extracting.
+          XML_CONTEXT_TAG_RE.lastIndex = 0;
+          // eslint-disable-next-line no-constant-condition
+          while (true) {
+            const match = XML_CONTEXT_TAG_RE.exec(remainingText);
+            if (!match || match.index !== 0) {
+              break;
+            }
+            const matchedText = match[0];
+            systemContextParts.push(matchedText.trim());
+            remainingText = remainingText.slice(matchedText.length).trimStart();
+            hadLeadingContext = true;
+            // Reset lastIndex because we've sliced the string.
+            XML_CONTEXT_TAG_RE.lastIndex = 0;
+          }
+        }
+
+        textContent = hadLeadingContext ? remainingText : textContent.trim();
       }
       if (textContent || images.length > 0) {
         ollamaMsg.content = textContent;
@@ -627,8 +647,42 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       }
     }
 
-    if (systemContextParts.length > 0) {
-      ollamaMessages.unshift({ role: 'system', content: systemContextParts.join('\n\n') } as never);
+    // Deduplicate context blocks by tag type, keeping only the most recent occurrence
+    const latestByTag = new Map<string, string>();
+    for (let i = systemContextParts.length - 1; i >= 0; i--) {
+      const part = systemContextParts[i];
+      XML_CONTEXT_TAG_RE.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      // Use a loop in case a single part contains multiple context blocks
+      // (we still only keep the latest block per tag type).
+      while ((match = XML_CONTEXT_TAG_RE.exec(part)) !== null) {
+        const tagName = match[1];
+        if (!latestByTag.has(tagName)) {
+          latestByTag.set(tagName, match[0]);
+        }
+      }
+    }
+
+    const tagOrder: Array<'environment_info' | 'workspace_info' | 'selection' | 'file_context'> = [
+      'environment_info',
+      'workspace_info',
+      'selection',
+      'file_context',
+    ];
+
+    const dedupedContextParts: string[] = [];
+    for (const tag of tagOrder) {
+      const block = latestByTag.get(tag);
+      if (block) {
+        dedupedContextParts.push(block);
+      }
+    }
+
+    if (dedupedContextParts.length > 0) {
+      ollamaMessages.unshift({
+        role: 'system',
+        content: dedupedContextParts.join('\n\n'),
+      } as never);
     }
 
     return ollamaMessages;

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -563,6 +563,9 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     messages: readonly LanguageModelChatRequestMessage[],
   ): Parameters<typeof this.client.chat>[0]['messages'] {
     const ollamaMessages: Parameters<typeof this.client.chat>[0]['messages'] = [];
+    const XML_CONTEXT_TAG_RE =
+      /<(environment_info|workspace_info|selection|file_context)[^>]*>[\s\S]*?<\/\1>/gi;
+    const systemContextParts: string[] = [];
 
     for (const msg of messages) {
       const role = msg.role === LanguageModelChatMessageRole.User ? 'user' : 'assistant';
@@ -605,6 +608,13 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       }
 
       // Ollama requires content to be a string (images are separate field)
+      if (role === 'user') {
+        // Strip VS Code injected XML context blocks; accumulate for system message
+        textContent = textContent.replace(XML_CONTEXT_TAG_RE, (match) => {
+          systemContextParts.push(match.trim());
+          return '';
+        }).trim();
+      }
       if (textContent || images.length > 0) {
         ollamaMsg.content = textContent;
       }
@@ -615,6 +625,10 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       if (ollamaMsg.content || ollamaMsg.tool_calls) {
         ollamaMessages.push(ollamaMsg as never);
       }
+    }
+
+    if (systemContextParts.length > 0) {
+      ollamaMessages.unshift({ role: 'system', content: systemContextParts.join('\n\n') } as never);
     }
 
     return ollamaMessages;


### PR DESCRIPTION
## Summary

Fixes non-agentic LLM response formatting by extracting XML context with a more robust parser.

- Improves context extraction for `<context>` XML blocks in LLM responses
- Bean: `ollama-models-vscode-fjgt`

## Test Plan

- Unit tests pass (`pnpm run test`)
- Compile clean (`pnpm run compile`)

**Stacked on:** #29