### PR TITLE
fix: harden XML context filtering and align Beans migration plan

### DIFF
--- a/.beans/ollama-models-vscode-0189--update-client-auth-and-host-helpers-for-transport.md
+++ b/.beans/ollama-models-vscode-0189--update-client-auth-and-host-helpers-for-transport.md
@@ -1,12 +1,18 @@
 ---
 # ollama-models-vscode-0189
 title: Update client auth and host helpers for transport
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-03-09T00:20:03Z
 updated_at: 2026-03-09T00:20:07Z
 parent: ollama-models-vscode-7d9m
+branch: fix/xu20-xml-context-leak
+pr: 45
 ---
 
 In `src/client.ts`, expose host/auth helpers for OpenAI transport while keeping SDK client creation for sidebar/model-management unchanged.
+
+## Summary of Changes
+
+Updated `src/client.ts` to expose host/auth accessors for the OpenAI-compatible transport while preserving SDK-based sidebar/model-management operations.

--- a/.beans/ollama-models-vscode-0189--update-client-auth-and-host-helpers-for-transport.md
+++ b/.beans/ollama-models-vscode-0189--update-client-auth-and-host-helpers-for-transport.md
@@ -1,0 +1,12 @@
+---
+# ollama-models-vscode-0189
+title: Update client auth and host helpers for transport
+status: todo
+type: task
+priority: normal
+created_at: 2026-03-09T00:20:03Z
+updated_at: 2026-03-09T00:20:07Z
+parent: ollama-models-vscode-7d9m
+---
+
+In `src/client.ts`, expose host/auth helpers for OpenAI transport while keeping SDK client creation for sidebar/model-management unchanged.

--- a/.beans/ollama-models-vscode-5loh--migrate-providerts-to-openai-compat-chat-calls.md
+++ b/.beans/ollama-models-vscode-5loh--migrate-providerts-to-openai-compat-chat-calls.md
@@ -1,12 +1,14 @@
 ---
 # ollama-models-vscode-5loh
 title: Migrate provider.ts to OpenAI-compat chat calls
-status: todo
+status: completed
 type: task
 priority: high
 created_at: 2026-03-09T00:20:03Z
 updated_at: 2026-03-09T00:20:07Z
 parent: ollama-models-vscode-7d9m
+branch: fix/xu20-xml-context-leak
+pr: 45
 ---
 
 Replace provider SDK chat calls with OpenAI transport while preserving:
@@ -16,3 +18,7 @@ Replace provider SDK chat calls with OpenAI transport while preserving:
 - stream->fallback behavior
 - cloud rescue ladder
 - XML sanitation behavior
+
+## Summary of Changes
+
+Migrated provider chat execution paths to use the OpenAI-compatible transport wrappers while preserving thinking/tool retry behavior, stream fallback semantics, cloud rescue ladder behavior, and XML sanitation parity.

--- a/.beans/ollama-models-vscode-5loh--migrate-providerts-to-openai-compat-chat-calls.md
+++ b/.beans/ollama-models-vscode-5loh--migrate-providerts-to-openai-compat-chat-calls.md
@@ -1,0 +1,18 @@
+---
+# ollama-models-vscode-5loh
+title: Migrate provider.ts to OpenAI-compat chat calls
+status: todo
+type: task
+priority: high
+created_at: 2026-03-09T00:20:03Z
+updated_at: 2026-03-09T00:20:07Z
+parent: ollama-models-vscode-7d9m
+---
+
+Replace provider SDK chat calls with OpenAI transport while preserving:
+
+- thinking retries
+- tools retries
+- stream->fallback behavior
+- cloud rescue ladder
+- XML sanitation behavior

--- a/.beans/ollama-models-vscode-7d9m--migrate-llm-interactions-to-openai-compat-transpor.md
+++ b/.beans/ollama-models-vscode-7d9m--migrate-llm-interactions-to-openai-compat-transpor.md
@@ -1,11 +1,13 @@
 ---
 # ollama-models-vscode-7d9m
 title: Migrate LLM interactions to OpenAI-compat transport (no flag)
-status: in-progress
+status: completed
 type: epic
 priority: high
 created_at: 2026-03-09T00:19:52Z
 updated_at: 2026-03-09T00:19:52Z
+branch: fix/xu20-xml-context-leak
+pr: 45
 ---
 
 ## Goal
@@ -14,15 +16,19 @@ Migrate chat/completion transport to Ollama OpenAI-compat HTTP endpoints while p
 
 ## Todo
 
-- [ ] Create shared OpenAI-compat transport (SSE + non-stream)
-- [ ] Add message/tool mapping helpers
-- [ ] Migrate provider chat path
-- [ ] Migrate @ollama participant path
-- [ ] Update client auth/host plumbing
-- [ ] Expand tests for new transport and parity
-- [ ] Run full validation and compile
+- [x] Create shared OpenAI-compat transport (SSE + non-stream)
+- [x] Add message/tool mapping helpers
+- [x] Migrate provider chat path
+- [x] Migrate @ollama participant path
+- [x] Update client auth/host plumbing
+- [x] Expand tests for new transport and parity
+- [x] Run full validation and compile
 
 ## Notes
 
 - No feature flag (pre-release product per user decision)
 - Preserve existing XML sanitation behavior
+
+## Summary of Changes
+
+Completed end-to-end migration of LLM interaction paths to OpenAI-compatible transport in provider and `@ollama` extension flows, added shared transport/mapping modules and tests, and validated via precommit, targeted tests, and compile.

--- a/.beans/ollama-models-vscode-7d9m--migrate-llm-interactions-to-openai-compat-transpor.md
+++ b/.beans/ollama-models-vscode-7d9m--migrate-llm-interactions-to-openai-compat-transpor.md
@@ -1,0 +1,28 @@
+---
+# ollama-models-vscode-7d9m
+title: Migrate LLM interactions to OpenAI-compat transport (no flag)
+status: in-progress
+type: epic
+priority: high
+created_at: 2026-03-09T00:19:52Z
+updated_at: 2026-03-09T00:19:52Z
+---
+
+## Goal
+
+Migrate chat/completion transport to Ollama OpenAI-compat HTTP endpoints while preserving Ollama SDK usage for sidebar/model-management.
+
+## Todo
+
+- [ ] Create shared OpenAI-compat transport (SSE + non-stream)
+- [ ] Add message/tool mapping helpers
+- [ ] Migrate provider chat path
+- [ ] Migrate @ollama participant path
+- [ ] Update client auth/host plumbing
+- [ ] Expand tests for new transport and parity
+- [ ] Run full validation and compile
+
+## Notes
+
+- No feature flag (pre-release product per user decision)
+- Preserve existing XML sanitation behavior

--- a/.beans/ollama-models-vscode-b02n--implement-message-and-tool-mapping-helpers.md
+++ b/.beans/ollama-models-vscode-b02n--implement-message-and-tool-mapping-helpers.md
@@ -1,12 +1,14 @@
 ---
 # ollama-models-vscode-b02n
 title: Implement message and tool mapping helpers
-status: todo
+status: completed
 type: task
 priority: high
 created_at: 2026-03-09T00:20:03Z
 updated_at: 2026-03-09T00:20:07Z
 parent: ollama-models-vscode-7d9m
+branch: fix/xu20-xml-context-leak
+pr: 45
 ---
 
 Add mapping layer for existing message/tool shapes to OpenAI chat-completions payload:
@@ -19,3 +21,7 @@ Add mapping layer for existing message/tool shapes to OpenAI chat-completions pa
 Acceptance:
 
 - parity with existing behavior for text/tools/images
+
+## Summary of Changes
+
+Added `src/openaiCompatMapping.ts` to map extension/provider message and tool structures into OpenAI-compatible payloads, including text/image part conversion, tool schema conversion, and tool-call/tool-result parity mapping.

--- a/.beans/ollama-models-vscode-b02n--implement-message-and-tool-mapping-helpers.md
+++ b/.beans/ollama-models-vscode-b02n--implement-message-and-tool-mapping-helpers.md
@@ -1,0 +1,21 @@
+---
+# ollama-models-vscode-b02n
+title: Implement message and tool mapping helpers
+status: todo
+type: task
+priority: high
+created_at: 2026-03-09T00:20:03Z
+updated_at: 2026-03-09T00:20:07Z
+parent: ollama-models-vscode-7d9m
+---
+
+Add mapping layer for existing message/tool shapes to OpenAI chat-completions payload:
+
+- role/content mapping
+- vision parts mapping
+- tool schema mapping
+- tool result message mapping
+
+Acceptance:
+
+- parity with existing behavior for text/tools/images

--- a/.beans/ollama-models-vscode-bt1d--create-openai-compat-transport-module.md
+++ b/.beans/ollama-models-vscode-bt1d--create-openai-compat-transport-module.md
@@ -1,12 +1,14 @@
 ---
 # ollama-models-vscode-bt1d
 title: Create OpenAI-compat transport module
-status: todo
+status: completed
 type: task
 priority: high
 created_at: 2026-03-09T00:20:03Z
 updated_at: 2026-03-09T00:20:07Z
 parent: ollama-models-vscode-7d9m
+branch: fix/xu20-xml-context-leak
+pr: 45
 ---
 
 Implement `src/openaiCompat.ts` with:
@@ -21,3 +23,7 @@ Acceptance:
 
 - Handles split chunks and [DONE]
 - Emits tool call deltas and text deltas robustly
+
+## Summary of Changes
+
+Implemented `src/openaiCompat.ts` with OpenAI-compatible chat-completions transport, including non-stream request support, streaming SSE parsing with split-chunk handling, response delta extraction, and robust terminal `[DONE]` handling.

--- a/.beans/ollama-models-vscode-bt1d--create-openai-compat-transport-module.md
+++ b/.beans/ollama-models-vscode-bt1d--create-openai-compat-transport-module.md
@@ -1,0 +1,23 @@
+---
+# ollama-models-vscode-bt1d
+title: Create OpenAI-compat transport module
+status: todo
+type: task
+priority: high
+created_at: 2026-03-09T00:20:03Z
+updated_at: 2026-03-09T00:20:07Z
+parent: ollama-models-vscode-7d9m
+---
+
+Implement `src/openaiCompat.ts` with:
+
+- headers/auth helpers
+- URL helper
+- streaming SSE parser
+- non-stream completions call
+- typed response fragments
+
+Acceptance:
+
+- Handles split chunks and [DONE]
+- Emits tool call deltas and text deltas robustly

--- a/.beans/ollama-models-vscode-tsud--run-validation-and-finalize-migration.md
+++ b/.beans/ollama-models-vscode-tsud--run-validation-and-finalize-migration.md
@@ -1,12 +1,18 @@
 ---
 # ollama-models-vscode-tsud
 title: Run validation and finalize migration
-status: todo
+status: completed
 type: task
 priority: normal
 created_at: 2026-03-09T00:20:03Z
 updated_at: 2026-03-09T00:20:07Z
 parent: ollama-models-vscode-7d9m
+branch: fix/xu20-xml-context-leak
+pr: 45
 ---
 
 Run compile and relevant tests; verify no sidebar regressions and update summary with results.
+
+## Summary of Changes
+
+Ran precommit validation, targeted unit tests for transport/mapping/provider/extension, and compile. All checks passed for this migration workstream.

--- a/.beans/ollama-models-vscode-tsud--run-validation-and-finalize-migration.md
+++ b/.beans/ollama-models-vscode-tsud--run-validation-and-finalize-migration.md
@@ -1,0 +1,12 @@
+---
+# ollama-models-vscode-tsud
+title: Run validation and finalize migration
+status: todo
+type: task
+priority: normal
+created_at: 2026-03-09T00:20:03Z
+updated_at: 2026-03-09T00:20:07Z
+parent: ollama-models-vscode-7d9m
+---
+
+Run compile and relevant tests; verify no sidebar regressions and update summary with results.

--- a/.beans/ollama-models-vscode-xa1x--migrate-extension-ollama-path-to-openai-transport.md
+++ b/.beans/ollama-models-vscode-xa1x--migrate-extension-ollama-path-to-openai-transport.md
@@ -1,12 +1,14 @@
 ---
 # ollama-models-vscode-xa1x
 title: Migrate extension @ollama path to OpenAI transport
-status: todo
+status: completed
 type: task
 priority: high
 created_at: 2026-03-09T00:20:03Z
 updated_at: 2026-03-09T00:20:07Z
 parent: ollama-models-vscode-7d9m
+branch: fix/xu20-xml-context-leak
+pr: 45
 ---
 
 Replace direct `effectiveClient.chat` in participant path with OpenAI-compat transport while preserving:
@@ -15,3 +17,7 @@ Replace direct `effectiveClient.chat` in participant path with OpenAI-compat tra
 - XML tool fallback
 - thinking/response formatting
 - error behavior
+
+## Summary of Changes
+
+Migrated the `@ollama` participant path in `src/extension.ts` from direct SDK chat calls to OpenAI-compatible transport wrappers while preserving tool invocation loops, XML tool fallback behavior, response formatting, and error-path handling.

--- a/.beans/ollama-models-vscode-xa1x--migrate-extension-ollama-path-to-openai-transport.md
+++ b/.beans/ollama-models-vscode-xa1x--migrate-extension-ollama-path-to-openai-transport.md
@@ -1,0 +1,17 @@
+---
+# ollama-models-vscode-xa1x
+title: Migrate extension @ollama path to OpenAI transport
+status: todo
+type: task
+priority: high
+created_at: 2026-03-09T00:20:03Z
+updated_at: 2026-03-09T00:20:07Z
+parent: ollama-models-vscode-7d9m
+---
+
+Replace direct `effectiveClient.chat` in participant path with OpenAI-compat transport while preserving:
+
+- tool invocation loops
+- XML tool fallback
+- thinking/response formatting
+- error behavior

--- a/.beans/ollama-models-vscode-xu20--fix-xml-context-tags-leaking-into-chat-output.md
+++ b/.beans/ollama-models-vscode-xu20--fix-xml-context-tags-leaking-into-chat-output.md
@@ -1,11 +1,11 @@
 ---
 # ollama-models-vscode-xu20
 title: Fix XML context tags leaking into chat output
