### PR TITLE
fix(extension): flush final-round text when MAX_TOOL_ROUNDS exhausted [q1wb]

### DIFF
--- a/.beans/ollama-models-vscode-q1wb--fix-agentic-tool-loop-silently-discarding-final-ro.md
+++ b/.beans/ollama-models-vscode-q1wb--fix-agentic-tool-loop-silently-discarding-final-ro.md
@@ -1,0 +1,6 @@
+---
+id: ollama-models-vscode-q1wb
+title: Fix agentic tool loop silently discarding final-round text when MAX_TOOL_ROUNDS exhausted
+status: todo
+type: fix
+---

--- a/.beans/ollama-models-vscode-q1wb--fix-agentic-tool-loop-silently-discarding-final-ro.md
+++ b/.beans/ollama-models-vscode-q1wb--fix-agentic-tool-loop-silently-discarding-final-ro.md
@@ -1,6 +1,30 @@
 ---
-id: ollama-models-vscode-q1wb
+# ollama-models-vscode-q1wb
 title: Fix agentic tool loop silently discarding final-round text when MAX_TOOL_ROUNDS exhausted
-status: todo
+status: completed
 type: fix
+priority: normal
+created_at: 2026-03-07T18:38:10Z
+updated_at: 2026-03-07T18:42:45Z
 ---
+
+When the VS Code LM tool loop exhausts all MAX_TOOL_ROUNDS iterations (11 rounds, 0–10), the loop exits naturally without hitting the `break` branch that flushes `assistantTextParts`. Any text the model produced in the final round is silently discarded and never rendered via `stream.markdown()`.
+
+## Root Cause
+
+In `handleChatRequest` (`src/extension.ts`), `assistantTextParts` is only flushed inside the `break` branch (`pendingToolCalls.length === 0`). If the loop runs all 11 rounds and each round has pending tool calls, the loop exits by falling off the end — the last round's text is lost.
+
+## Todo
+
+- [x] Write failing test: model always returns tool calls for MAX_TOOL_ROUNDS+1 rounds — verify final-round text is still rendered
+- [x] Declare `lastRoundTextParts` outside the for loop, assign in each iteration, clear when flushed in break branch
+- [x] After the for loop, flush `lastRoundTextParts` unconditionally
+- [x] Compile passes, all tests pass
+
+## Summary of Changes
+
+- Added `lastRoundTextParts` variable outside the `for` loop
+- Each iteration assigns `lastRoundTextParts = assistantTextParts`
+- The `break` path clears `lastRoundTextParts = []` to avoid double-flush
+- After the loop, flush any remaining `lastRoundTextParts` via `stream.markdown()`
+- Commit: `3f30404b40ca2152b670b79016778f1ca973beeb`, branch: `fix/q1wb-tool-loop-flush-final-round-text`

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1464,6 +1464,99 @@ describe('handleChatRequest model selection', () => {
     expect(mockMarkdown).toHaveBeenCalledWith('response from chosen model');
     expect(mockSelectChatModels).not.toHaveBeenCalled();
   });
