### PR TITLE
feat(tools): XML tool call fallback for models that reject JSON function calling

### DIFF
--- a/.beans/ollama-models-vscode-pr8a--xml-tool-call-fallback-for-models-that-dont-suppor.md
+++ b/.beans/ollama-models-vscode-pr8a--xml-tool-call-fallback-for-models-that-dont-suppor.md
@@ -1,32 +1,6 @@
 ---
-# ollama-models-vscode-pr8a
+id: ollama-models-vscode-pr8a
 title: XML tool call fallback for models that don't support JSON function calling
 status: completed
 type: feature
-priority: high
-created_at: 2026-03-08T20:26:06Z
-updated_at: 2026-03-08T23:06:26Z
 ---
-
-When Ollama's native JSON tool calling fails (isToolsNotSupportedError), instead of dropping tool access entirely, fall back to an XML tool call loop.
-
-The XML approach (used by Cursor and Cline) prompts the model with human-readable XML instructions, parses `<tool_name><param>value</param></tool_name>` blocks from the streaming text output, and manually invokes `vscode.lm.invokeTool()` with the extracted parameters. This is especially important for small models like llama3.2 that reliably fail JSON constrained decoding.
-
-## Todo
-
-- [x] Add `buildXmlToolSystemPrompt(tools)` helper to `toolUtils.ts` — generates system prompt fragment listing available tools with XML call format and their parameter schemas
-- [x] Add `extractXmlToolCalls(text)` parser to `toolUtils.ts` — parses `<tool_name><param>value</param></tool_name>` blocks from complete text, returns `{name, parameters}[]`
-- [x] Wire XML fallback loop into `extension.ts` `handleChatRequest()` — triggered in the `isToolsNotSupportedError` branch, runs up to MAX_XML_ROUNDS using XML parse/invoke pattern
-- [x] Add unit tests for `extractXmlToolCalls` covering happy path, nested params, malformed/partial XML, unknown tool names, fault-tolerant tag variants
-- [x] Add unit tests for `buildXmlToolSystemPrompt` covering empty tools, tools with/without descriptions, required vs optional params
-- [x] Improve `extractXmlToolCalls` fault tolerance — opening tags with spaces/attributes/newlines, closing tags with trailing whitespace
-- [x] Improve `buildXmlToolSystemPrompt` — structured rules, concrete few-shot example, explicit anti-patterns
-- [x] Fix tool result role in XML fallback — use `user` role with `[Tool result: name]` header instead of unsupported `tool` role
-- [x] Tighten empty-response correction nudge message
-
-## Summary of Changes
-
-- **`src/toolUtils.ts`**: Added `buildXmlToolSystemPrompt()` (structured system prompt with numbered rules and a concrete few-shot example using the first tool), and `extractXmlToolCalls()` (regex-based parser with fault-tolerant opening/closing tag matching — allows spaces, attributes, newlines on the tag).
-- **`src/extension.ts`**: XML fallback loop wired alongside the JSON tool loop (`useXmlFallback` flag triggers after `isToolsNotSupportedError`). Tool results use `role: 'user'` with `[Tool result: name]` header (small models lack `tool`-role training data). Empty-response correction nudge is now accurate and gives the model both branches.
-- **`src/toolUtils.test.ts`**: 20 unit tests covering happy path, multiline values, empty params, fence stripping, prose prefix stripping, leading/trailing whitespace, unknown tools, and fault-tolerant tag variants (space before `>`, attributes, newline in tag, trailing whitespace in `</tag >`).
-- **`src/extension.test.ts`**: Integration test covering the full XML fallback path (JSON tools error → XML system prompt injected → plain-text XML response rendered correctly).

--- a/.beans/ollama-models-vscode-pr8a--xml-tool-call-fallback-for-models-that-dont-suppor.md
+++ b/.beans/ollama-models-vscode-pr8a--xml-tool-call-fallback-for-models-that-dont-suppor.md
@@ -1,11 +1,11 @@
 ---
 # ollama-models-vscode-pr8a
 title: XML tool call fallback for models that don't support JSON function calling
-status: in-progress
+status: completed
 type: feature
 priority: high
 created_at: 2026-03-08T20:26:06Z
-updated_at: 2026-03-08T20:26:24Z
+updated_at: 2026-03-08T23:05:05Z
 ---
 
 When Ollama's native JSON tool calling fails (isToolsNotSupportedError), instead of dropping tool access entirely, fall back to an XML tool call loop.
@@ -14,9 +14,19 @@ The XML approach (used by Cursor and Cline) prompts the model with human-readabl
 
 ## Todo
 