-status: in-progress
+status: completed
 type: bug
 priority: high
 created_at: 2026-03-08T23:39:18Z
-updated_at: 2026-03-08T23:39:18Z
+updated_at: 2026-03-09T01:23:26Z
 ---
 
 ## Todo

--- a/.beans/ollama-models-vscode-xu20--fix-xml-context-tags-leaking-into-chat-output.md
+++ b/.beans/ollama-models-vscode-xu20--fix-xml-context-tags-leaking-into-chat-output.md
@@ -1,0 +1,21 @@
+---
+# ollama-models-vscode-xu20
+title: Fix XML context tags leaking into chat output
+status: in-progress
+type: bug
+priority: high
+created_at: 2026-03-08T23:39:18Z
+updated_at: 2026-03-08T23:39:18Z
+---
+
+## Todo
+
+- [ ] Add regression tests for repeated <user_info>/<workspace_info> leakage
+- [ ] Refactor shared context extraction/dedup helper
+- [ ] Unify non-stream fallback sanitation pipeline
+- [ ] Validate provider + @ollama paths
+- [ ] Run tests and compile
+
+## Notes
+
+User reports repeated XML context blocks in visible output. Goal: context tags should never be user-visible; non-context XML should still format to markdown.

--- a/.beans/ollama-models-vscode-ztdf--add-transport-and-parity-tests.md
+++ b/.beans/ollama-models-vscode-ztdf--add-transport-and-parity-tests.md
@@ -1,12 +1,14 @@
 ---
 # ollama-models-vscode-ztdf
 title: Add transport and parity tests
-status: todo
+status: completed
 type: task
 priority: high
 created_at: 2026-03-09T00:20:03Z
 updated_at: 2026-03-09T00:20:07Z
 parent: ollama-models-vscode-7d9m
+branch: fix/xu20-xml-context-leak
+pr: 45
 ---
 
 Add/extend tests:
@@ -19,3 +21,7 @@ Add/extend tests:
 Acceptance:
 
 - targeted suites green
+
+## Summary of Changes
+
+Added transport and mapping coverage in `src/openaiCompat.test.ts` and `src/openaiCompatMapping.test.ts`, and verified parity with provider/extension behavior through targeted suites including XML leakage regressions.

--- a/.beans/ollama-models-vscode-ztdf--add-transport-and-parity-tests.md
+++ b/.beans/ollama-models-vscode-ztdf--add-transport-and-parity-tests.md
@@ -1,0 +1,21 @@
+---
+# ollama-models-vscode-ztdf
+title: Add transport and parity tests
+status: todo
+type: task
+priority: high
+created_at: 2026-03-09T00:20:03Z
+updated_at: 2026-03-09T00:20:07Z
+parent: ollama-models-vscode-7d9m
+---
+
+Add/extend tests:
+
+- SSE parser edge cases
+- provider transport parity
+- extension path parity
+- XML leakage regression
+
+Acceptance:
+
+- targeted suites green

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,15 @@ name: Release
 
 on:
   push:
-    tags: ["v*"]
+    tags: ['v*']
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to release — plain major.minor.patch (e.g. 1.2.3). Use odd minor for pre-release (0.1.x), even minor for stable (0.2.x)."
+        description: 'Version to release — plain major.minor.patch (e.g. 1.2.3). Use odd minor for pre-release (0.1.x), even minor for stable (0.2.x).'
         required: true
         type: string
       pre_release:
-        description: "Publish as pre-release"
+        description: 'Publish as pre-release'
         required: false
         type: boolean
         default: false
@@ -186,8 +186,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
-          cache: "pnpm"
+          node-version: '22'
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -208,7 +208,7 @@ jobs:
         with:
           tag_name: ${{ needs.detect-tag.outputs.release_tag }}
           body_path: release-notes.md
-          files: "opilot.vsix"
+          files: 'opilot.vsix'
           draft: false
           prerelease: ${{ needs.detect-tag.outputs.is_prerelease == 'true' }}
         env:

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -144,6 +144,95 @@ describe('getOllamaClient', () => {
 });
 
 // ---------------------------------------------------------------------------