+
+  it('flushes final-round text when MAX_TOOL_ROUNDS is exhausted', async () => {
+    const LMTextPart = class {
+      constructor(public value: string) {}
+    };
+    const LMToolCallPart = class {
+      constructor(
+        public callId: string,
+        public name: string,
+        public input: Record<string, unknown>,
+      ) {}
+    };
+    const LMToolResultPart = class {
+      constructor(
+        public callId: string,
+        public content: unknown,
+      ) {}
+    };
+
+    // Every round returns a tool call AND a text part — so the loop never breaks early.
+    // After MAX_TOOL_ROUNDS (10) iterations the loop falls off the end; the last round's
+    // text must still be rendered.
+    let round = 0;
+    const mockSendRequest = vi.fn().mockImplementation(() => ({
+      stream: (async function* () {
+        round++;
+        yield new LMTextPart(`round-${round}-text`);
+        yield new LMToolCallPart(`call-${round}`, 'someTool', {});
+      })(),
+    }));
+
+    const mockInvokeTool = vi.fn().mockResolvedValue({ content: [] });
+
+    vi.doMock('vscode', () => ({
+      TreeItem: class {
+        constructor(public label: string) {}
+      },
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      ThemeIcon: class {
+        constructor(public id: string) {}
+      },
+      EventEmitter: class {
+        event = {};
+        fire = vi.fn();
+      },
+      Uri: { file: vi.fn(), joinPath: vi.fn().mockReturnValue(undefined), parse: vi.fn() },
+      LanguageModelTextPart: LMTextPart,
+      LanguageModelToolCallPart: LMToolCallPart,
+      LanguageModelToolResultPart: LMToolResultPart,
+      LanguageModelChatMessage: {
+        User: (content: unknown) => ({ role: 'user', content }),
+        Assistant: (content: unknown) => ({ role: 'assistant', content }),
+      },
+      ChatRequestTurn: class {},
+      ChatResponseTurn: class {},
+      ChatResponseMarkdownPart: class {},
+      window: {
+        createOutputChannel: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), show: vi.fn() })),
+        createTreeView: vi.fn(() => ({ dispose: vi.fn() })),
+        showErrorMessage: vi.fn(),
+        showInformationMessage: vi.fn(),
+        showInputBox: vi.fn(),
+      },
+      commands: {
+        registerCommand: vi.fn(() => ({ dispose: vi.fn() })),
+        executeCommand: vi.fn(),
+      },
+      lm: {
+        selectChatModels: vi.fn().mockResolvedValue([]),
+        tools: [],
+        invokeTool: mockInvokeTool,
+      },
+      workspace: { getConfiguration: vi.fn().mockReturnValue({ get: vi.fn() }) },
+    }));
+
+    const ext = await import('./extension.js');
+    const mockMarkdown = vi.fn();
+    const mockRequest = {
+      prompt: 'test',
+      model: { vendor: 'selfagency-ollama', sendRequest: mockSendRequest },
+      toolInvocationToken: 'tok',
+    };
+
+    await ext.handleChatRequest(
+      mockRequest as any,
+      { history: [] } as any,
+      { markdown: mockMarkdown } as any,
+      { isCancellationRequested: false } as any,
+    );
+
+    // The loop runs 11 rounds (0..10) all with tool calls; last-round text must be flushed.
+    expect(mockMarkdown).toHaveBeenCalledWith('round-11-text');
+  });
 });
 
 describe('handleBuiltInOllamaConflict', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -487,6 +487,7 @@ export async function handleChatRequest(
     const tools = vscode.lm.tools ?? [];
     const conversationMessages = [...messages];
     const MAX_TOOL_ROUNDS = 10;
+    let lastRoundTextParts: vscode.LanguageModelTextPart[] = [];
 
     for (let round = 0; round <= MAX_TOOL_ROUNDS; round++) {
       const response = await model.sendRequest(
@@ -507,11 +508,14 @@ export async function handleChatRequest(
         }
       }
 
+      lastRoundTextParts = assistantTextParts;
+
       if (pendingToolCalls.length === 0 || !request.toolInvocationToken) {
         // No more tool calls — stream any buffered text and finish.
         for (const part of assistantTextParts) {
           stream.markdown(part.value);
         }
+        lastRoundTextParts = [];
         break;
       }
 
@@ -537,6 +541,12 @@ export async function handleChatRequest(
         }
       }
       conversationMessages.push(vscode.LanguageModelChatMessage.User(toolResults));
+    }
+
+    // Flush any text produced in the final round when all tool rounds were exhausted
+    // without a clean break (i.e. the model kept requesting tools for every round).
+    for (const part of lastRoundTextParts) {
+      stream.markdown(part.value);
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';


### PR DESCRIPTION
## Summary

Fixes the agentic VS Code LM tool loop silently discarding text produced in the final round when `MAX_TOOL_ROUNDS` (10) is exhausted.

**Root cause:** `assistantTextParts` was only flushed via `stream.markdown()` inside the `break` branch. If the model keeps requesting tool calls for all 11 rounds, the loop exits by falling off the end and the final round's text is never rendered.

**Fix:**
- Introduces `lastRoundTextParts` outside the loop, updated on each iteration
- Cleared (set to `[]`) in the `break` path to avoid a double-flush
- After the loop, flushes any remaining `lastRoundTextParts` unconditionally
- Bean: `ollama-models-vscode-q1wb`

## Test Plan

- Added failing test: model always returns tool calls × 11 rounds; validates final-round text reaches `stream.markdown()`
- All 229 unit tests pass (`pnpm run test`)
- Compile clean (`pnpm run compile`)

Reported at: https://github.com/selfagency/ollama-copilot/pull/26#pullrequestreview-...

**Stacked on:** #32