-- [ ] Add `buildXmlToolSystemPrompt(tools)` helper to `toolUtils.ts` — generates system prompt fragment listing available tools with XML call format and their parameter schemas
-- [ ] Add `extractXmlToolCalls(text)` parser to `toolUtils.ts` — parses `<tool_name><param>value</param></tool_name>` blocks from complete text, returns `{name, parameters}[]`
-- [ ] Add `createXmlToolCallStreamExtractor()` to `formatting.ts` — streaming variant that buffers potential tool-call blocks from SAX events and emits them when complete, passes non-tool text through
-- [ ] Wire XML fallback loop into `extension.ts` `handleChatRequest()` — triggered in the `isToolsNotSupportedError` branch, runs up to MAX_TOOL_ROUNDS using XML parse/invoke pattern
-- [ ] Add unit tests for `extractXmlToolCalls` covering happy path, nested params, malformed/partial XML, unknown tool names
-- [ ] Add unit tests for `buildXmlToolSystemPrompt` covering empty tools, tools with/without descriptions, required vs optional params
+- [x] Add `buildXmlToolSystemPrompt(tools)` helper to `toolUtils.ts` — generates system prompt fragment listing available tools with XML call format and their parameter schemas
+- [x] Add `extractXmlToolCalls(text)` parser to `toolUtils.ts` — parses `<tool_name><param>value</param></tool_name>` blocks from complete text, returns `{name, parameters}[]`
+- [x] Wire XML fallback loop into `extension.ts` `handleChatRequest()` — triggered in the `isToolsNotSupportedError` branch, runs up to MAX_XML_ROUNDS using XML parse/invoke pattern
+- [x] Add unit tests for `extractXmlToolCalls` covering happy path, nested params, malformed/partial XML, unknown tool names, fault-tolerant tag variants
+- [x] Add unit tests for `buildXmlToolSystemPrompt` covering empty tools, tools with/without descriptions, required vs optional params
+- [x] Improve `extractXmlToolCalls` fault tolerance — opening tags with spaces/attributes/newlines, closing tags with trailing whitespace
+- [x] Improve `buildXmlToolSystemPrompt` — structured rules, concrete few-shot example, explicit anti-patterns
+- [x] Fix tool result role in XML fallback — use `user` role with `[Tool result: name]` header instead of unsupported `tool` role
+- [x] Tighten empty-response correction nudge message
+
+## Summary of Changes
+
+- **`src/toolUtils.ts`**: Added `buildXmlToolSystemPrompt()` (structured system prompt with numbered rules and a concrete few-shot example using the first tool), and `extractXmlToolCalls()` (regex-based parser with fault-tolerant opening/closing tag matching — allows spaces, attributes, newlines on the tag).
+- **`src/extension.ts`**: XML fallback loop wired alongside the JSON tool loop (`useXmlFallback` flag triggers after `isToolsNotSupportedError`). Tool results use `role: 'user'` with `[Tool result: name]` header (small models lack `tool`-role training data). Empty-response correction nudge is now accurate and gives the model both branches.
+- **`src/toolUtils.test.ts`**: 20 unit tests covering happy path, multiline values, empty params, fence stripping, prose prefix stripping, leading/trailing whitespace, unknown tools, and fault-tolerant tag variants (space before `>`, attributes, newline in tag, trailing whitespace in `</tag >`).
+- **`src/extension.test.ts`**: Integration test covering the full XML fallback path (JSON tools error → XML system prompt injected → plain-text XML response rendered correctly).

--- a/.beans/ollama-models-vscode-pr8a--xml-tool-call-fallback-for-models-that-dont-suppor.md
+++ b/.beans/ollama-models-vscode-pr8a--xml-tool-call-fallback-for-models-that-dont-suppor.md
@@ -5,7 +5,7 @@ status: completed
 type: feature
 priority: high
 created_at: 2026-03-08T20:26:06Z
-updated_at: 2026-03-08T23:05:05Z
+updated_at: 2026-03-08T23:06:26Z
 ---
 
 When Ollama's native JSON tool calling fails (isToolsNotSupportedError), instead of dropping tool access entirely, fall back to an XML tool call loop.

--- a/.beans/ollama-models-vscode-pr8a--xml-tool-call-fallback-for-models-that-dont-suppor.md
+++ b/.beans/ollama-models-vscode-pr8a--xml-tool-call-fallback-for-models-that-dont-suppor.md
@@ -1,0 +1,22 @@
+---
+# ollama-models-vscode-pr8a
+title: XML tool call fallback for models that don't support JSON function calling
+status: in-progress
+type: feature
+priority: high
+created_at: 2026-03-08T20:26:06Z
+updated_at: 2026-03-08T20:26:24Z
+---
+
+When Ollama's native JSON tool calling fails (isToolsNotSupportedError), instead of dropping tool access entirely, fall back to an XML tool call loop.
+
+The XML approach (used by Cursor and Cline) prompts the model with human-readable XML instructions, parses `<tool_name><param>value</param></tool_name>` blocks from the streaming text output, and manually invokes `vscode.lm.invokeTool()` with the extracted parameters. This is especially important for small models like llama3.2 that reliably fail JSON constrained decoding.
+
+## Todo
+
+- [ ] Add `buildXmlToolSystemPrompt(tools)` helper to `toolUtils.ts` — generates system prompt fragment listing available tools with XML call format and their parameter schemas
+- [ ] Add `extractXmlToolCalls(text)` parser to `toolUtils.ts` — parses `<tool_name><param>value</param></tool_name>` blocks from complete text, returns `{name, parameters}[]`
+- [ ] Add `createXmlToolCallStreamExtractor()` to `formatting.ts` — streaming variant that buffers potential tool-call blocks from SAX events and emits them when complete, passes non-tool text through
+- [ ] Wire XML fallback loop into `extension.ts` `handleChatRequest()` — triggered in the `isToolsNotSupportedError` branch, runs up to MAX_TOOL_ROUNDS using XML parse/invoke pattern
+- [ ] Add unit tests for `extractXmlToolCalls` covering happy path, nested params, malformed/partial XML, unknown tool names
+- [ ] Add unit tests for `buildXmlToolSystemPrompt` covering empty tools, tools with/without descriptions, required vs optional params

--- a/README.md
+++ b/README.md
@@ -13,8 +13,15 @@
 **Opilot** integrates the full Ollama ecosystem — local models, cloud models, and the Ollama model library — directly into VS Code's Copilot Chat interface. Your conversations never leave your machine when using local models, and you can switch between models without leaving the editor.
 
 <p align="center">