+// host/auth helper exports
+// ---------------------------------------------------------------------------
+
+describe('getOllamaHost / getOllamaAuthToken / getOllamaAuthHeaders / getCloudOllamaClient', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('getOllamaHost reads configured host and falls back to localhost', async () => {
+    vi.doMock('vscode', () => makeVscodeMock('http://configured-host:11434'));
+    vi.doMock('ollama', () => ({ Ollama: class {} }));
+
+    const { getOllamaHost } = await import('./client.js');
+    expect(getOllamaHost()).toBe('http://configured-host:11434');
+
+    vi.resetModules();
+    vi.doMock('vscode', () => makeVscodeMock(''));
+    vi.doMock('ollama', () => ({ Ollama: class {} }));
+    const { getOllamaHost: getHostWithDefault } = await import('./client.js');
+    expect(getHostWithDefault()).toBe('http://localhost:11434');
+  });
+
+  it('getOllamaAuthToken returns token from secret storage', async () => {
+    vi.doMock('vscode', () => makeVscodeMock());
+    vi.doMock('ollama', () => ({ Ollama: class {} }));
+
+    const context = {
+      secrets: { get: vi.fn().mockResolvedValue('secret-token') },
+    } as any;
+
+    const { getOllamaAuthToken } = await import('./client.js');
+    await expect(getOllamaAuthToken(context)).resolves.toBe('secret-token');
+  });
+
+  it('getOllamaAuthHeaders returns bearer header when token exists', async () => {
+    vi.doMock('vscode', () => makeVscodeMock());
+    vi.doMock('ollama', () => ({ Ollama: class {} }));
+
+    const context = {
+      secrets: { get: vi.fn().mockResolvedValue('secret-token') },
+    } as any;
+
+    const { getOllamaAuthHeaders } = await import('./client.js');
+    await expect(getOllamaAuthHeaders(context)).resolves.toEqual({
+      Authorization: 'Bearer secret-token',
+    });
+  });
+
+  it('getOllamaAuthHeaders returns undefined when token is missing', async () => {
+    vi.doMock('vscode', () => makeVscodeMock());
+    vi.doMock('ollama', () => ({ Ollama: class {} }));
+
+    const context = {
+      secrets: { get: vi.fn().mockResolvedValue(undefined) },
+    } as any;
+
+    const { getOllamaAuthHeaders } = await import('./client.js');
+    await expect(getOllamaAuthHeaders(context)).resolves.toBeUndefined();
+  });
+
+  it('getCloudOllamaClient reuses getOllamaClient behavior', async () => {
+    vi.doMock('vscode', () => makeVscodeMock('http://localhost:11434'));
+
+    const OllamaClass = vi.fn().mockImplementation(function (this: { config: unknown }, config: unknown) {
+      this.config = config;
+    });
+    vi.doMock('ollama', () => ({ Ollama: OllamaClass }));
+
+    const context = {
+      secrets: { get: vi.fn().mockResolvedValue('cloud-token') },
+    } as any;
+
+    const { getCloudOllamaClient } = await import('./client.js');
+    await getCloudOllamaClient(context);
+
+    expect(OllamaClass).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: 'http://localhost:11434',
+        headers: { Authorization: 'Bearer cloud-token' },
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // testConnection
 // ---------------------------------------------------------------------------
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,26 @@
 import { Ollama } from 'ollama';
 import { ExtensionContext, workspace } from 'vscode';
 
+export function getOllamaHost(): string {
+  const config = workspace.getConfiguration('ollama');
+  return config.get<string>('host') || 'http://localhost:11434';
+}
+
+export async function getOllamaAuthToken(context: ExtensionContext): Promise<string | undefined> {
+  return context.secrets.get('ollama-auth-token');
+}
+
+export async function getOllamaAuthHeaders(context: ExtensionContext): Promise<Record<string, string> | undefined> {
+  const authToken = await getOllamaAuthToken(context);
+  if (!authToken) {
+    return undefined;
+  }
+
+  return {
+    Authorization: `Bearer ${authToken}`,
+  };
+}
+
 /**
  * Get or create an Ollama client instance configured with the current settings.
  *
@@ -17,9 +37,8 @@ import { ExtensionContext, workspace } from 'vscode';
  *   mechanism instead.
  */
 export async function getOllamaClient(context: ExtensionContext): Promise<Ollama> {
-  const config = workspace.getConfiguration('ollama');
-  const host = config.get<string>('host') || 'http://localhost:11434';
-  const authToken = await context.secrets.get('ollama-auth-token');
+  const host = getOllamaHost();
+  const authToken = await getOllamaAuthToken(context);
 
   const clientConfig: { host: string; headers?: Record<string, string> } = {
     host,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,11 +30,11 @@ const LANGUAGE_MODEL_VENDOR = 'selfagency-opilot';
 const PROVIDER_MODEL_ID_PREFIX = 'ollama:';
 let builtInOllamaConflictPromptInProgress = false;
 
-function toRuntimeModelId(modelId: string): string {
+export function toRuntimeModelId(modelId: string): string {
   return modelId.startsWith(PROVIDER_MODEL_ID_PREFIX) ? modelId.slice(PROVIDER_MODEL_ID_PREFIX.length) : modelId;
 }
 
-function mapOpenAiToolCallsToOllamaLike(toolCalls: unknown):
+export function mapOpenAiToolCallsToOllamaLike(toolCalls: unknown):
   | Array<{
       id?: string;
       function?: {
@@ -195,7 +195,7 @@ async function openAiCompatChatOnce(params: {
 
 // normalizeToolParameters/isToolsNotSupportedError moved to src/toolUtils.ts
 
-function isSelectedAction(selection: unknown, actionLabel: string): boolean {
+export function isSelectedAction(selection: unknown, actionLabel: string): boolean {
   if (typeof selection === 'string') {
     return selection === actionLabel;
   }
@@ -300,7 +300,7 @@ export function handleConfigurationChange(
   onAutoStartChange?.(enabled);
 }
 
-function formatBytes(bytes: number): string {
+export function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 ** 2) return `${(bytes / 1024).toFixed(1)} KB`;
   if (bytes < 1024 ** 3) return `${(bytes / 1024 ** 2).toFixed(1)} MB`;
@@ -372,7 +372,7 @@ export async function handleConnectionTestFailure(
   }
 }
 
-function getOllamaServerLogPath(): string | null {
+export function getOllamaServerLogPath(): string | null {
   const platform = process.platform;
   if (platform === 'darwin') {
     return join(homedir(), '.ollama', 'logs', 'server.log');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import type { ChatResponse, Message, Ollama, Tool } from 'ollama';
 import * as vscode from 'vscode';
-import { getCloudOllamaClient, getOllamaClient, testConnection } from './client.js';
+import { getCloudOllamaClient, getOllamaAuthToken, getOllamaClient, getOllamaHost, testConnection } from './client.js';
 import { OllamaInlineCompletionProvider } from './completions.js';
 import { createDiagnosticsLogger, getConfiguredLogLevel, type DiagnosticsLogger } from './diagnostics.js';
 import { reportError } from './errorHandler.js';
@@ -15,6 +15,8 @@ import {
   splitLeadingXmlContextBlocks,
 } from './formatting';
 import { registerModelfileManager } from './modelfiles.js';
+import { chatCompletionsOnce, chatCompletionsStream } from './openaiCompat.js';
+import { ollamaMessagesToOpenAICompat, ollamaToolsToOpenAICompat } from './openaiCompatMapping.js';
 import { isThinkingModelId, OllamaChatModelProvider } from './provider.js';
 import { registerSidebar, type SidebarProfilingSnapshot } from './sidebar.js';
 import {
@@ -30,6 +32,165 @@ let builtInOllamaConflictPromptInProgress = false;
 
 function toRuntimeModelId(modelId: string): string {
   return modelId.startsWith(PROVIDER_MODEL_ID_PREFIX) ? modelId.slice(PROVIDER_MODEL_ID_PREFIX.length) : modelId;
+}
+
+function mapOpenAiToolCallsToOllamaLike(toolCalls: unknown):
+  | Array<{
+      id?: string;
+      function?: {
+        name?: string;
+        arguments?: Record<string, unknown>;
+      };
+    }>
+  | undefined {
+  if (!Array.isArray(toolCalls) || toolCalls.length === 0) {
+    return undefined;
+  }
+
+  const mapped: Array<{
+    id?: string;
+    function?: {
+      name?: string;
+      arguments?: Record<string, unknown>;
+    };
+  }> = [];
+
+  for (const call of toolCalls) {
+    if (!call || typeof call !== 'object') {
+      continue;
+    }
+
+    const typed = call as {
+      id?: unknown;
+      function?: {
+        name?: unknown;
+        arguments?: unknown;
+      };
+    };
+
+    let parsedArgs: Record<string, unknown> = {};
+    if (typeof typed.function?.arguments === 'string' && typed.function.arguments.trim()) {
+      try {
+        const parsed = JSON.parse(typed.function.arguments);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          parsedArgs = parsed as Record<string, unknown>;
+        }
+      } catch {
+        parsedArgs = {};
+      }
+    }
+
+    mapped.push({
+      id: typeof typed.id === 'string' ? typed.id : undefined,
+      function: {
+        name: typeof typed.function?.name === 'string' ? typed.function.name : undefined,
+        arguments: parsedArgs,
+      },
+    });
+  }
+
+  return mapped;
+}
+
+async function openAiCompatStreamChat(params: {
+  modelId: string;
+  messages: Message[];
+  tools?: Tool[];
+  shouldThink: boolean;
+  effectiveClient: Ollama;
+  extensionContext?: vscode.ExtensionContext;
+  signal?: AbortSignal;
+}): Promise<AsyncIterable<ChatResponse>> {
+  try {
+    const baseUrl = getOllamaHost();
+    const authToken = params.extensionContext ? await getOllamaAuthToken(params.extensionContext) : undefined;
+
+    const stream = chatCompletionsStream({
+      baseUrl,
+      authToken,
+      signal: params.signal,
+      request: {
+        model: params.modelId,
+        messages: ollamaMessagesToOpenAICompat(params.messages),
+        tools: ollamaToolsToOpenAICompat(params.tools),
+        ...(params.shouldThink ? { think: true } : {}),
+      },
+    });
+
+    return (async function* (): AsyncGenerator<ChatResponse> {
+      for await (const chunk of stream) {
+        const choice = chunk.choices?.[0];
+        const delta = choice?.delta;
+        const content = typeof delta?.content === 'string' ? delta.content : '';
+        const mappedToolCalls = mapOpenAiToolCallsToOllamaLike(delta?.tool_calls);
+
+        yield {
+          message: {
+            role: 'assistant',
+            content,
+            ...(mappedToolCalls ? { tool_calls: mappedToolCalls } : {}),
+          },
+          done: choice?.finish_reason != null,
+        } as ChatResponse;
+      }
+    })();
+  } catch {
+    return params.effectiveClient.chat({
+      model: params.modelId,
+      messages: params.messages,
+      stream: true,
+      ...(params.tools ? { tools: params.tools } : {}),
+      ...(params.shouldThink ? { think: true } : {}),
+    });
+  }
+}
+
+async function openAiCompatChatOnce(params: {
+  modelId: string;
+  messages: Message[];
+  tools?: Tool[];
+  shouldThink: boolean;
+  effectiveClient: Ollama;
+  extensionContext?: vscode.ExtensionContext;
+  signal?: AbortSignal;
+}): Promise<ChatResponse> {
+  try {
+    const baseUrl = getOllamaHost();
+    const authToken = params.extensionContext ? await getOllamaAuthToken(params.extensionContext) : undefined;
+
+    const response = await chatCompletionsOnce({
+      baseUrl,
+      authToken,
+      signal: params.signal,
+      request: {
+        model: params.modelId,
+        messages: ollamaMessagesToOpenAICompat(params.messages),
+        tools: ollamaToolsToOpenAICompat(params.tools),
+        ...(params.shouldThink ? { think: true } : {}),
+      },
+    });
+
+    const choice = response.choices?.[0];
+    const content = typeof choice?.message?.content === 'string' ? choice.message.content : '';
+    const mappedToolCalls = mapOpenAiToolCallsToOllamaLike(choice?.message?.tool_calls);
+
+    return {
+      message: {
+        role: 'assistant',
+        content,
+        ...(mappedToolCalls ? { tool_calls: mappedToolCalls } : {}),
+      },
+      done: true,
+    } as ChatResponse;
+  } catch {
+    return (await params.effectiveClient.chat({
+      model: params.modelId,
+      messages: params.messages,
+      stream: false,
+      ...(params.tools ? { tools: params.tools } : {}),
+      ...(params.shouldThink ? { think: true } : {}),
+    })) as ChatResponse;
+  }
 }
 
 // normalizeToolParameters/isToolsNotSupportedError moved to src/toolUtils.ts
@@ -439,13 +600,14 @@ export async function handleChatRequest(
 
           let roundResponse: ChatResponse;
           try {
-            roundResponse = (await effectiveClient.chat({
-              model: modelId,
+            roundResponse = await openAiCompatChatOnce({
+              modelId,
               messages: ollamaMessages as Message[],
-              stream: false,
               tools: ollamaTools,
-              ...(shouldThinkInToolLoop ? { think: true } : {}),
-            })) as ChatResponse;
+              shouldThink: shouldThinkInToolLoop,
+              effectiveClient,
+              extensionContext,
+            });
           } catch (toolError) {
             if (isToolsNotSupportedError(toolError)) {
               outputChannel?.warn(
@@ -519,11 +681,13 @@ export async function handleChatRequest(
         for (let xmlRound = 0; xmlRound < MAX_XML_ROUNDS; xmlRound++) {
           if (token.isCancellationRequested) return;
 
-          const xmlResponse = (await effectiveClient.chat({
-            model: modelId,
+          const xmlResponse = await openAiCompatChatOnce({
+            modelId,
             messages: xmlConversation,
-            stream: false,
-          })) as ChatResponse;
+            shouldThink: false,
+            effectiveClient,
+            extensionContext,
+          });
 
           const responseText = xmlResponse.message.content ?? '';
           const xmlToolCalls = extractXmlToolCalls(responseText, toolNames);
@@ -585,11 +749,12 @@ export async function handleChatRequest(
       let response: AsyncIterable<ChatResponse>;
 
       try {
-        response = await effectiveClient.chat({
-          model: modelId,
+        response = await openAiCompatStreamChat({
+          modelId,
           messages: ollamaMessages as Message[],
-          stream: true,
-          ...(shouldThink ? { think: true } : {}),
+          shouldThink,
+          effectiveClient,
+          extensionContext,
         });
       } catch (chatError) {
         const supportsThinkingError =
@@ -599,18 +764,22 @@ export async function handleChatRequest(
           chatError.message.toLowerCase().includes('does not support thinking');
 
         if (supportsThinkingError) {
-          response = await effectiveClient.chat({
-            model: modelId,
+          response = await openAiCompatStreamChat({
+            modelId,
             messages: ollamaMessages as Message[],
-            stream: true,
+            shouldThink: false,
+            effectiveClient,
+            extensionContext,
           });
         } else if (isToolsNotSupportedError(chatError)) {
           outputChannel?.warn(`[client] model ${modelId} rejected tools; retrying stream without tools/thinking`);
           shouldThink = false;
-          response = await effectiveClient.chat({
-            model: modelId,
+          response = await openAiCompatStreamChat({
+            modelId,
             messages: ollamaMessages as Message[],
-            stream: true,
+            shouldThink: false,
+            effectiveClient,
+            extensionContext,
           });
         } else {
           throw chatError;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,12 @@ import { getCloudOllamaClient, getOllamaClient, testConnection } from './client.
 import { OllamaInlineCompletionProvider } from './completions.js';
 import { createDiagnosticsLogger, getConfiguredLogLevel, type DiagnosticsLogger } from './diagnostics.js';
 import { reportError } from './errorHandler.js';
-import { createXmlStreamFilter, formatXmlLikeResponseForDisplay, stripXmlContextTags } from './formatting';
+import {
+  createXmlStreamFilter,
+  dedupeXmlContextBlocksByTag,
+  sanitizeNonStreamingModelOutput,
+  splitLeadingXmlContextBlocks,
+} from './formatting';
 import { registerModelfileManager } from './modelfiles.js';
 import { isThinkingModelId, OllamaChatModelProvider } from './provider.js';
 import { registerSidebar, type SidebarProfilingSnapshot } from './sidebar.js';
@@ -385,7 +390,6 @@ export async function handleChatRequest(
       // only (stopping as soon as a tag does not begin at index 0), collected into systemContextParts,
       // deduplicated by tag name (most-recent wins), then prepended as a single Ollama `system` message.
       // This keeps IDE-injected context separate from the conversational user turn.
-      const XML_CONTEXT_TAG_RE = /<([a-zA-Z_][a-zA-Z0-9_.-]*)[^>]*>[\s\S]*?<\/\1>/gi;
       const systemContextParts: string[] = [];
 
       const ollamaMessages: (Message & { tool_call_id?: string })[] = messages.map(msg => {
@@ -395,30 +399,11 @@ export async function handleChatRequest(
           .map(p => p.value)
           .join('');
         if (isUser) {
-          let remainingText = content;
-          let hadLeadingContext = false;
-
-          if (remainingText.trimStart().startsWith('<')) {
-            remainingText = remainingText.trimStart();
-            // Iteratively consume XML_CONTEXT_TAG_RE matches only when they appear at the very start
-            // of the remaining text. As soon as a match is not at index 0, we stop extracting.
-            XML_CONTEXT_TAG_RE.lastIndex = 0;
-            // eslint-disable-next-line no-constant-condition
-            while (true) {
-              const match = XML_CONTEXT_TAG_RE.exec(remainingText);
-              if (!match || match.index !== 0) {
-                break;
-              }
-              const matchedText = match[0];
-              systemContextParts.push(matchedText.trim());
-              remainingText = remainingText.slice(matchedText.length).trimStart();
-              hadLeadingContext = true;
-              // Reset lastIndex because we've sliced the string.
-              XML_CONTEXT_TAG_RE.lastIndex = 0;
-            }
+          const split = splitLeadingXmlContextBlocks(content);
+          if (split.contextBlocks.length > 0) {
+            systemContextParts.push(...split.contextBlocks);
           }
-
-          content = hadLeadingContext ? remainingText : content.trim();
+          content = split.content;
         }
         return {
           role: (isUser ? 'user' : 'assistant') as 'user' | 'assistant',
@@ -426,24 +411,7 @@ export async function handleChatRequest(
         };
       });
 
-      // Deduplicate context blocks by tag type, keeping only the most recent occurrence
-      const latestByTag = new Map<string, string>();
-      for (let i = systemContextParts.length - 1; i >= 0; i--) {
-        const part = systemContextParts[i];
-        XML_CONTEXT_TAG_RE.lastIndex = 0;
-        let match: RegExpExecArray | null;
-        // Use a loop in case a single part contains multiple context blocks
-        // (we still only keep the latest block per tag type).
-        while ((match = XML_CONTEXT_TAG_RE.exec(part)) !== null) {
-          const tagName = match[1];
-          if (!latestByTag.has(tagName)) {
-            latestByTag.set(tagName, match[0]);
-          }
-        }
-      }
-
-      // Preserve insertion order (latest occurrence of each tag wins, collected in reverse above)
-      const dedupedContextParts = [...latestByTag.values()].reverse();
+      const dedupedContextParts = dedupeXmlContextBlocksByTag(systemContextParts);
 
       if (dedupedContextParts.length > 0) {
         ollamaMessages.unshift({ role: 'system', content: dedupedContextParts.join('\n\n') });
@@ -493,7 +461,7 @@ export async function handleChatRequest(
           if (!toolCalls?.length) {
             // No tool invocations needed — render the response text and exit.
             if (roundResponse.message.content) {
-              stream.markdown(formatXmlLikeResponseForDisplay(stripXmlContextTags(roundResponse.message.content)));
+              stream.markdown(sanitizeNonStreamingModelOutput(roundResponse.message.content));
             }
             return;
           }
@@ -573,7 +541,7 @@ export async function handleChatRequest(
               continue;
             }
             if (responseText.trim()) {
-              stream.markdown(formatXmlLikeResponseForDisplay(stripXmlContextTags(responseText)));
+              stream.markdown(sanitizeNonStreamingModelOutput(responseText));
             }
             return;
           }

--- a/src/extension.utils.test.ts
+++ b/src/extension.utils.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+
+  vi.doMock('vscode', () => ({
+    workspace: {
+      getConfiguration: vi.fn(() => ({ get: vi.fn(), update: vi.fn() })),
+      onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      openTextDocument: vi.fn(),
+    },
+    window: {
+      createOutputChannel: vi.fn(() => ({
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+        log: vi.fn(),
+        show: vi.fn(),
+      })),
+      showErrorMessage: vi.fn(),
+      showWarningMessage: vi.fn(),
+      showInformationMessage: vi.fn(),
+      showTextDocument: vi.fn(),
+    },
+    commands: {
+      executeCommand: vi.fn(),
+      registerCommand: vi.fn(() => ({ dispose: vi.fn() })),
+    },
+    lm: {
+      selectChatModels: vi.fn().mockResolvedValue([]),
+      registerLanguageModelChatProvider: vi.fn(() => ({ dispose: vi.fn() })),
+      tools: [],
+      invokeTool: vi.fn(),
+    },
+    languages: {
+      registerInlineCompletionItemProvider: vi.fn(() => ({ dispose: vi.fn() })),
+    },
+    chat: {
+      createChatParticipant: vi.fn(() => ({ iconPath: undefined, dispose: vi.fn() })),
+    },
+    Uri: {
+      file: vi.fn((path: string) => ({ fsPath: path })),
+      joinPath: vi.fn((_base: unknown, p: string) => ({ fsPath: p })),
+    },
+    LanguageModelTextPart: class {
+      constructor(public value: string) {}
+    },
+    LanguageModelChatMessage: {
+      User: vi.fn((content: string) => ({ role: 'user', content })),
+      Assistant: vi.fn((content: string) => ({ role: 'assistant', content })),
+    },
+    LanguageModelChatMessageRole: { User: 1, Assistant: 2 },
+    ChatRequestTurn: class {},
+    ChatResponseTurn: class {},
+    ChatResponseMarkdownPart: class {},
+    InlineCompletionItem: class {
+      constructor(public readonly insertText: string) {}
+    },
+    ConfigurationTarget: { Global: 1 },
+  }));
+
+  vi.doMock('./client.js', () => ({
+    getOllamaClient: vi.fn(),
+    getCloudOllamaClient: vi.fn(),
+    getOllamaAuthToken: vi.fn(),
+    getOllamaHost: vi.fn(() => 'http://localhost:11434'),
+    testConnection: vi.fn(),
+  }));
+
+  vi.doMock('./diagnostics.js', () => ({
+    createDiagnosticsLogger: vi.fn(() => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      exception: vi.fn(),
+    })),
+    getConfiguredLogLevel: vi.fn(() => 'info'),
+  }));
+
+  vi.doMock('./provider.js', () => ({
+    OllamaChatModelProvider: class {
+      setAuthToken = vi.fn();
+    },
+    isThinkingModelId: vi.fn(() => false),
+  }));
+
+  vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
+  vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
+});
+
+describe('extension utility helpers', () => {
+  it('toRuntimeModelId removes provider prefix only when present', async () => {
+    const { toRuntimeModelId } = await import('./extension.js');
+    expect(toRuntimeModelId('ollama:llama3.2:latest')).toBe('llama3.2:latest');
+    expect(toRuntimeModelId('llama3.2:latest')).toBe('llama3.2:latest');
+  });
+
+  it('mapOpenAiToolCallsToOllamaLike maps ids/names and parses arguments safely', async () => {
+    const { mapOpenAiToolCallsToOllamaLike } = await import('./extension.js');
+
+    const mapped = mapOpenAiToolCallsToOllamaLike([
+      { id: 'c1', function: { name: 'search', arguments: '{"q":"abc"}' } },
+      { id: 'c2', function: { name: 'broken', arguments: '{bad json' } },
+      null,
+    ]);
+
+    expect(mapped).toEqual([
+      { id: 'c1', function: { name: 'search', arguments: { q: 'abc' } } },
+      { id: 'c2', function: { name: 'broken', arguments: {} } },
+    ]);
+
+    expect(mapOpenAiToolCallsToOllamaLike([])).toBeUndefined();
+    expect(mapOpenAiToolCallsToOllamaLike('bad')).toBeUndefined();
+  });
+
+  it('isSelectedAction supports string and {title} selections', async () => {
+    const { isSelectedAction } = await import('./extension.js');
+    expect(isSelectedAction('Reload Window', 'Reload Window')).toBe(true);
+    expect(isSelectedAction({ title: 'Reload Window' }, 'Reload Window')).toBe(true);
+    expect(isSelectedAction({ title: 'Other' }, 'Reload Window')).toBe(false);
+    expect(isSelectedAction(undefined, 'Reload Window')).toBe(false);
+  });
+
+  it('formatBytes handles B/KB/MB/GB thresholds', async () => {
+    const { formatBytes } = await import('./extension.js');
+    expect(formatBytes(999)).toBe('999 B');
+    expect(formatBytes(1024)).toBe('1.0 KB');
+    expect(formatBytes(1024 ** 2)).toBe('1.0 MB');
+    expect(formatBytes(5 * 1024 ** 3)).toBe('5.00 GB');
+  });
+
+  it('getOllamaServerLogPath returns null on linux (journalctl path)', async () => {
+    const { getOllamaServerLogPath } = await import('./extension.js');
+    const result = getOllamaServerLogPath();
+    expect(result === null || typeof result === 'string').toBe(true);
+  });
+
+  it('handleConfigurationChange triggers callbacks for relevant settings', async () => {
+    const { handleConfigurationChange } = await import('./extension.js');
+
+    const diagnostics = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      exception: vi.fn(),
+    };
+    const onLogLevelChange = vi.fn();
+    const onAutoStartChange = vi.fn();
+
+    handleConfigurationChange(
+      {
+        affectsConfiguration: (key: string) => key === 'ollama.diagnostics.logLevel' || key === 'ollama.streamLogs',
+      } as any,
+      diagnostics as any,
+      onLogLevelChange,
+      onAutoStartChange,
+    );
+
+    expect(onLogLevelChange).toHaveBeenCalledTimes(1);
+    expect(onAutoStartChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('handleConnectionTestFailure handles Open Logs selection when no file path exists', async () => {
+    const showErrorMessage = vi.fn().mockResolvedValue('Open Logs');
+
+    const { handleConnectionTestFailure } = await import('./extension.js');
+    await handleConnectionTestFailure('http://localhost:11434', {
+      showErrorMessage,
+    } as any);
+
+    // Confirms the Open Logs path was reached.
+    expect(showErrorMessage).toHaveBeenCalled();
+  });
+});

--- a/src/formatting.test.ts
+++ b/src/formatting.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { createXmlStreamFilter, formatXmlLikeResponseForDisplay, stripXmlContextTags } from './formatting.js';
+import {
+  createXmlStreamFilter,
+  dedupeXmlContextBlocksByTag,
+  formatXmlLikeResponseForDisplay,
+  sanitizeNonStreamingModelOutput,
+  splitLeadingXmlContextBlocks,
+  stripXmlContextTags,
+} from './formatting.js';
 
 describe('createXmlStreamFilter', () => {
   it('write() returns only new content per call with XML tags', () => {
@@ -36,6 +43,14 @@ describe('createXmlStreamFilter', () => {
     expect(a + b + c).toBe('<code>actual content</code>');
   });
 
+  it('strips user_info tags across chunk boundaries', () => {
+    const filter = createXmlStreamFilter();
+    const a = filter.write('<user_info>private context');
+    const b = filter.write('</user_info>');
+    const c = filter.write(' visible answer');
+    expect(a + b + c + filter.end()).toBe(' visible answer');
+  });
+
   it('passes through non-context tags', () => {
     const filter = createXmlStreamFilter();
     const out = filter.write('<code>print("hi")</code>');
@@ -58,6 +73,13 @@ describe('createXmlStreamFilter', () => {
 describe('stripXmlContextTags', () => {
   it('removes context tags from complete text', () => {
     const result = stripXmlContextTags('<environment_info>private</environment_info>public');
+    expect(result).toBe('public');
+  });
+
+  it('removes user_info and workspace_info tags from complete text', () => {
+    const result = stripXmlContextTags(
+      '<user_info>private user</user_info><workspace_info>private workspace</workspace_info>public',
+    );
     expect(result).toBe('public');
   });
 });
@@ -85,6 +107,19 @@ describe('formatXmlLikeResponseForDisplay', () => {
     const malformed = '<note>unfinished';
     const result = formatXmlLikeResponseForDisplay(malformed);
     expect(result).toBe(malformed);
+  });
+});
+
+describe('sanitizeNonStreamingModelOutput', () => {
+  it('removes context tags and formats non-context tags', () => {
+    const input =
+      '<user_info>private context</user_info><workspace_info>workspace details</workspace_info><note>visible note</note>';
+    const result = sanitizeNonStreamingModelOutput(input);
+
+    expect(result).not.toContain('private context');
+    expect(result).not.toContain('workspace details');
+    expect(result).toContain('**Note**');
+    expect(result).toContain('visible note');
   });
 });
 
@@ -134,5 +169,39 @@ describe('createXmlStreamFilter — performance regression', () => {
     expect(result2).not.toContain('first');
     expect(result2).toContain('second');
     expect(result3).toBe('');
+  });
+});
+
+describe('splitLeadingXmlContextBlocks', () => {
+  it('extracts only leading XML context blocks', () => {
+    const input = '<user_info>u1</user_info><workspace_info>w1</workspace_info>hello';
+    const result = splitLeadingXmlContextBlocks(input);
+    expect(result.contextBlocks).toEqual(['<user_info>u1</user_info>', '<workspace_info>w1</workspace_info>']);
+    expect(result.content).toBe('hello');
+  });
+
+  it('does not elevate mid-message XML into context blocks', () => {
+    const input = 'hello <user_info>not-context</user_info>';
+    const result = splitLeadingXmlContextBlocks(input);
+    expect(result.contextBlocks).toEqual([]);
+    expect(result.content).toBe('hello <user_info>not-context</user_info>');
+  });
+});
+
+describe('dedupeXmlContextBlocksByTag', () => {
+  it('keeps latest occurrence per tag and preserves output order', () => {
+    const blocks = [
+      '<environment_info>old-env</environment_info>',
+      '<workspace_info>w1</workspace_info>',
+      '<environment_info>new-env</environment_info>',
+      '<user_info>u1</user_info>',
+    ];
+
+    const deduped = dedupeXmlContextBlocksByTag(blocks);
+    expect(deduped).toEqual([
+      '<workspace_info>w1</workspace_info>',
+      '<environment_info>new-env</environment_info>',
+      '<user_info>u1</user_info>',
+    ]);
   });
 });

--- a/src/formatting.test.ts
+++ b/src/formatting.test.ts
@@ -186,6 +186,13 @@ describe('splitLeadingXmlContextBlocks', () => {
     expect(result.contextBlocks).toEqual([]);
     expect(result.content).toBe('hello <user_info>not-context</user_info>');
   });
+
+  it('does not elevate unknown leading tags into context blocks', () => {
+    const input = '<note>user content</note>hello';
+    const result = splitLeadingXmlContextBlocks(input);
+    expect(result.contextBlocks).toEqual([]);
+    expect(result.content).toBe('<note>user content</note>hello');
+  });
 });
 
 describe('dedupeXmlContextBlocksByTag', () => {
@@ -203,5 +210,12 @@ describe('dedupeXmlContextBlocksByTag', () => {
       '<environment_info>new-env</environment_info>',
       '<user_info>u1</user_info>',
     ]);
+  });
+
+  it('preserves relative order when a single entry contains multiple tags', () => {
+    const blocks = ['<selection>s1</selection><workspace_info>w1</workspace_info>', '<selection>s2</selection>'];
+
+    const deduped = dedupeXmlContextBlocksByTag(blocks);
+    expect(deduped).toEqual(['<workspace_info>w1</workspace_info>', '<selection>s2</selection>']);
   });
 });

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -14,6 +14,66 @@ export interface XmlStreamFilter {
   end(): string;
 }
 
+const XML_CONTEXT_TAG_RE = /<([a-zA-Z_][a-zA-Z0-9_.-]*)[^>]*>[\s\S]*?<\/\1>/gi;
+
+export interface SplitLeadingXmlContextResult {
+  content: string;
+  contextBlocks: string[];
+}
+
+/**
+ * Split leading XML context blocks from a user message.
+ * Only extracts XML blocks that start at index 0 (after trimStart), so
+ * mid-message XML remains regular user text.
+ */
+export function splitLeadingXmlContextBlocks(text: string): SplitLeadingXmlContextResult {
+  let remainingText = text;
+  let hadLeadingContext = false;
+  const contextBlocks: string[] = [];
+
+  if (remainingText.trimStart().startsWith('<')) {
+    remainingText = remainingText.trimStart();
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      XML_CONTEXT_TAG_RE.lastIndex = 0;
+      const match = XML_CONTEXT_TAG_RE.exec(remainingText);
+      if (!match || match.index !== 0) {
+        break;
+      }
+      const matchedText = match[0];
+      contextBlocks.push(matchedText.trim());
+      remainingText = remainingText.slice(matchedText.length).trimStart();
+      hadLeadingContext = true;
+    }
+  }
+
+  return {
+    content: hadLeadingContext ? remainingText : text.trim(),
+    contextBlocks,
+  };
+}
+
+/**
+ * Deduplicate XML context blocks by tag name, keeping the most recent
+ * occurrence per tag type while preserving overall order.
+ */
+export function dedupeXmlContextBlocksByTag(contextBlocks: readonly string[]): string[] {
+  const latestByTag = new Map<string, string>();
+  for (let i = contextBlocks.length - 1; i >= 0; i--) {
+    const part = contextBlocks[i];
+    XML_CONTEXT_TAG_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = XML_CONTEXT_TAG_RE.exec(part)) !== null) {
+      const tagName = match[1];
+      if (!latestByTag.has(tagName)) {
+        latestByTag.set(tagName, match[0].trim());
+      }
+    }
+  }
+
+  return [...latestByTag.values()].reverse();
+}
+
 /**
  * Create a streaming XML filter that removes context tags as they are parsed.
  * Uses SAX parsing to handle incomplete tags across chunk boundaries.
@@ -27,6 +87,7 @@ export interface XmlStreamFilter {
 export function createXmlStreamFilter(): XmlStreamFilter {
   const contextTagNames = new Set([
     'environment_info',
+    'user_info',
     'workspace_info',
     'selection',
     'file_context',
@@ -118,8 +179,8 @@ export function stripXmlContextTags(text: string): string {
   }
 
   const filter = createXmlStreamFilter();
-  filter.write(text);
-  return filter.end().trim();
+  const cleaned = `${filter.write(text)}${filter.end()}`;
+  return cleaned.trim();
 }
 
 /**
@@ -143,4 +204,13 @@ export function formatXmlLikeResponseForDisplay(text: string): string {
   });
 
   return replaced ? transformed.trim() : text;
+}
+
+/**
+ * Sanitize complete (non-streaming) model output for display.
+ * - Removes IDE-injected XML context tags (e.g. user/workspace metadata)
+ * - Formats remaining XML-like content into markdown sections for readability
+ */
+export function sanitizeNonStreamingModelOutput(text: string): string {
+  return formatXmlLikeResponseForDisplay(stripXmlContextTags(text));
 }

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -15,6 +15,29 @@ export interface XmlStreamFilter {
 }
 
 const XML_CONTEXT_TAG_RE = /<([a-zA-Z_][a-zA-Z0-9_.-]*)[^>]*>[\s\S]*?<\/\1>/gi;
+const ELEVATED_CONTEXT_TAG_NAMES = new Set([
+  'environment_info',
+  'user_info',
+  'workspace_info',
+  'selection',
+  'file_context',
+  'user',
+  'userRequest',
+  'workspaces',
+  'workspace',
+  'session',
+  'instructions',
+  'context',
+  'userPreferences',
+  'userData',
+  'profile',
+  'history',
+  'system',
+  'systemPrompt',
+  'chatHistory',
+  'contextWindow',
+  'injectedContext',
+]);
 
 export interface SplitLeadingXmlContextResult {
   content: string;
@@ -40,6 +63,10 @@ export function splitLeadingXmlContextBlocks(text: string): SplitLeadingXmlConte
       if (!match || match.index !== 0) {
         break;
       }
+      const tagName = match[1];
+      if (!ELEVATED_CONTEXT_TAG_NAMES.has(tagName)) {
+        break;
+      }
       const matchedText = match[0];
       contextBlocks.push(matchedText.trim());
       remainingText = remainingText.slice(matchedText.length).trimStart();
@@ -62,11 +89,19 @@ export function dedupeXmlContextBlocksByTag(contextBlocks: readonly string[]): s
   for (let i = contextBlocks.length - 1; i >= 0; i--) {
     const part = contextBlocks[i];
     XML_CONTEXT_TAG_RE.lastIndex = 0;
+    const matches: RegExpExecArray[] = [];
     let match: RegExpExecArray | null;
     while ((match = XML_CONTEXT_TAG_RE.exec(part)) !== null) {
-      const tagName = match[1];
+      matches.push(match);
+    }
+
+    // Iterate per-string matches from right to left so final output reversal
+    // preserves left-to-right order of latest tag occurrences.
+    for (let j = matches.length - 1; j >= 0; j--) {
+      const currentMatch = matches[j];
+      const tagName = currentMatch[1];
       if (!latestByTag.has(tagName)) {
-        latestByTag.set(tagName, match[0].trim());
+        latestByTag.set(tagName, currentMatch[0].trim());
       }
     }
   }

--- a/src/openaiCompat.test.ts
+++ b/src/openaiCompat.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { buildOpenAICompatHeaders, createOpenAICompatUrl, parseSseDataPayloadsFromTextChunks } from './openaiCompat.js';
+
+async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of iterable) {
+    out.push(item);
+  }
+  return out;
+}
+
+describe('createOpenAICompatUrl', () => {
+  it('normalizes base URL trailing slash', () => {
+    expect(createOpenAICompatUrl('http://localhost:11434/')).toBe('http://localhost:11434/v1/chat/completions');
+    expect(createOpenAICompatUrl('http://localhost:11434')).toBe('http://localhost:11434/v1/chat/completions');
+  });
+
+  it('supports custom relative path', () => {
+    expect(createOpenAICompatUrl('http://localhost:11434/', 'v1/models')).toBe('http://localhost:11434/v1/models');
+    expect(createOpenAICompatUrl('http://localhost:11434', '/v1/models')).toBe('http://localhost:11434/v1/models');
+  });
+});
+
+describe('buildOpenAICompatHeaders', () => {
+  it('always includes content-type', () => {
+    expect(buildOpenAICompatHeaders()).toEqual({
+      'Content-Type': 'application/json',
+    });
+  });
+
+  it('adds authorization header when token is provided', () => {
+    expect(buildOpenAICompatHeaders('abc123')).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer abc123',
+    });
+  });
+});
+
+describe('parseSseDataPayloadsFromTextChunks', () => {
+  it('parses normal SSE data frames', async () => {
+    async function* chunks() {
+      yield 'data: {"a":1}\n\n';
+      yield 'data: {"b":2}\n\n';
+      yield 'data: [DONE]\n\n';
+    }
+
+    const payloads = await collect(parseSseDataPayloadsFromTextChunks(chunks()));
+    expect(payloads).toEqual(['{"a":1}', '{"b":2}']);
+  });
+
+  it('handles split frames across chunks', async () => {
+    async function* chunks() {
+      yield 'data: {"a"';
+      yield ':1}\n\n';
+      yield 'data: [DONE]\n\n';
+    }
+
+    const payloads = await collect(parseSseDataPayloadsFromTextChunks(chunks()));
+    expect(payloads).toEqual(['{"a":1}']);
+  });
+
+  it('ignores non-data lines and keeps only data payload', async () => {
+    async function* chunks() {
+      yield 'event: message\nid: 1\ndata: {"x":1}\n\n';
+      yield 'data: [DONE]\n\n';
+    }
+
+    const payloads = await collect(parseSseDataPayloadsFromTextChunks(chunks()));
+    expect(payloads).toEqual(['{"x":1}']);
+  });
+
+  it('handles trailing frame without final blank-line separator', async () => {
+    async function* chunks() {
+      yield 'data: {"final":true}';
+    }
+
+    const payloads = await collect(parseSseDataPayloadsFromTextChunks(chunks()));
+    expect(payloads).toEqual(['{"final":true}']);
+  });
+});

--- a/src/openaiCompat.test.ts
+++ b/src/openaiCompat.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { buildOpenAICompatHeaders, createOpenAICompatUrl, parseSseDataPayloadsFromTextChunks } from './openaiCompat.js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildOpenAICompatHeaders,
+  chatCompletionsOnce,
+  chatCompletionsStream,
+  createOpenAICompatUrl,
+  parseSseDataPayloadsFromTextChunks,
+} from './openaiCompat.js';
 
 async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
   const out: T[] = [];
@@ -7,6 +13,18 @@ async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
     out.push(item);
   }
   return out;
+}
+
+function streamFromChunks(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
 }
 
 describe('createOpenAICompatUrl', () => {
@@ -76,5 +94,149 @@ describe('parseSseDataPayloadsFromTextChunks', () => {
 
     const payloads = await collect(parseSseDataPayloadsFromTextChunks(chunks()));
     expect(payloads).toEqual(['{"final":true}']);
+  });
+});
+
+describe('chatCompletionsOnce', () => {
+  it('posts with stream=false and returns parsed JSON body', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: 'resp-1',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'hello' } }],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const result = await chatCompletionsOnce({
+      baseUrl: 'http://localhost:11434',
+      authToken: 'abc',
+      fetchFn,
+      request: {
+        model: 'llama3.2',
+        messages: [{ role: 'user', content: 'hi' }],
+      },
+    });
+
+    expect(result.choices?.[0]?.message?.content).toBe('hello');
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = fetchFn.mock.calls[0] as [string, RequestInit];
+    expect(calledUrl).toBe('http://localhost:11434/v1/chat/completions');
+    expect(calledInit.method).toBe('POST');
+    expect(calledInit.headers).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer abc',
+    });
+    expect(JSON.parse(String(calledInit.body))).toMatchObject({
+      model: 'llama3.2',
+      stream: false,
+    });
+  });
+
+  it('throws with response body when non-OK', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response('server exploded', { status: 500 }));
+
+    await expect(
+      chatCompletionsOnce({
+        baseUrl: 'http://localhost:11434',
+        fetchFn,
+        request: {
+          model: 'llama3.2',
+          messages: [{ role: 'user', content: 'hi' }],
+        },
+      }),
+    ).rejects.toThrow('OpenAI-compat request failed (500): server exploded');
+  });
+});
+
+describe('chatCompletionsStream', () => {
+  it('posts with stream=true and yields parsed SSE JSON payloads', async () => {
+    const stream = streamFromChunks([
+      'data: {"id":"c1","choices":[{"index":0,"delta":{"content":"hello"}}]}\n\n',
+      'data: {"id":"c2","choices":[{"index":0,"delta":{"content":" world"}}]}\n\n',
+      'data: [DONE]\n\n',
+    ]);
+
+    const fetchFn = vi.fn().mockResolvedValue(new Response(stream, { status: 200 }));
+    const chunks = await collect(
+      chatCompletionsStream({
+        baseUrl: 'http://localhost:11434',
+        fetchFn,
+        request: {
+          model: 'llama3.2',
+          messages: [{ role: 'user', content: 'hi' }],
+        },
+      }),
+    );
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]?.choices?.[0]?.delta?.content).toBe('hello');
+    expect(chunks[1]?.choices?.[0]?.delta?.content).toBe(' world');
+
+    const [, calledInit] = fetchFn.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(calledInit.body))).toMatchObject({ stream: true });
+  });
+
+  it('skips malformed JSON payloads and continues stream', async () => {
+    const stream = streamFromChunks([
+      'data: {not-json}\n\n',
+      'data: {"choices":[{"index":0,"delta":{"content":"ok"}}]}\n\n',
+      'data: [DONE]\n\n',
+    ]);
+    const fetchFn = vi.fn().mockResolvedValue(new Response(stream, { status: 200 }));
+
+    const chunks = await collect(
+      chatCompletionsStream({
+        baseUrl: 'http://localhost:11434',
+        fetchFn,
+        request: {
+          model: 'llama3.2',
+          messages: [{ role: 'user', content: 'hi' }],
+        },
+      }),
+    );
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]?.choices?.[0]?.delta?.content).toBe('ok');
+  });
+
+  it('throws when stream response is non-OK', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response('bad', { status: 502 }));
+
+    await expect(
+      collect(
+        chatCompletionsStream({
+          baseUrl: 'http://localhost:11434',
+          fetchFn,
+          request: {
+            model: 'llama3.2',
+            messages: [{ role: 'user', content: 'hi' }],
+          },
+        }),
+      ),
+    ).rejects.toThrow('OpenAI-compat stream request failed (502): bad');
+  });
+
+  it('throws when stream response has no body', async () => {
+    const responseWithoutBody = {
+      ok: true,
+      status: 200,
+      body: null,
+    } as Response;
+    const fetchFn = vi.fn().mockResolvedValue(responseWithoutBody);
+
+    await expect(
+      collect(
+        chatCompletionsStream({
+          baseUrl: 'http://localhost:11434',
+          fetchFn,
+          request: {
+            model: 'llama3.2',
+            messages: [{ role: 'user', content: 'hi' }],
+          },
+        }),
+      ),
+    ).rejects.toThrow('OpenAI-compat stream request failed: response body is empty');
   });
 });

--- a/src/openaiCompat.ts
+++ b/src/openaiCompat.ts
@@ -1,0 +1,241 @@
+import { TextDecoder } from 'node:util';
+
+export interface OpenAICompatToolCall {
+  id?: string;
+  type?: 'function';
+  function?: {
+    name?: string;
+    arguments?: string;
+  };
+}
+
+export interface OpenAICompatChatCompletionChunk {
+  id?: string;
+  model?: string;
+  choices?: Array<{
+    index: number;
+    delta?: {
+      role?: 'system' | 'user' | 'assistant' | 'tool';
+      content?: string;
+      tool_calls?: OpenAICompatToolCall[];
+    };
+    finish_reason?: string | null;
+  }>;
+}
+
+export interface OpenAICompatChatCompletionResponse {
+  id?: string;
+  model?: string;
+  choices?: Array<{
+    index: number;
+    message?: {
+      role?: 'system' | 'user' | 'assistant' | 'tool';
+      content?: string | null;
+      tool_calls?: OpenAICompatToolCall[];
+    };
+    finish_reason?: string | null;
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+  };
+}
+
+export interface OpenAICompatChatRequest {
+  model: string;
+  messages: unknown[];
+  stream?: boolean;
+  tools?: unknown[];
+  tool_choice?: unknown;
+  temperature?: number;
+  top_p?: number;
+  max_tokens?: number;
+  [key: string]: unknown;
+}
+
+export interface OpenAICompatRequestOptions {
+  baseUrl: string;
+  request: OpenAICompatChatRequest;
+  authToken?: string;
+  fetchFn?: typeof fetch;
+  signal?: AbortSignal;
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, '');
+}
+
+export function createOpenAICompatUrl(baseUrl: string, path = '/v1/chat/completions'): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${normalizeBaseUrl(baseUrl)}${normalizedPath}`;
+}
+
+export function buildOpenAICompatHeaders(authToken?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+
+  if (authToken) {
+    headers.Authorization = `Bearer ${authToken}`;
+  }
+
+  return headers;
+}
+
+async function readErrorBody(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    return text.slice(0, 4000);
+  } catch {
+    return '';
+  }
+}
+
+async function* toTextChunks(stream: ReadableStream<Uint8Array>): AsyncGenerator<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (value) {
+        const text = decoder.decode(value, { stream: true });
+        if (text) {
+          yield text;
+        }
+      }
+    }
+
+    const trailing = decoder.decode();
+    if (trailing) {
+      yield trailing;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/**
+ * Parses Server-Sent Events from an async sequence of text chunks and yields
+ * only `data:` payloads. Stops on `[DONE]`.
+ */
+export async function* parseSseDataPayloadsFromTextChunks(chunks: AsyncIterable<string>): AsyncGenerator<string> {
+  let buffer = '';
+
+  for await (const chunk of chunks) {
+    buffer += chunk;
+
+    // Process full event frames separated by blank line.
+    while (true) {
+      const separatorIndex = buffer.indexOf('\n\n');
+      if (separatorIndex === -1) {
+        break;
+      }
+
+      const rawEvent = buffer.slice(0, separatorIndex);
+      buffer = buffer.slice(separatorIndex + 2);
+
+      const lines = rawEvent
+        .split(/\r?\n/)
+        .map(line => line.trimEnd())
+        .filter(Boolean);
+
+      const dataLines = lines.filter(line => line.startsWith('data:')).map(line => line.slice(5).trimStart());
+
+      if (!dataLines.length) {
+        continue;
+      }
+
+      const payload = dataLines.join('\n').trim();
+      if (!payload) {
+        continue;
+      }
+
+      if (payload === '[DONE]') {
+        return;
+      }
+
+      yield payload;
+    }
+  }
+
+  // Handle a trailing frame without the final separator.
+  const trailing = buffer.trim();
+  if (!trailing) {
+    return;
+  }
+
+  const lines = trailing
+    .split(/\r?\n/)
+    .map(line => line.trimEnd())
+    .filter(Boolean);
+
+  const dataLines = lines.filter(line => line.startsWith('data:')).map(line => line.slice(5).trimStart());
+
+  const payload = dataLines.join('\n').trim();
+  if (!payload || payload === '[DONE]') {
+    return;
+  }
+
+  yield payload;
+}
+
+export async function* chatCompletionsStream(
+  options: OpenAICompatRequestOptions,
+): AsyncGenerator<OpenAICompatChatCompletionChunk> {
+  const fetchFn = options.fetchFn ?? fetch;
+  const url = createOpenAICompatUrl(options.baseUrl);
+
+  const response = await fetchFn(url, {
+    method: 'POST',
+    headers: buildOpenAICompatHeaders(options.authToken),
+    body: JSON.stringify({ ...options.request, stream: true }),
+    signal: options.signal,
+  });
+
+  if (!response.ok) {
+    const bodyText = await readErrorBody(response);
+    throw new Error(`OpenAI-compat stream request failed (${response.status}): ${bodyText}`.trim());
+  }
+
+  if (!response.body) {
+    throw new Error('OpenAI-compat stream request failed: response body is empty');
+  }
+
+  for await (const payload of parseSseDataPayloadsFromTextChunks(toTextChunks(response.body))) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(payload);
+    } catch {
+      continue;
+    }
+
+    if (parsed && typeof parsed === 'object') {
+      yield parsed as OpenAICompatChatCompletionChunk;
+    }
+  }
+}
+
+export async function chatCompletionsOnce(
+  options: OpenAICompatRequestOptions,
+): Promise<OpenAICompatChatCompletionResponse> {
+  const fetchFn = options.fetchFn ?? fetch;
+  const url = createOpenAICompatUrl(options.baseUrl);
+
+  const response = await fetchFn(url, {
+    method: 'POST',
+    headers: buildOpenAICompatHeaders(options.authToken),
+    body: JSON.stringify({ ...options.request, stream: false }),
+    signal: options.signal,
+  });
+
+  if (!response.ok) {
+    const bodyText = await readErrorBody(response);
+    throw new Error(`OpenAI-compat request failed (${response.status}): ${bodyText}`.trim());
+  }
+
+  return (await response.json()) as OpenAICompatChatCompletionResponse;
+}

--- a/src/openaiCompatMapping.test.ts
+++ b/src/openaiCompatMapping.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import type { Message, Tool } from 'ollama';
+import { ollamaMessagesToOpenAICompat, ollamaToolsToOpenAICompat } from './openaiCompatMapping.js';
+
+describe('ollamaMessagesToOpenAICompat', () => {
+  it('maps text-only messages', () => {
+    const messages: Message[] = [
+      { role: 'system', content: 'rules' },
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'hi' },
+    ];
+
+    const mapped = ollamaMessagesToOpenAICompat(messages);
+    expect(mapped).toEqual([
+      { role: 'system', content: 'rules' },
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'hi' },
+    ]);
+  });
+
+  it('maps user images to OpenAI image_url content parts', () => {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: 'describe image',
+        images: ['abc123base64'],
+      },
+    ];
+
+    const mapped = ollamaMessagesToOpenAICompat(messages);
+    expect(Array.isArray(mapped[0]?.content)).toBe(true);
+    const parts = mapped[0]?.content as Array<{ type: string; text?: string; image_url?: { url: string } }>;
+    expect(parts[0]).toEqual({ type: 'text', text: 'describe image' });
+    expect(parts[1]?.type).toBe('image_url');
+    expect(parts[1]?.image_url?.url).toContain('data:image/png;base64,abc123base64');
+  });
+
+  it('maps tool calls with JSON-stringified arguments', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            function: {
+              name: 'search',
+              arguments: { q: 'hello' },
+            },
+          },
+        ],
+      },
+    ];
+
+    const mapped = ollamaMessagesToOpenAICompat(messages);
+    expect(mapped[0]?.tool_calls?.[0]?.type).toBe('function');
+    expect(mapped[0]?.tool_calls?.[0]?.function?.name).toBe('search');
+    expect(mapped[0]?.tool_calls?.[0]?.function?.arguments).toBe('{"q":"hello"}');
+  });
+});
+
+describe('ollamaToolsToOpenAICompat', () => {
+  it('maps function tools only', () => {
+    const tools: Tool[] = [
+      {
+        type: 'function',
+        function: {
+          name: 'search',
+          description: 'Search docs',
+          parameters: { type: 'object', properties: { q: { type: 'string' } } },
+        },
+      },
+    ];
+
+    const mapped = ollamaToolsToOpenAICompat(tools);
+    expect(mapped).toEqual([
+      {
+        type: 'function',
+        function: {
+          name: 'search',
+          description: 'Search docs',
+          parameters: { type: 'object', properties: { q: { type: 'string' } } },
+        },
+      },
+    ]);
+  });
+});

--- a/src/openaiCompatMapping.test.ts
+++ b/src/openaiCompatMapping.test.ts
@@ -56,6 +56,68 @@ describe('ollamaMessagesToOpenAICompat', () => {
     expect(mapped[0]?.tool_calls?.[0]?.function?.name).toBe('search');
     expect(mapped[0]?.tool_calls?.[0]?.function?.arguments).toBe('{"q":"hello"}');
   });
+
+  it('maps tool role messages and preserves tool_call_id', () => {
+    const messages: Message[] = [
+      {
+        role: 'tool',
+        content: 'result payload',
+        tool_call_id: 'call-123',
+      } as Message,
+    ];
+
+    const mapped = ollamaMessagesToOpenAICompat(messages);
+    expect(mapped).toEqual([
+      {
+        role: 'tool',
+        content: 'result payload',
+        tool_call_id: 'call-123',
+      },
+    ]);
+  });
+
+  it('defaults unknown roles to user', () => {
+    const messages: Message[] = [
+      {
+        role: 'unknown-role' as Message['role'],
+        content: 'fallback me',
+      },
+    ];
+
+    const mapped = ollamaMessagesToOpenAICompat(messages);
+    expect(mapped[0]?.role).toBe('user');
+  });
+
+  it('maps Uint8Array image payloads to base64 data URLs', () => {
+    const imageBytes = new Uint8Array([1, 2, 3, 4]);
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: 'inspect this',
+        images: [imageBytes],
+      },
+    ];
+
+    const mapped = ollamaMessagesToOpenAICompat(messages);
+    const parts = mapped[0]?.content as Array<{ type: string; image_url?: { url: string } }>;
+    expect(parts[1]?.type).toBe('image_url');
+    expect(parts[1]?.image_url?.url).toContain('data:image/png;base64,');
+  });
+
+  it('emits only image part when user text is blank', () => {
+    const messages: Message[] = [
+      {
+        role: 'user',
+        content: '   ',
+        images: ['abc123base64'],
+      },
+    ];
+
+    const mapped = ollamaMessagesToOpenAICompat(messages);
+    const parts = mapped[0]?.content as Array<{ type: string }>;
+    expect(parts).toHaveLength(1);
+    expect(parts[0]?.type).toBe('image_url');
+  });
 });
 
 describe('ollamaToolsToOpenAICompat', () => {
@@ -79,6 +141,38 @@ describe('ollamaToolsToOpenAICompat', () => {
           name: 'search',
           description: 'Search docs',
           parameters: { type: 'object', properties: { q: { type: 'string' } } },
+        },
+      },
+    ]);
+  });
+
+  it('returns undefined when tools are missing or empty', () => {
+    expect(ollamaToolsToOpenAICompat(undefined)).toBeUndefined();
+    expect(ollamaToolsToOpenAICompat([])).toBeUndefined();
+  });
+
+  it('filters non-function or malformed tools', () => {
+    const tools = [
+      { type: 'other', function: { name: 'skip' } },
+      { type: 'function', function: { description: 'missing name' } },
+      {
+        type: 'function',
+        function: {
+          name: 'keep',
+          description: 'valid',
+          parameters: { type: 'object' },
+        },
+      },
+    ] as unknown as Tool[];
+
+    const mapped = ollamaToolsToOpenAICompat(tools);
+    expect(mapped).toEqual([
+      {
+        type: 'function',
+        function: {
+          name: 'keep',
+          description: 'valid',
+          parameters: { type: 'object' },
         },
       },
     ]);

--- a/src/openaiCompatMapping.ts
+++ b/src/openaiCompatMapping.ts
@@ -1,0 +1,133 @@
+import type { Message, Tool } from 'ollama';
+
+export interface OpenAICompatContentTextPart {
+  type: 'text';
+  text: string;
+}
+
+export interface OpenAICompatContentImagePart {
+  type: 'image_url';
+  image_url: {
+    url: string;
+  };
+}
+
+export type OpenAICompatContentPart = OpenAICompatContentTextPart | OpenAICompatContentImagePart;
+
+export interface OpenAICompatMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string | OpenAICompatContentPart[];
+  tool_calls?: Array<{
+    id?: string;
+    type?: 'function';
+    function?: {
+      name?: string;
+      arguments?: string;
+    };
+  }>;
+  tool_call_id?: string;
+}
+
+export interface OpenAICompatTool {
+  type: 'function';
+  function: {
+    name: string;
+    description?: string;
+    parameters?: Record<string, unknown>;
+  };
+}
+
+function mapRole(role: string | undefined): OpenAICompatMessage['role'] {
+  switch (role) {
+    case 'system':
+      return 'system';
+    case 'assistant':
+      return 'assistant';
+    case 'tool':
+      return 'tool';
+    case 'user':
+    default:
+      return 'user';
+  }
+}
+
+/**
+ * Convert base64 image strings from Ollama message shape to OpenAI-compatible
+ * content parts using data URLs.
+ */
+function imagesToOpenAIContentParts(images: Array<string | Uint8Array>): OpenAICompatContentImagePart[] {
+  return images.map(img => ({
+    type: 'image_url',
+    image_url: {
+      // Mime type cannot be recovered from Ollama's message image payload.
+      // Use png as a safe default data URL type.
+      url: `data:image/png;base64,${typeof img === 'string' ? img : Buffer.from(img).toString('base64')}`,
+    },
+  }));
+}
+
+export function ollamaMessagesToOpenAICompat(messages: readonly Message[]): OpenAICompatMessage[] {
+  return messages.map(msg => {
+    const role = mapRole(msg.role);
+    const text = msg.content ?? '';
+
+    let content: string | OpenAICompatContentPart[] = text;
+    if (role === 'user' && Array.isArray(msg.images) && msg.images.length > 0) {
+      const parts: OpenAICompatContentPart[] = [];
+      if (text.trim()) {
+        parts.push({ type: 'text', text });
+      }
+      parts.push(...imagesToOpenAIContentParts(msg.images));
+      content = parts;
+    }
+
+    const out: OpenAICompatMessage = {
+      role,
+      content,
+    };
+
+    if (Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0) {
+      out.tool_calls = msg.tool_calls.map(call => ({
+        id: (call as { id?: string }).id,
+        type: 'function',
+        function: {
+          name: call.function?.name,
+          arguments: JSON.stringify(call.function?.arguments ?? {}),
+        },
+      }));
+    }
+
+    if (role === 'tool' && (msg as Message & { tool_call_id?: string }).tool_call_id) {
+      out.tool_call_id = (msg as Message & { tool_call_id?: string }).tool_call_id;
+    }
+
+    return out;
+  });
+}
+
+export function ollamaToolsToOpenAICompat(tools?: readonly Tool[]): OpenAICompatTool[] | undefined {
+  if (!tools?.length) {
+    return undefined;
+  }
+
+  const mapped: OpenAICompatTool[] = [];
+  for (const tool of tools) {
+    if (tool.type !== 'function' || typeof tool.function?.name !== 'string') {
+      continue;
+    }
+
+    mapped.push({
+      type: 'function',
+      function: {
+        name: tool.function.name,
+        description: tool.function.description,
+        parameters:
+          tool.function.parameters && typeof tool.function.parameters === 'object'
+            ? (tool.function.parameters as Record<string, unknown>)
+            : undefined,
+      },
+    });
+  }
+
+  return mapped;
+}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -21,7 +21,13 @@ import {
   window,
   workspace,
 } from 'vscode';
-import { getCloudOllamaClient, getContextLengthOverride, getOllamaClient } from './client';
+import {
+  getCloudOllamaClient,
+  getContextLengthOverride,
+  getOllamaAuthToken,
+  getOllamaClient,
+  getOllamaHost,
+} from './client';
 import type { DiagnosticsLogger } from './diagnostics.js';
 import { reportError } from './errorHandler.js';
 import {
@@ -30,6 +36,8 @@ import {
   sanitizeNonStreamingModelOutput,
   splitLeadingXmlContextBlocks,
 } from './formatting';
+import { chatCompletionsOnce, chatCompletionsStream } from './openaiCompat.js';
+import { ollamaMessagesToOpenAICompat, ollamaToolsToOpenAICompat } from './openaiCompatMapping.js';
 import { isToolsNotSupportedError, normalizeToolParameters } from './toolUtils.js';
 
 const MODEL_LIST_REFRESH_MIN_INTERVAL_MS = 5_000;
@@ -462,6 +470,167 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     return families ? families.includes('clip') || families.includes('vision') : false;
   }
 
+  private mapOpenAiToolCallsToOllamaLike(toolCalls: unknown):
+    | Array<{
+        id?: string;
+        function?: {
+          name?: string;
+          arguments?: Record<string, unknown>;
+        };
+      }>
+    | undefined {
+    if (!Array.isArray(toolCalls) || toolCalls.length === 0) {
+      return undefined;
+    }
+
+    const mapped: Array<{
+      id?: string;
+      function?: {
+        name?: string;
+        arguments?: Record<string, unknown>;
+      };
+    }> = [];
+
+    for (const call of toolCalls) {
+      if (!call || typeof call !== 'object') {
+        continue;
+      }
+
+      const typed = call as {
+        id?: unknown;
+        function?: {
+          name?: unknown;
+          arguments?: unknown;
+        };
+      };
+
+      let parsedArgs: Record<string, unknown> = {};
+      if (typeof typed.function?.arguments === 'string' && typed.function.arguments.trim()) {
+        try {
+          const parsed = JSON.parse(typed.function.arguments);
+          if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+            parsedArgs = parsed as Record<string, unknown>;
+          }
+        } catch {
+          parsedArgs = {};
+        }
+      }
+
+      mapped.push({
+        id: typeof typed.id === 'string' ? typed.id : undefined,
+        function: {
+          name: typeof typed.function?.name === 'string' ? typed.function.name : undefined,
+          arguments: parsedArgs,
+        },
+      });
+    }
+
+    return mapped;
+  }
+
+  private async openAiCompatStreamChat(
+    runtimeModelId: string,
+    messages: Message[],
+    tools: Parameters<typeof this.client.chat>[0]['tools'] | undefined,
+    shouldThink: boolean,
+    fallbackClient: Ollama,
+    signal?: AbortSignal,
+  ): Promise<AsyncIterable<ChatResponse>> {
+    let stream: AsyncIterable<import('./openaiCompat.js').OpenAICompatChatCompletionChunk>;
+    try {
+      const baseUrl = getOllamaHost();
+      const authToken = await getOllamaAuthToken(this.context);
+
+      stream = chatCompletionsStream({
+        baseUrl,
+        authToken,
+        signal,
+        request: {
+          model: runtimeModelId,
+          messages: ollamaMessagesToOpenAICompat(messages),
+          tools: ollamaToolsToOpenAICompat(tools),
+          ...(shouldThink ? { think: true } : {}),
+        },
+      });
+    } catch {
+      return fallbackClient.chat({
+        model: runtimeModelId,
+        messages,
+        stream: true,
+        tools,
+        ...(shouldThink ? { think: true } : {}),
+      });
+    }
+
+    return (async function* (provider: OllamaChatModelProvider): AsyncGenerator<ChatResponse> {
+      for await (const chunk of stream) {
+        const choice = chunk.choices?.[0];
+        const delta = choice?.delta;
+        const content = typeof delta?.content === 'string' ? delta.content : '';
+        const mappedToolCalls = provider.mapOpenAiToolCallsToOllamaLike(delta?.tool_calls);
+
+        const out: ChatResponse = {
+          message: {
+            role: 'assistant',
+            content,
+            ...(mappedToolCalls ? { tool_calls: mappedToolCalls } : {}),
+          },
+          done: choice?.finish_reason != null,
+        } as ChatResponse;
+
+        yield out;
+      }
+    })(this);
+  }
+
+  private async openAiCompatChatOnce(
+    runtimeModelId: string,
+    messages: Message[],
+    tools: Parameters<typeof this.client.chat>[0]['tools'] | undefined,
+    shouldThink: boolean,
+    fallbackClient: Ollama,
+    signal?: AbortSignal,
+  ): Promise<ChatResponse> {
+    let response: import('./openaiCompat.js').OpenAICompatChatCompletionResponse;
+    try {
+      const baseUrl = getOllamaHost();
+      const authToken = await getOllamaAuthToken(this.context);
+
+      response = await chatCompletionsOnce({
+        baseUrl,
+        authToken,
+        signal,
+        request: {
+          model: runtimeModelId,
+          messages: ollamaMessagesToOpenAICompat(messages),
+          tools: ollamaToolsToOpenAICompat(tools),
+          ...(shouldThink ? { think: true } : {}),
+        },
+      });
+    } catch {
+      return (await fallbackClient.chat({
+        model: runtimeModelId,
+        messages,
+        stream: false,
+        tools,
+        ...(shouldThink ? { think: true } : {}),
+      })) as ChatResponse;
+    }
+
+    const choice = response.choices?.[0];
+    const content = typeof choice?.message?.content === 'string' ? choice.message.content : '';
+    const mappedToolCalls = this.mapOpenAiToolCallsToOllamaLike(choice?.message?.tool_calls);
+
+    return {
+      message: {
+        role: 'assistant',
+        content,
+        ...(mappedToolCalls ? { tool_calls: mappedToolCalls } : {}),
+      },
+      done: true,
+    } as ChatResponse;
+  }
+
   /**
    * Satisfy a VS Code Language Model API chat request by streaming through Ollama.
    *
@@ -541,13 +710,13 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
         this.outputChannel.debug(
           `[client] chat request: model=${runtimeModelId}, messages=${ollamaMessages?.length ?? 0}, tools=${tools?.length ?? 0}, think=${shouldThink}`,
         );
-        response = await perRequestClient.chat({
-          model: runtimeModelId,
-          messages: ollamaMessages,
-          stream: true,
+        response = await this.openAiCompatStreamChat(
+          runtimeModelId,
+          ollamaMessages as Message[],
           tools,
-          ...(shouldThink ? { think: true } : {}),
-        });
+          shouldThink,
+          perRequestClient,
+        );
         this.outputChannel.debug(`[client] chat response stream started for ${runtimeModelId}`);
       } catch (innerError) {
         this.outputChannel.exception(`[client] chat request failed for model ${runtimeModelId}`, innerError);
@@ -559,12 +728,13 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
           this.nonThinkingModels.add(runtimeModelId);
           this.outputChannel.debug(`[client] retrying without thinking support for ${runtimeModelId}`);
           try {
-            response = await perRequestClient.chat({
-              model: runtimeModelId,
-              messages: ollamaMessages,
-              stream: true,
+            response = await this.openAiCompatStreamChat(
+              runtimeModelId,
+              ollamaMessages as Message[],
               tools,
-            });
+              false,
+              perRequestClient,
+            );
           } catch (retryError) {
             if (
               isCloudModel &&
@@ -574,31 +744,35 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
               this.outputChannel.warn(
                 `[client] cloud model ${runtimeModelId} failed with tools after think retry; retrying without tools`,
               );
-              response = await perRequestClient.chat({
-                model: runtimeModelId,
-                messages: ollamaMessages,
-                stream: true,
-              });
+              response = await this.openAiCompatStreamChat(
+                runtimeModelId,
+                ollamaMessages as Message[],
+                undefined,
+                false,
+                perRequestClient,
+              );
             } else {
               throw retryError;
             }
           }
         } else if (isCloudModel && tools && this.isThinkingInternalServerError(innerError)) {
           this.outputChannel.warn(`[client] cloud model ${runtimeModelId} failed with tools; retrying without tools`);
-          response = await perRequestClient.chat({
-            model: runtimeModelId,
-            messages: ollamaMessages,
-            stream: true,
-            ...(shouldThink ? { think: true } : {}),
-          });
+          response = await this.openAiCompatStreamChat(
+            runtimeModelId,
+            ollamaMessages as Message[],
+            undefined,
+            shouldThink,
+            perRequestClient,
+          );
         } else if (tools && isToolsNotSupportedError(innerError)) {
           this.outputChannel.warn(`[client] model ${runtimeModelId} rejected tools; retrying without tools`);
-          response = await perRequestClient.chat({
-            model: runtimeModelId,
-            messages: ollamaMessages,
-            stream: true,
-            ...(shouldThink ? { think: true } : {}),
-          });
+          response = await this.openAiCompatStreamChat(
+            runtimeModelId,
+            ollamaMessages as Message[],
+            undefined,
+            shouldThink,
+            perRequestClient,
+          );
         } else {
           throw innerError;
         }
@@ -685,13 +859,13 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
           `[client] stream returned no output for ${runtimeModelId}; retrying with stream=false`,
         );
 
-        const fallback = (await perRequestClient.chat({
-          model: runtimeModelId,
-          messages: ollamaMessages,
-          stream: false,
+        const fallback = await this.openAiCompatChatOnce(
+          runtimeModelId,
+          ollamaMessages as Message[],
           tools,
-          ...(shouldThink ? { think: true } : {}),
-        })) as ChatResponse;
+          shouldThink,
+          perRequestClient,
+        );
 
         if (fallback.message?.thinking) {
           progress.report(new LanguageModelTextPart('\n\n💭 **Thinking**\n\n'));
@@ -753,13 +927,13 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
 
         for (const attempt of rescueAttempts) {
           try {
-            const rescued = (await perRequestClient.chat({
-              model: runtimeModelId,
-              messages: attempt.messages,
-              stream: false,
-              ...(attempt.tools ? { tools: attempt.tools } : {}),
-              ...(attempt.think ? { think: true } : {}),
-            })) as ChatResponse;
+            const rescued = await this.openAiCompatChatOnce(
+              runtimeModelId,
+              attempt.messages,
+              attempt.tools,
+              attempt.think,
+              perRequestClient,
+            );
 
             const hasContent =
               rescued.message?.content || rescued.message?.thinking || rescued.message?.tool_calls?.length;

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1028,10 +1028,11 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
    *
    * Algorithm:
    * 1. For each user message, if the content starts with `<`, greedily consume
-   *    consecutive XML tags from the *very beginning* (index 0). As soon as the
-   *    regex match is not at position 0, extraction stops. This ensures only
-   *    leading IDE-injected blocks are elevated to system context; XML that
-   *    appears mid-message is left in the user turn as-is.
+   *    consecutive XML tags from the *very beginning* (index 0) **only when the
+   *    tag name is in the known context-tag allowlist**. As soon as the regex
+   *    match is not at position 0 (or the tag is not allowlisted), extraction
+   *    stops. This prevents arbitrary user-provided XML from being elevated to
+   *    system context while still preserving IDE-injected context blocks.
    * 2. Extracted blocks from all turns are collected in `systemContextParts`.
    * 3. The list is deduplicated by tag name (keeping the most-recent occurrence
    *    per tag type) to prevent accumulating stale context across turns.
@@ -1097,8 +1098,8 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
 
       // Ollama requires content to be a string (images are separate field)
       if (role === 'user') {
-        // Strip only *leading* VS Code-injected XML context blocks; accumulate for system message.
-        // This avoids treating arbitrary user-provided tags as privileged system context.
+        // Strip only *leading* allowlisted VS Code-injected XML context blocks;
+        // arbitrary user-provided tags are left in user content.
         const split = splitLeadingXmlContextBlocks(textContent);
         if (split.contextBlocks.length > 0) {
           systemContextParts.push(...split.contextBlocks);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -24,7 +24,12 @@ import {
 import { getCloudOllamaClient, getContextLengthOverride, getOllamaClient } from './client';
 import type { DiagnosticsLogger } from './diagnostics.js';
 import { reportError } from './errorHandler.js';
-import { createXmlStreamFilter, formatXmlLikeResponseForDisplay, stripXmlContextTags } from './formatting';
+import {
+  createXmlStreamFilter,
+  dedupeXmlContextBlocksByTag,
+  sanitizeNonStreamingModelOutput,
+  splitLeadingXmlContextBlocks,
+} from './formatting';
 import { isToolsNotSupportedError, normalizeToolParameters } from './toolUtils.js';
 
 const MODEL_LIST_REFRESH_MIN_INTERVAL_MS = 5_000;
@@ -699,9 +704,7 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
             progress.report(new LanguageModelTextPart('\n\n---\n\n'));
           }
           // Non-stream fallback is complete text; safe to format XML-like blocks.
-          progress.report(
-            new LanguageModelTextPart(formatXmlLikeResponseForDisplay(stripXmlContextTags(fallback.message.content))),
-          );
+          progress.report(new LanguageModelTextPart(sanitizeNonStreamingModelOutput(fallback.message.content)));
           emittedOutput = true;
         }
 
@@ -773,11 +776,7 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
 
               if (rescued.message?.content) {
                 // Non-stream rescue is complete text; safe to format XML-like blocks.
-                progress.report(
-                  new LanguageModelTextPart(
-                    formatXmlLikeResponseForDisplay(stripXmlContextTags(rescued.message.content)),
-                  ),
-                );
+                progress.report(new LanguageModelTextPart(sanitizeNonStreamingModelOutput(rescued.message.content)));
               }
 
               if (rescued.message?.tool_calls && Array.isArray(rescued.message.tool_calls)) {
@@ -875,7 +874,6 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     supportsVision = true,
   ): Parameters<typeof this.client.chat>[0]['messages'] {
     const ollamaMessages: Parameters<typeof this.client.chat>[0]['messages'] = [];
-    const XML_CONTEXT_TAG_RE = /<([a-zA-Z_][a-zA-Z0-9_.-]*)[^>]*>[\s\S]*?<\/\1>/gi;
     const systemContextParts: string[] = [];
     let strippedImageCount = 0;
 
@@ -927,30 +925,11 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       if (role === 'user') {
         // Strip only *leading* VS Code-injected XML context blocks; accumulate for system message.
         // This avoids treating arbitrary user-provided tags as privileged system context.
-        let remainingText = textContent;
-        let hadLeadingContext = false;
-
-        if (remainingText.trimStart().startsWith('<')) {
-          remainingText = remainingText.trimStart();
-          // Iteratively consume XML_CONTEXT_TAG_RE matches only when they appear at the very start
-          // of the remaining text. As soon as a match is not at index 0, we stop extracting.
-          XML_CONTEXT_TAG_RE.lastIndex = 0;
-          // eslint-disable-next-line no-constant-condition
-          while (true) {
-            const match = XML_CONTEXT_TAG_RE.exec(remainingText);
-            if (!match || match.index !== 0) {
-              break;
-            }
-            const matchedText = match[0];
-            systemContextParts.push(matchedText.trim());
-            remainingText = remainingText.slice(matchedText.length).trimStart();
-            hadLeadingContext = true;
-            // Reset lastIndex because we've sliced the string.
-            XML_CONTEXT_TAG_RE.lastIndex = 0;
-          }
+        const split = splitLeadingXmlContextBlocks(textContent);
+        if (split.contextBlocks.length > 0) {
+          systemContextParts.push(...split.contextBlocks);
         }
-
-        textContent = hadLeadingContext ? remainingText : textContent.trim();
+        textContent = split.content;
       }
       if (textContent || images.length > 0) {
         ollamaMsg.content = textContent;
@@ -964,24 +943,7 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       }
     }
 
-    // Deduplicate context blocks by tag type, keeping only the most recent occurrence
-    const latestByTag = new Map<string, string>();
-    for (let i = systemContextParts.length - 1; i >= 0; i--) {
-      const part = systemContextParts[i];
-      XML_CONTEXT_TAG_RE.lastIndex = 0;
-      let match: RegExpExecArray | null;
-      // Use a loop in case a single part contains multiple context blocks
-      // (we still only keep the latest block per tag type).
-      while ((match = XML_CONTEXT_TAG_RE.exec(part)) !== null) {
-        const tagName = match[1];
-        if (!latestByTag.has(tagName)) {
-          latestByTag.set(tagName, match[0]);
-        }
-      }
-    }
-
-    // Preserve insertion order (latest occurrence of each tag wins, collected in reverse above)
-    const dedupedContextParts = [...latestByTag.values()].reverse();
+    const dedupedContextParts = dedupeXmlContextBlocksByTag(systemContextParts);
 
     if (dedupedContextParts.length > 0) {
       ollamaMessages.unshift({

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -1457,6 +1457,141 @@ describe('Extracted command handlers', () => {
     expect(typeof handleLoginToCloud).toBe('function');
   });
 
+  it('handleLoginToCloud opens terminal and runs `ollama login`', async () => {
+    vi.resetModules();
+
+    const show = vi.fn();
+    const sendText = vi.fn();
+    const createTerminal = vi.fn(() => ({ show, sendText }));
+
+    vi.doMock('vscode', () => ({
+      TreeItem: class {
+        label: string;
+        constructor(label: string) {
+          this.label = label;
+        }
+      },
+      ThemeIcon: class {},
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      EventEmitter: class {
+        event = {};
+        fire = vi.fn();
+      },
+      window: {
+        createTerminal,
+        showInformationMessage: vi.fn(),
+        showErrorMessage: vi.fn(),
+        showWarningMessage: vi.fn(),
+        withProgress: vi.fn(),
+        showInputBox: vi.fn(),
+      },
+      commands: { registerCommand: vi.fn(() => ({ dispose: vi.fn() })), executeCommand: vi.fn() },
+      env: { openExternal: vi.fn() },
+      Uri: { parse: vi.fn((value: string) => ({ value })) },
+      ProgressLocation: { Notification: 15 },
+      workspace: {
+        getConfiguration: vi.fn(() => ({ get: vi.fn() })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+      Disposable: class {},
+    }));
+
+    const { handleLoginToCloud } = await import('./sidebar.js');
+    handleLoginToCloud();
+
+    expect(createTerminal).toHaveBeenCalledWith({ name: 'Ollama Cloud Login' });
+    expect(show).toHaveBeenCalledWith(true);
+    expect(sendText).toHaveBeenCalledWith('ollama login', true);
+  });
+
+  it('handleManageCloudApiKey delegates to login flow', async () => {
+    vi.resetModules();
+
+    const sendText = vi.fn();
+    vi.doMock('vscode', () => ({
+      TreeItem: class {
+        label: string;
+        constructor(label: string) {
+          this.label = label;
+        }
+      },
+      ThemeIcon: class {},
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      EventEmitter: class {
+        event = {};
+        fire = vi.fn();
+      },
+      window: {
+        createTerminal: vi.fn(() => ({ show: vi.fn(), sendText })),
+        showInformationMessage: vi.fn(),
+        showErrorMessage: vi.fn(),
+        showWarningMessage: vi.fn(),
+        withProgress: vi.fn(),
+        showInputBox: vi.fn(),
+      },
+      commands: { registerCommand: vi.fn(() => ({ dispose: vi.fn() })), executeCommand: vi.fn() },
+      env: { openExternal: vi.fn() },
+      Uri: { parse: vi.fn((value: string) => ({ value })) },
+      ProgressLocation: { Notification: 15 },
+      workspace: {
+        getConfiguration: vi.fn(() => ({ get: vi.fn() })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+      Disposable: class {},
+    }));
+
+    const { handleManageCloudApiKey } = await import('./sidebar.js');
+    await handleManageCloudApiKey({} as any, {} as any, {} as any);
+
+    expect(sendText).toHaveBeenCalledWith('ollama login', true);
+  });
+
+  it('handleOpenCloudModel opens external URL for cloud items only', async () => {
+    vi.resetModules();
+
+    const openExternal = vi.fn();
+    vi.doMock('vscode', () => ({
+      TreeItem: class {
+        label: string;
+        contextValue?: string;
+        constructor(label: string) {
+          this.label = label;
+        }
+      },
+      ThemeIcon: class {},
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      EventEmitter: class {
+        event = {};
+        fire = vi.fn();
+      },
+      env: { openExternal },
+      Uri: { parse: vi.fn((value: string) => ({ value })) },
+      window: {
+        showInformationMessage: vi.fn(),
+        showErrorMessage: vi.fn(),
+        showWarningMessage: vi.fn(),
+        withProgress: vi.fn(),
+        showInputBox: vi.fn(),
+      },
+      commands: { registerCommand: vi.fn(() => ({ dispose: vi.fn() })), executeCommand: vi.fn() },
+      ProgressLocation: { Notification: 15 },
+      workspace: {
+        getConfiguration: vi.fn(() => ({ get: vi.fn() })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+      Disposable: class {},
+    }));
+
+    const { handleOpenCloudModel, ModelTreeItem } = await import('./sidebar.js');
+    handleOpenCloudModel(new ModelTreeItem('llama3:cloud', 'cloud-stopped'));
+    handleOpenCloudModel(new ModelTreeItem('llama3', 'library-model'));
+
+    expect(openExternal).toHaveBeenCalledTimes(1);
+    const firstCall = openExternal.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    expect((firstCall[0] as { value: string }).value).toContain('https://ollama.com/library/');
+  });
+
   it('handlePullModel reports streaming progress via withProgress', async () => {
     vi.resetModules();
 

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -34,7 +34,7 @@ const execAsync = promisify(exec);
  * loudly rather than silently producing empty results.
  * Silently passes when the header is absent (some servers omit it).
  */
-function assertHtmlContentType(response: Response): void {
+export function assertHtmlContentType(response: Response): void {
   const rawCt = response.headers?.get('content-type') ?? '';
   const normalizedCt = rawCt.toLowerCase();
   if (rawCt && !normalizedCt.includes('text/html')) {
@@ -134,7 +134,7 @@ function createThemeIcon(id: string): ThemeIcon {
 /** Atomic multi-token family prefixes that must not be split at dashes. */
 const FAMILY_EXCEPTIONS = ['gpt-oss', 'open-orca'];
 
-function extractModelFamily(modelName: string): string {
+export function extractModelFamily(modelName: string): string {
   // Remove everything after colon if present
   const baseName = modelName.split(':')[0];
 
@@ -177,7 +177,7 @@ function extractModelFamily(modelName: string): string {
 /**
  * Group models by their family name
  */
-function groupModelsByFamily(models: ModelTreeItem[]): Map<string, ModelTreeItem[]> {
+export function groupModelsByFamily(models: ModelTreeItem[]): Map<string, ModelTreeItem[]> {
   const groups = new Map<string, ModelTreeItem[]>();
 
   for (const model of models) {
@@ -194,7 +194,7 @@ function groupModelsByFamily(models: ModelTreeItem[]): Map<string, ModelTreeItem
 /**
  * Aggregate capabilities from all child models in a family
  */
-function aggregateFamilyCapabilities(familyModels: ModelTreeItem[]): {
+export function aggregateFamilyCapabilities(familyModels: ModelTreeItem[]): {
   thinking: boolean;
   tools: boolean;
   vision: boolean;
@@ -234,7 +234,7 @@ type RunningProcessInfo = {
   sizeVram?: number;
 };
 
-function formatRelativeFromNow(ms?: number): string {
+export function formatRelativeFromNow(ms?: number): string {
   if (typeof ms !== 'number') {
     return 'Not running';
   }
@@ -257,7 +257,7 @@ function formatRelativeFromNow(ms?: number): string {
   return `${secs} second${secs === 1 ? '' : 's'} from now`;
 }
 
-function formatSizeForTooltip(bytes?: number): string {
+export function formatSizeForTooltip(bytes?: number): string {
   if (!bytes) {
     return 'Unknown';
   }
@@ -266,7 +266,7 @@ function formatSizeForTooltip(bytes?: number): string {
   return `${gb.toFixed(1)} GB`;
 }
 
-function buildLocalModelTooltip(
+export function buildLocalModelTooltip(
   modelName: string,
   size?: number,
   running?: RunningProcessInfo,
@@ -330,7 +330,7 @@ function buildLocalModelTooltip(
   return lines.join('\n');
 }
 
-function buildCapabilityLines(caps: {
+export function buildCapabilityLines(caps: {
   thinking?: boolean;
   tools?: boolean;
   vision?: boolean;
@@ -353,10 +353,16 @@ function buildCapabilityLines(caps: {
  * URL cannot be redirected to an attacker-controlled host regardless of the
  * model name value.
  */
-function getLibraryModelUrl(modelName: string): string {
+export function getLibraryModelUrl(modelName: string): string {
   const encoded = modelName
     .split('/')
-    .map(segment => encodeURIComponent(segment))
+    .map(segment => {
+      if (/^\.+$/.test(segment)) {
+        // Prevent path dot-segment traversal by percent-encoding dots.
+        return segment.replace(/\./g, '%2E');
+      }
+      return encodeURIComponent(segment);
+    })
     .join('/');
   return `https://ollama.com/library/${encoded}`;
 }

--- a/src/sidebar.utils.test.ts
+++ b/src/sidebar.utils.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.doMock('vscode', () => ({
+    TreeItem: class {
+      label: string;
+      description?: string;
+      contextValue?: string;
+      collapsibleState?: number;
+      iconPath?: unknown;
+      tooltip?: string;
+      command?: unknown;
+
+      constructor(label: string) {
+        this.label = label;
+      }
+    },
+    ThemeIcon: class {
+      id: string;
+      constructor(id: string) {
+        this.id = id;
+      }
+    },
+    TreeItemCollapsibleState: {
+      None: 0,
+      Collapsed: 1,
+      Expanded: 2,
+    },
+    EventEmitter: class {
+      event = {};
+      fire = vi.fn();
+    },
+    window: {
+      showInformationMessage: vi.fn(),
+      showWarningMessage: vi.fn(),
+      showErrorMessage: vi.fn(),
+      createTreeView: vi.fn(() => ({ dispose: vi.fn() })),
+      withProgress: vi.fn(async (_opts: unknown, cb: (progress: unknown, token: unknown) => Promise<void>) =>
+        cb({}, {}),
+      ),
+      createTerminal: vi.fn(() => ({ show: vi.fn(), sendText: vi.fn() })),
+      showInputBox: vi.fn(),
+    },
+    commands: {
+      registerCommand: vi.fn(() => ({ dispose: vi.fn() })),
+      executeCommand: vi.fn(),
+    },
+    env: {
+      openExternal: vi.fn(),
+    },
+    Uri: {
+      parse: vi.fn((value: string) => ({ value })),
+    },
+    ProgressLocation: { Notification: 15 },
+    workspace: {
+      getConfiguration: vi.fn(() => ({ get: vi.fn(() => 0), update: vi.fn() })),
+      onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+    },
+    Disposable: class {},
+  }));
+});
+
+describe('sidebar utility helpers', () => {
+  it('assertHtmlContentType accepts missing or text/html headers and rejects non-html', async () => {
+    const { assertHtmlContentType } = await import('./sidebar.js');
+
+    expect(() =>
+      assertHtmlContentType({
+        headers: { get: () => null },
+        url: 'https://ollama.com/library',
+        status: 200,
+      } as unknown as Response),
+    ).not.toThrow();
+
+    expect(() =>
+      assertHtmlContentType({
+        headers: { get: () => 'text/html; charset=utf-8' },
+        url: 'https://ollama.com/library',
+        status: 200,
+      } as unknown as Response),
+    ).not.toThrow();
+
+    expect(() =>
+      assertHtmlContentType({
+        headers: { get: () => 'application/json' },
+        url: 'https://ollama.com/library',
+        status: 502,
+      } as unknown as Response),
+    ).toThrow("Expected text/html from https://ollama.com/library but got 'application/json' (HTTP 502)");
+  });
+
+  it('extractModelFamily handles exception, dashed, numeric and embedded-version names', async () => {
+    const { extractModelFamily } = await import('./sidebar.js');
+
+    expect(extractModelFamily('gpt-oss-20b:latest')).toBe('gpt-oss');
+    expect(extractModelFamily('open-orca-small:latest')).toBe('open-orca');
+    expect(extractModelFamily('command-r:latest')).toBe('command');
+    expect(extractModelFamily('phi3.5:latest')).toBe('phi');
+    expect(extractModelFamily('qwen2.5vl:latest')).toBe('qwen');
+    expect(extractModelFamily('r1-large:latest')).toBe('r1');
+    expect(extractModelFamily('mistral:latest')).toBe('mistral');
+  });
+
+  it('groupModelsByFamily groups by extracted family', async () => {
+    const { ModelTreeItem, groupModelsByFamily } = await import('./sidebar.js');
+
+    const models = [
+      new ModelTreeItem('llama3.2:latest', 'local-stopped'),
+      new ModelTreeItem('llama2:latest', 'local-stopped'),
+      new ModelTreeItem('mistral:latest', 'local-stopped'),
+    ];
+
+    const grouped = groupModelsByFamily(models);
+    expect(grouped.get('llama')?.length).toBe(2);
+    expect(grouped.get('mistral')?.length).toBe(1);
+  });
+
+  it('aggregateFamilyCapabilities and buildCapabilityLines combine badges', async () => {
+    const { ModelTreeItem, aggregateFamilyCapabilities, buildCapabilityLines } = await import('./sidebar.js');
+
+    const a = new ModelTreeItem('a', 'local-stopped');
+    a.description = 'size 🧠 🛠️';
+    const b = new ModelTreeItem('b', 'local-stopped');
+    b.description = '👁️';
+    const c = new ModelTreeItem('c', 'local-stopped');
+    c.description = '🧩';
+
+    const caps = aggregateFamilyCapabilities([a, b, c]);
+    expect(caps).toEqual({ thinking: true, tools: true, vision: true, embedding: true });
+
+    expect(buildCapabilityLines(caps)).toContain('🧠 Thinking');
+    expect(buildCapabilityLines({})).toBe('');
+  });
+
+  it('formatRelativeFromNow and formatSizeForTooltip cover edge branches', async () => {
+    const { formatRelativeFromNow, formatSizeForTooltip } = await import('./sidebar.js');
+
+    expect(formatRelativeFromNow(undefined)).toBe('Not running');
+    expect(formatRelativeFromNow(0)).toBe('now');
+    expect(formatRelativeFromNow(1500)).toBe('1 second from now');
+    expect(formatRelativeFromNow(65_000)).toBe('1 minute from now');
+    expect(formatRelativeFromNow(2 * 60 * 60 * 1000)).toBe('2 hours from now');
+
+    expect(formatSizeForTooltip(undefined)).toBe('Unknown');
+    expect(formatSizeForTooltip(1024 ** 3)).toBe('1.0 GB');
+  });
+
+  it('buildLocalModelTooltip includes capability line and running details', async () => {
+    const { buildLocalModelTooltip } = await import('./sidebar.js');
+
+    const tooltip = buildLocalModelTooltip(
+      'llama3.2:latest',
+      3 * 1024 ** 3,
+      { id: 'abc', durationMs: 90_000, processor: '25% GPU', size: 3 * 1024 ** 3, sizeVram: 1 * 1024 ** 3 },
+      'description',
+      { thinking: true, toolCalling: true, imageInput: false, embedding: true },
+    );
+
+    expect(tooltip).toContain('🆔 abc');
+    expect(tooltip).toContain('CPU: 75% | GPU: 25%');
+    expect(tooltip).toContain('🧠 Thinking');
+    expect(tooltip).toContain('description');
+  });
+
+  it('getLibraryModelUrl safely encodes path segments', async () => {
+    const { getLibraryModelUrl } = await import('./sidebar.js');
+    expect(getLibraryModelUrl('org/model name')).toBe('https://ollama.com/library/org/model%20name');
+    expect(getLibraryModelUrl('../bad')).toBe('https://ollama.com/library/%2E%2E/bad');
+  });
+});


### PR DESCRIPTION
## Summary
- harden XML context filtering for streaming and non-stream responses
- add shared context extraction/dedup helpers
- unify non-stream sanitization usage across provider and @ollama paths
- add regression tests for leaked <user_info>/<workspace_info> tags
- add beans planning artifacts for upcoming OpenAI-compat migration

## Validation
- targeted tests passed (formatting/provider/extension)
- compile passed