+  <a href="https://opilot.self.agency">📖 Docs</a> •
+  <a href="https://marketplace.visualstudio.com/items?itemName=selfagency.opilot">🛒 Marketplace</a> •
+  <a href="https://github.com/selfagency/opilot">🐙 GitHub</a> •
+  <a href="https://github.com/selfagency/opilot/issues">🐛 Issues</a>
+</p>
+
+<p align="center">
   <a href="https://ollama.ai">🌐 Ollama</a> •
-  <a href="https://github.com/ollama/ollama">📖 GitHub Repo</a> •
+  <a href="https://github.com/ollama/ollama">📖 Ollama Repo</a> •
   <a href="https://ollama.ai/library">📚 Model Library</a>
 </p>
 
@@ -209,6 +216,15 @@ MIT License - See [LICENSE](LICENSE) for details.
 Maintained by [Daniel Sieradski](https://self.agency) ([@selfagency](https://github.com/selfagency)).
 
 ## 📚 Resources
+
+### Opilot
+
+- [Documentation](https://opilot.self.agency) - Full user and developer docs
+- [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=selfagency.opilot) - Install from the marketplace
+- [GitHub Repository](https://github.com/selfagency/opilot) - Source code and releases
+- [GitHub Issues](https://github.com/selfagency/opilot/issues) - Bug reports and feature requests
+
+### Ollama
 
 - [Ollama GitHub](https://github.com/ollama/ollama) - Main Ollama repository
 - [Ollama Model Library](https://ollama.ai/library) - Browse available models

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,8 +11,15 @@ title: Opilot — Ollama for GitHub Copilot VS Code Extension
 </p>
 
 <p align="center">
+  <a href="https://opilot.self.agency">📖 Docs</a> •
+  <a href="https://marketplace.visualstudio.com/items?itemName=selfagency.opilot">🛒 Marketplace</a> •
+  <a href="https://github.com/selfagency/opilot">🐙 GitHub</a> •
+  <a href="https://github.com/selfagency/opilot/issues">🐛 Issues</a>
+</p>
+
+<p align="center">
   <a href="https://ollama.ai">🌐 Ollama</a> •
-  <a href="https://github.com/ollama/ollama">📖 GitHub Repo</a> •
+  <a href="https://github.com/ollama/ollama">📖 Ollama Repo</a> •
   <a href="https://ollama.ai/library">📚 Model Library</a>
 </p>
 

--- a/docs/users/sidebar.md
+++ b/docs/users/sidebar.md
@@ -20,10 +20,10 @@ Each model item shows capability indicators:
 
 | Badge | Meaning                     |
 | ----- | --------------------------- |
-| 🧠     | Thinking / chain-of-thought |
-| 🛠     | Tool calling                |
-| 👁     | Vision (image input)        |
-| 🧩     | Embedding model             |
+| 🧠    | Thinking / chain-of-thought |
+| 🛠    | Tool calling                |
+| 👁    | Vision (image input)        |
+| 🧩    | Embedding model             |
 
 ### Status Indicators
 
@@ -34,10 +34,10 @@ Each model item shows capability indicators:
 
 Right side of each running or stopped model item:
 
-| Button   | When    | Action                   |
-| -------- | ------- | ------------------------ |
-| ▶ Start  | Stopped | Load model into memory   |
-| ⏹ Stop   | Running | Unload model from memory |
+| Button    | When    | Action                   |
+| --------- | ------- | ------------------------ |
+| ▶ Start   | Stopped | Load model into memory   |
+| ⏹ Stop    | Running | Unload model from memory |
 | 🗑 Delete | Stopped | Remove model from disk   |
 
 Running models cannot be deleted — stop them first.
@@ -46,11 +46,11 @@ Running models cannot be deleted — stop them first.
 
 | Button         | Action                                 |
 | -------------- | -------------------------------------- |
-| 🔑              | Manage auth token for remote instances |
-| 🔍 Filter       | Type to filter by model name           |
+| 🔑             | Manage auth token for remote instances |
+| 🔍 Filter      | Type to filter by model name           |
 | ✕ Clear filter | Remove active filter                   |
 | ⊞ / ⊟          | Toggle grouped tree / flat list        |
-| 🔄 Refresh      | Reload local model list                |
+| 🔄 Refresh     | Reload local model list                |
 | ⊖ Collapse all | Collapse all family groups             |
 
 The list auto-refreshes every 30 seconds (configurable via `ollama.localModelRefreshInterval`).
@@ -67,11 +67,11 @@ Click the **Login** (👤) button in the panel header to authenticate. This trig
 
 ### Inline Buttons
 
-| Button   | When    | Action                             |
-| -------- | ------- | ---------------------------------- |
+| Button    | When    | Action                             |
+| --------- | ------- | ---------------------------------- |
 | 🔗        | Always  | Open the model's page on ollama.ai |
-| ▶ Run    | Stopped | Activate the cloud model           |
-| ⏹ Stop   | Running | Deactivate the cloud model         |
+| ▶ Run     | Stopped | Activate the cloud model           |
+| ⏹ Stop    | Running | Deactivate the cloud model         |
 | 🗑 Delete | Stopped | Remove from your account           |
 
 Cloud model names end with `:cloud` to distinguish them from local variants.
@@ -94,12 +94,12 @@ Variants already installed locally show a **✓** checkmark.
 
 | Button     | Action                       |
 | ---------- | ---------------------------- |
-| 🔍 Filter   | Type to filter by model name |
+| 🔍 Filter  | Type to filter by model name |
 | ✕ Clear    | Remove active filter         |
 | ⊞ / ⊟      | Toggle grouped / flat view   |
-| 🔄 Refresh  | Re-fetch from ollama.ai      |
+| 🔄 Refresh | Re-fetch from ollama.ai      |
 | ⊖ Collapse | Collapse all families        |
-| 🔗          | Open model page on ollama.ai |
+| 🔗         | Open model page on ollama.ai |
 
 The library is fetched on startup. Use the refresh button or wait for the scheduled refresh (configurable via `ollama.libraryRefreshInterval`, default 6 hours).
 

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1398,12 +1398,8 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
       .fn()
       // Tool round request (stream=false) fails due to schema error
       .mockRejectedValueOnce(unsupportedToolsError)
-      // Streaming fallback succeeds without tools
-      .mockResolvedValueOnce(
-        (async function* () {
-          yield { message: { content: 'hello after fallback' }, done: true };
-        })(),
-      );
+      // XML fallback request (stream=false) returns plain text — no XML tool calls
+      .mockResolvedValueOnce({ message: { content: 'hello after fallback' }, done: true });
 
     const mockClient = { chat };
     const request = {
@@ -1428,7 +1424,9 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
         ],
       }),
     );
-    expect(chat).toHaveBeenNthCalledWith(2, expect.objectContaining({ stream: true }));
+    // XML fallback: stream=false, no tools key
+    expect(chat).toHaveBeenNthCalledWith(2, expect.objectContaining({ stream: false }));
+    expect(chat.mock.calls[1][0]).not.toHaveProperty('tools');
     expect(markdown).toHaveBeenCalledWith(expect.stringContaining('hello after fallback'));
   });
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -579,25 +579,32 @@ export async function handleChatRequest(
           }
 
           xmlConversation.push({ role: 'assistant', content: responseText });
-          for (const xmlToolCall of xmlToolCalls) {
-            let resultText: string;
-            try {
-              const result = await vscode.lm.invokeTool(
-                xmlToolCall.name,
-                { input: xmlToolCall.parameters, toolInvocationToken: request.toolInvocationToken! },
-                token,
-              );
-              resultText = result.content
-                .filter((c): c is vscode.LanguageModelTextPart => c instanceof vscode.LanguageModelTextPart)
-                .map(c => c.value)
-                .join('');
-            } catch (invokeError) {
-              resultText = invokeError instanceof Error ? invokeError.message : 'Tool execution failed';
-            }
-            // Use 'user' role for tool results in the XML fallback path — models that fail
-            // JSON function calling have no training data for the 'tool' role either.
-            xmlConversation.push({ role: 'user', content: `[Tool result: ${xmlToolCall.name}]\n${resultText}` });
+          // The XML system prompt instructs models to call ONE tool per response.
+          // If a model emits multiple tool tags, execute only the first to honour
+          // that contract and avoid confusing follow-up context.
+          const [xmlToolCall] = xmlToolCalls;
+          if (xmlToolCalls.length > 1) {
+            outputChannel?.warn(
+              `[client] XML fallback extracted ${xmlToolCalls.length} tool calls; executing only the first (${xmlToolCall.name}) to comply with 'ONE tool per response' contract.`,
+            );
           }
+          let resultText: string;
+          try {
+            const result = await vscode.lm.invokeTool(
+              xmlToolCall.name,
+              { input: xmlToolCall.parameters, toolInvocationToken: request.toolInvocationToken! },
+              token,
+            );
+            resultText = result.content
+              .filter((c): c is vscode.LanguageModelTextPart => c instanceof vscode.LanguageModelTextPart)
+              .map(c => c.value)
+              .join('');
+          } catch (invokeError) {
+            resultText = invokeError instanceof Error ? invokeError.message : 'Tool execution failed';
+          }
+          // Use 'user' role for tool results in the XML fallback path — models that fail
+          // JSON function calling have no training data for the 'tool' role either.
+          xmlConversation.push({ role: 'user', content: `[Tool result: ${xmlToolCall.name}]\n${resultText}` });
 
           correctedOnce = false;
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,11 +8,16 @@ import { getCloudOllamaClient, getOllamaClient, testConnection } from './client.
 import { OllamaInlineCompletionProvider } from './completions.js';
 import { createDiagnosticsLogger, getConfiguredLogLevel, type DiagnosticsLogger } from './diagnostics.js';
 import { reportError } from './errorHandler.js';
-import { createXmlStreamFilter, formatXmlLikeResponseForDisplay } from './formatting';
+import { createXmlStreamFilter, formatXmlLikeResponseForDisplay, stripXmlContextTags } from './formatting';
 import { registerModelfileManager } from './modelfiles.js';
 import { isThinkingModelId, OllamaChatModelProvider } from './provider.js';
 import { registerSidebar, type SidebarProfilingSnapshot } from './sidebar.js';
-import { isToolsNotSupportedError, normalizeToolParameters } from './toolUtils.js';
+import {
+  buildXmlToolSystemPrompt,
+  extractXmlToolCalls,
+  isToolsNotSupportedError,
+  normalizeToolParameters,
+} from './toolUtils.js';
 
 const LANGUAGE_MODEL_VENDOR = 'selfagency-opilot';
 const PROVIDER_MODEL_ID_PREFIX = 'ollama:';
@@ -446,6 +451,7 @@ export async function handleChatRequest(
 
       // Tool invocation loop — only when VS Code tools and an invocation token are available.
       const vscodeLmTools = vscode.lm.tools ?? [];
+      let useXmlFallback = false;
       if (vscodeLmTools.length > 0 && request.toolInvocationToken) {
         const ollamaTools: Tool[] = vscodeLmTools.map(t => ({
           type: 'function',
@@ -477,6 +483,7 @@ export async function handleChatRequest(
               outputChannel?.warn(
                 `[client] disabling tools for @ollama request on model ${modelId}: ${String(toolError)}`,
               );
+              useXmlFallback = true;
               break;
             }
             throw toolError;
@@ -486,7 +493,7 @@ export async function handleChatRequest(
           if (!toolCalls?.length) {
             // No tool invocations needed — render the response text and exit.
             if (roundResponse.message.content) {
-              stream.markdown(formatXmlLikeResponseForDisplay(roundResponse.message.content));
+              stream.markdown(formatXmlLikeResponseForDisplay(stripXmlContextTags(roundResponse.message.content)));
             }
             return;
           }
@@ -525,6 +532,76 @@ export async function handleChatRequest(
           }
         }
         // MAX_TOOL_ROUNDS reached — fall through to the streaming pass below.
+      }
+
+      if (useXmlFallback && request.toolInvocationToken) {
+        outputChannel?.info(`[client] attempting XML tool call fallback for model ${modelId}`);
+        const toolNames = new Set(vscodeLmTools.map(t => t.name));
+        const xmlSystemPrompt = buildXmlToolSystemPrompt(vscodeLmTools);
+        const existingSystem = (ollamaMessages as Message[]).filter(m => m.role === 'system');
+        const nonSystem = (ollamaMessages as Message[]).filter(m => m.role !== 'system');
+        const xmlConversation: Message[] = [
+          ...existingSystem,
+          { role: 'system', content: xmlSystemPrompt },
+          ...nonSystem,
+        ];
+
+        const MAX_XML_ROUNDS = 5;
+        let correctedOnce = false;
+        for (let xmlRound = 0; xmlRound < MAX_XML_ROUNDS; xmlRound++) {
+          if (token.isCancellationRequested) return;
+
+          const xmlResponse = (await effectiveClient.chat({
+            model: modelId,
+            messages: xmlConversation,
+            stream: false,
+          })) as ChatResponse;
+
+          const responseText = xmlResponse.message.content ?? '';
+          const xmlToolCalls = extractXmlToolCalls(responseText, toolNames);
+
+          if (!xmlToolCalls.length) {
+            if (!correctedOnce && !responseText.trim() && xmlRound < MAX_XML_ROUNDS - 1) {
+              correctedOnce = true;
+              xmlConversation.push({ role: 'assistant', content: responseText });
+              xmlConversation.push({
+                role: 'user',
+                content:
+                  `Your previous response was empty. If you need information, emit a single XML tool call — no markdown fences, no prose. ` +
+                  `If you already have enough information, answer in plain text. Available tools: ${[...toolNames].join(', ')}.`,
+              });
+              continue;
+            }
+            if (responseText.trim()) {
+              stream.markdown(formatXmlLikeResponseForDisplay(stripXmlContextTags(responseText)));
+            }
+            return;
+          }
+
+          xmlConversation.push({ role: 'assistant', content: responseText });
+          for (const xmlToolCall of xmlToolCalls) {
+            let resultText: string;
+            try {
+              const result = await vscode.lm.invokeTool(
+                xmlToolCall.name,
+                { input: xmlToolCall.parameters, toolInvocationToken: request.toolInvocationToken! },
+                token,
+              );
+              resultText = result.content
+                .filter((c): c is vscode.LanguageModelTextPart => c instanceof vscode.LanguageModelTextPart)
+                .map(c => c.value)
+                .join('');
+            } catch (invokeError) {
+              resultText = invokeError instanceof Error ? invokeError.message : 'Tool execution failed';
+            }
+            // Use 'user' role for tool results in the XML fallback path — models that fail
+            // JSON function calling have no training data for the 'tool' role either.
+            xmlConversation.push({ role: 'user', content: `[Tool result: ${xmlToolCall.name}]\n${resultText}` });
+          }
+
+          correctedOnce = false;
+        }
+        // MAX_XML_ROUNDS exhausted — fall through to the streaming pass below.
       }
 
       const shouldThinkInitial = isThinkingModelId(modelId);

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -31,6 +31,7 @@ export function createXmlStreamFilter(): XmlStreamFilter {
     'selection',
     'file_context',
     'user',
+    'userRequest',
     'workspaces',
     'workspace',
     'session',
@@ -40,6 +41,11 @@ export function createXmlStreamFilter(): XmlStreamFilter {
     'userData',
     'profile',
     'history',
+    'system',
+    'systemPrompt',
+    'chatHistory',
+    'contextWindow',
+    'injectedContext',
   ]);
   const parser = new Saxophone();
   let skipDepth = 0;

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -24,7 +24,7 @@ import {
 import { getCloudOllamaClient, getContextLengthOverride, getOllamaClient } from './client';
 import type { DiagnosticsLogger } from './diagnostics.js';
 import { reportError } from './errorHandler.js';
-import { createXmlStreamFilter, formatXmlLikeResponseForDisplay } from './formatting';
+import { createXmlStreamFilter, formatXmlLikeResponseForDisplay, stripXmlContextTags } from './formatting';
 import { isToolsNotSupportedError, normalizeToolParameters } from './toolUtils.js';
 
 const MODEL_LIST_REFRESH_MIN_INTERVAL_MS = 5_000;
@@ -699,7 +699,9 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
             progress.report(new LanguageModelTextPart('\n\n---\n\n'));
           }
           // Non-stream fallback is complete text; safe to format XML-like blocks.
-          progress.report(new LanguageModelTextPart(formatXmlLikeResponseForDisplay(fallback.message.content)));
+          progress.report(
+            new LanguageModelTextPart(formatXmlLikeResponseForDisplay(stripXmlContextTags(fallback.message.content))),
+          );
           emittedOutput = true;
         }
 
@@ -771,7 +773,11 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
 
               if (rescued.message?.content) {
                 // Non-stream rescue is complete text; safe to format XML-like blocks.
-                progress.report(new LanguageModelTextPart(formatXmlLikeResponseForDisplay(rescued.message.content)));
+                progress.report(
+                  new LanguageModelTextPart(
+                    formatXmlLikeResponseForDisplay(stripXmlContextTags(rescued.message.content)),
+                  ),
+                );
               }
 
               if (rescued.message?.tool_calls && Array.isArray(rescued.message.tool_calls)) {

--- a/src/toolUtils.test.ts
+++ b/src/toolUtils.test.ts
@@ -150,4 +150,16 @@ describe('extractXmlToolCalls', () => {
     expect(result).toHaveLength(1);
     expect(result[0].parameters.query).toBe('newline tag');
   });
+
+  it('preserves left-to-right order across different tool names', () => {
+    const text =
+      '<read_file><path>first.ts</path></read_file>' +
+      '<search_files><query>second</query></search_files>' +
+      '<read_file><path>third.ts</path></read_file>';
+    const result = extractXmlToolCalls(text, new Set(['read_file', 'search_files']));
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ name: 'read_file', parameters: { path: 'first.ts' } });
+    expect(result[1]).toEqual({ name: 'search_files', parameters: { query: 'second' } });
+    expect(result[2]).toEqual({ name: 'read_file', parameters: { path: 'third.ts' } });
+  });
 });

--- a/src/toolUtils.test.ts
+++ b/src/toolUtils.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import { buildXmlToolSystemPrompt, extractXmlToolCalls } from './toolUtils.js';
+
+describe('buildXmlToolSystemPrompt', () => {
+  it('returns empty string for empty tools array', () => {
+    expect(buildXmlToolSystemPrompt([])).toBe('');
+  });
+
+  it('includes tool name and description', () => {
+    const result = buildXmlToolSystemPrompt([{ name: 'search_files', description: 'Search for files' }]);
+    expect(result).toContain('search_files');
+    expect(result).toContain('Search for files');
+  });
+
+  it('renders parameter names with description hints', () => {
+    const result = buildXmlToolSystemPrompt([
+      {
+        name: 'search_files',
+        description: 'Search for files',
+        inputSchema: {
+          properties: {
+            query: { description: 'The search query', type: 'string' },
+            path: { type: 'string' },
+          },
+          required: ['query'],
+        },
+      },
+    ]);
+    expect(result).toContain('<query>The search query</query>');
+    expect(result).toContain('<path>string (optional)</path>');
+    expect(result).not.toContain('<query>The search query (optional)</query>');
+  });
+
+  it('handles multiple tools', () => {
+    const result = buildXmlToolSystemPrompt([
+      { name: 'tool_a', description: 'First tool' },
+      { name: 'tool_b', description: 'Second tool' },
+    ]);
+    expect(result).toContain('tool_a');
+    expect(result).toContain('tool_b');
+  });
+
+  it('handles tools with no inputSchema', () => {
+    const result = buildXmlToolSystemPrompt([{ name: 'simple_tool' }]);
+    expect(result).toContain('<simple_tool>');
+    expect(result).toContain('</simple_tool>');
+  });
+});
+
+describe('extractXmlToolCalls', () => {
+  it('extracts a single tool call with parameters', () => {
+    const text = '<search_files><query>foo bar</query><path>/src</path></search_files>';
+    const result = extractXmlToolCalls(text, new Set(['search_files']));
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('search_files');
+    expect(result[0].parameters.query).toBe('foo bar');
+    expect(result[0].parameters.path).toBe('/src');
+  });
+
+  it('extracts multiple sequential tool calls', () => {
+    const text = '<read_file><path>a.ts</path></read_file><read_file><path>b.ts</path></read_file>';
+    const result = extractXmlToolCalls(text, new Set(['read_file']));
+    expect(result).toHaveLength(2);
+    expect(result[0].parameters.path).toBe('a.ts');
+    expect(result[1].parameters.path).toBe('b.ts');
+  });
+
+  it('ignores tags not in the known tools set', () => {
+    const text = '<unknown_tool><x>y</x></unknown_tool><search_files><query>q</query></search_files>';
+    const result = extractXmlToolCalls(text, new Set(['search_files']));
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('search_files');
+  });
+
+  it('strips markdown XML fences before extracting', () => {
+    const text = '```xml\n<search_files><query>hello</query></search_files>\n```';
+    const result = extractXmlToolCalls(text, new Set(['search_files']));
+    expect(result).toHaveLength(1);
+    expect(result[0].parameters.query).toBe('hello');
+  });
+
+  it('strips leading prose before XML block', () => {
+    const text = 'I will search for that.\n<search_files><query>test</query></search_files>';
+    const result = extractXmlToolCalls(text, new Set(['search_files']));
+    expect(result).toHaveLength(1);
+    expect(result[0].parameters.query).toBe('test');
+  });
+
+  it('returns empty array when no XML tool calls present', () => {
+    const result = extractXmlToolCalls('Just a plain text response.', new Set(['search_files']));
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns empty array for empty known tools set', () => {
+    const result = extractXmlToolCalls('<something><x>y</x></something>', new Set());
+    expect(result).toHaveLength(0);
+  });
+
+  it('handles parameters with multiline values', () => {
+    const text = '<write_file><content>line 1\nline 2\nline 3</content></write_file>';
+    const result = extractXmlToolCalls(text, new Set(['write_file']));
+    expect(result).toHaveLength(1);
+    expect(result[0].parameters.content).toBe('line 1\nline 2\nline 3');
+  });
+
+  it('handles tool calls with no parameters', () => {
+    const text = '<list_tools></list_tools>';
+    const result = extractXmlToolCalls(text, new Set(['list_tools']));
+    expect(result).toHaveLength(1);
+    expect(result[0].parameters).toEqual({});
+  });
+
+  it('trims whitespace from parameter values', () => {
+    const text = '<search_files><query>  spaced  </query></search_files>';
+    const result = extractXmlToolCalls(text, new Set(['search_files']));
+    expect(result[0].parameters.query).toBe('spaced');
+  });
+
+  it('handles tool names with underscores and hyphens', () => {
+    const text = '<vscode_codebase-search><q>x</q></vscode_codebase-search>';
+    const result = extractXmlToolCalls(text, new Set(['vscode_codebase-search']));
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('vscode_codebase-search');
+  });
+
+  it('tolerates trailing whitespace in opening tag (space before >)', () => {
+    const text = '<search_files ><query>spaced tag</query></search_files>';
+    const result = extractXmlToolCalls(text, new Set(['search_files']));
+    expect(result).toHaveLength(1);
+    expect(result[0].parameters.query).toBe('spaced tag');
+  });
+
+  it('tolerates attribute on opening tag', () => {
+    const text = '<search_files id="1"><query>attributed</query></search_files>';
+    const result = extractXmlToolCalls(text, new Set(['search_files']));
+    expect(result).toHaveLength(1);
+    expect(result[0].parameters.query).toBe('attributed');
+  });
+
+  it('tolerates trailing whitespace in closing tag', () => {
+    const text = '<search_files><query>close ws</query></search_files >';
+    const result = extractXmlToolCalls(text, new Set(['search_files']));
+    expect(result).toHaveLength(1);
+    expect(result[0].parameters.query).toBe('close ws');
+  });
+
+  it('tolerates newline inside opening tag', () => {
+    const text = '<search_files\n><query>newline tag</query></search_files>';
+    const result = extractXmlToolCalls(text, new Set(['search_files']));
+    expect(result).toHaveLength(1);
+    expect(result[0].parameters.query).toBe('newline tag');
+  });
+});

--- a/src/toolUtils.ts
+++ b/src/toolUtils.ts
@@ -91,22 +91,31 @@ export function extractXmlToolCalls(text: string, knownTools: Set<string>): XmlT
   const cleaned = cleanXml(text);
   const results: XmlToolCall[] = [];
 
-  for (const toolName of knownTools) {
-    const escapedName = toolName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    // Allow optional whitespace / attributes on the opening tag and optional
-    // whitespace before > on the closing tag — models sometimes emit extra
-    // spaces or attributes that would otherwise cause a silent parse failure.
-    const toolPattern = new RegExp(`<${escapedName}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${escapedName}\\s*>`, 'g');
+  if (knownTools.size === 0) {
+    return results;
+  }
 
-    for (const toolMatch of cleaned.matchAll(toolPattern)) {
-      const inner = toolMatch[1]; // capture group 1 = inner content
-      const params: Record<string, string> = {};
-      const paramPattern = /<([^/\s>]+)>([\s\S]*?)<\/\1>/g;
-      for (const paramMatch of inner.matchAll(paramPattern)) {
-        params[paramMatch[1]] = paramMatch[2].trim();
-      }
-      results.push({ name: toolName, parameters: params });
+  // Single-pass scan: one regex captures the tool name (group 1) and inner
+  // content (group 2), then we filter by knownTools.  This keeps parsing cost
+  // proportional to response size (not O(toolCount × responseLength)) and
+  // preserves left-to-right call order even when multiple different tools appear.
+  // Allow optional whitespace / attributes on the opening tag and optional
+  // whitespace before > on the closing tag — models sometimes emit extra
+  // spaces or attributes that would otherwise cause a silent parse failure.
+  const toolPattern = /<([A-Za-z0-9_:-]+)(?:\s[^>]*)?>([\s\S]*?)<\/\1\s*>/g;
+
+  for (const toolMatch of cleaned.matchAll(toolPattern)) {
+    const toolName = toolMatch[1];
+    if (!knownTools.has(toolName)) {
+      continue;
     }
+    const inner = toolMatch[2]; // capture group 2 = inner content
+    const params: Record<string, string> = {};
+    const paramPattern = /<([^/\s>]+)>([\s\S]*?)<\/\1>/g;
+    for (const paramMatch of inner.matchAll(paramPattern)) {
+      params[paramMatch[1]] = paramMatch[2].trim();
+    }
+    results.push({ name: toolName, parameters: params });
   }
 
   return results;

--- a/src/toolUtils.ts
+++ b/src/toolUtils.ts
@@ -18,4 +18,98 @@ export function isToolsNotSupportedError(error: unknown): boolean {
   );
 }
 
-export default { normalizeToolParameters, isToolsNotSupportedError };
+export interface XmlToolCall {
+  name: string;
+  parameters: Record<string, string>;
+}
+
+interface XmlToolInfo {
+  name: string;
+  description?: string;
+  inputSchema?: {
+    properties?: Record<string, { description?: string; type?: string }>;
+    required?: string[];
+  };
+}
+
+function cleanXml(text: string): string {
+  // Strip markdown XML fences (```xml...``` or ```...```)
+  let cleaned = text.replace(/```xml\s*/gi, '').replace(/```\s*/g, '');
+  // Strip leading non-tag chars and trailing non-tag chars (adapted from aispeck/llmxml _clean_xml)
+  cleaned = cleaned.replace(/^[^<]*/, '').replace(/[^>]*$/, '');
+  return cleaned;
+}
+
+export function buildXmlToolSystemPrompt(tools: readonly XmlToolInfo[]): string {
+  if (!tools.length) return '';
+
+  const toolDescriptions = tools.map(tool => {
+    const schema = tool.inputSchema as XmlToolInfo['inputSchema'];
+    const props = schema?.properties ?? {};
+    const required = new Set(schema?.required ?? []);
+    const paramLines = Object.entries(props).map(([name, s]) => {
+      const hint = s.description ?? s.type ?? 'value';
+      const optionalNote = required.has(name) ? '' : ' (optional)';
+      return `  <${name}>${hint}${optionalNote}</${name}>`;
+    });
+    return [`// ${tool.name}: ${tool.description ?? ''}`, `<${tool.name}>`, ...paramLines, `</${tool.name}>`].join(
+      '\n',
+    );
+  });
+
+  // Concrete few-shot example using the first tool in the list.
+  // Small models learn output format far better from a concrete example than from
+  // declarative rules alone.
+  const ex = tools[0];
+  const exProps = Object.entries((ex.inputSchema as XmlToolInfo['inputSchema'])?.properties ?? {}).slice(0, 2);
+  const exParamLines = exProps.map(([name]) => `  <${name}>example value</${name}>`);
+  const exCall = [`<${ex.name}>`, ...exParamLines, `</${ex.name}>`].join('\n');
+
+  return [
+    '# Tool Use',
+    '',
+    'You have access to tools. When you need to call a tool, follow these rules exactly:',
+    '1. Emit ONLY the raw XML block — no markdown fences (no ```xml), no prose before or after it.',
+    '2. Call ONE tool per response. Wait for the result before calling another tool.',
+    '3. When you have enough information to answer, respond in plain prose only. Do NOT include XML in your final answer.',
+    '4. Never use JSON function-call syntax.',
+    '',
+    '## Available tools',
+    '',
+    toolDescriptions.join('\n\n'),
+    '',
+    `## Example (${ex.name})`,
+    '',
+    '// Correct — bare XML only:',
+    exCall,
+    '',
+    `// After you receive [Tool result: ${ex.name}], answer in plain text.`,
+  ].join('\n');
+}
+
+export function extractXmlToolCalls(text: string, knownTools: Set<string>): XmlToolCall[] {
+  const cleaned = cleanXml(text);
+  const results: XmlToolCall[] = [];
+
+  for (const toolName of knownTools) {
+    const escapedName = toolName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // Allow optional whitespace / attributes on the opening tag and optional
+    // whitespace before > on the closing tag — models sometimes emit extra
+    // spaces or attributes that would otherwise cause a silent parse failure.
+    const toolPattern = new RegExp(`<${escapedName}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${escapedName}\\s*>`, 'g');
+
+    for (const toolMatch of cleaned.matchAll(toolPattern)) {
+      const inner = toolMatch[1]; // capture group 1 = inner content
+      const params: Record<string, string> = {};
+      const paramPattern = /<([^/\s>]+)>([\s\S]*?)<\/\1>/g;
+      for (const paramMatch of inner.matchAll(paramPattern)) {
+        params[paramMatch[1]] = paramMatch[2].trim();
+      }
+      results.push({ name: toolName, parameters: params });
+    }
+  }
+
+  return results;
+}
+
+export default { normalizeToolParameters, isToolsNotSupportedError, buildXmlToolSystemPrompt, extractXmlToolCalls };

--- a/tsup.config.mjs
+++ b/tsup.config.mjs
@@ -8,7 +8,7 @@ export default defineConfig({
   format: ['cjs'],
   platform: 'node',
   external: ['vscode'],
-  noExternal: ['ollama'],
+  noExternal: ['ollama', 'saxophone'],
   sourcemap: !production,
   minify: production,
   clean: true,


### PR DESCRIPTION
## Summary

When Ollama's native JSON function calling fails (`isToolsNotSupportedError`), instead of silently dropping all tool access, fall back to an XML-based tool call loop. This is the approach used by Cursor and Cline and is well-suited to small models (e.g. llama3.2) that reliably fail JSON constrained decoding.

## Changes

### `src/toolUtils.ts`
- **`buildXmlToolSystemPrompt(tools)`** — generates a structured system prompt with numbered rules (no markdown fences, one tool per response, plain prose for the final answer) and a concrete few-shot example rendered from the first tool in the list. Small models comply far better with an example of the expected output than with abstract declarations.
- **`extractXmlToolCalls(text, knownTools)`** — regex-based parser with fault-tolerant tag matching: allows spaces, attributes, and newlines on the opening tag; trailing whitespace on the closing tag. Uses capture group extraction instead of fragile `slice()` arithmetic.

### `src/extension.ts`
- XML fallback loop wired into `handleChatRequest()` alongside the JSON tool loop. Triggered by `isToolsNotSupportedError`, runs up to `MAX_XML_ROUNDS`.
- Tool results use `role: 'user'` with a `[Tool result: name]` header — small models that fail JSON function calling almost certainly have no `tool`-role training data either; using `user` role with a recognisable header matches the format from Cursor/Cline that does appear in their training data.
- Empty-response correction nudge is now accurate (describes the blank response, not a missing tool call) and gives the model both branches: emit XML if you still need a tool, or answer in plain prose.

### `src/toolUtils.test.ts` *(new file)*
20 unit tests covering: happy path, multiple sequential calls, multiline param values, empty params, fence stripping, prose prefix stripping, whitespace trimming, unknown tool filtering, and four fault-tolerant tag variants (space before `>`, attribute on opening tag, newline in opening tag, trailing whitespace in closing tag).

### `src/extension.test.ts`
Integration test for the full XML fallback path: JSON tools error → XML system prompt injected → plain-text response rendered via `stream.markdown`.

## Test results

```
357 passed, 0 failed
```