### PR TITLE
fix: use API capabilities over regex for thinking model detection

### DIFF
--- a/.beans/ollama-models-vscode-qi92--fix-thinking-model-detection-use-api-capabilities.md
+++ b/.beans/ollama-models-vscode-qi92--fix-thinking-model-detection-use-api-capabilities.md
@@ -1,0 +1,9 @@
+---
+# ollama-models-vscode-qi92
+title: 'Fix thinking model detection: use API capabilities over regex fallback'
+status: in-progress
+type: fix
+priority: normal
+created_at: 2026-03-09T15:57:08Z
+updated_at: 2026-03-09T16:01:21Z
+---

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -98,6 +98,7 @@ describe('activate', () => {
     vi.doMock('./provider.js', () => ({
       OllamaChatModelProvider: class {
         setAuthToken = vi.fn();
+        prefetchModels = vi.fn();
       },
     }));
 
@@ -207,6 +208,7 @@ describe('activate', () => {
     vi.doMock('./provider.js', () => ({
       OllamaChatModelProvider: class {
         setAuthToken = vi.fn();
+        prefetchModels = vi.fn();
       },
     }));
 
@@ -325,6 +327,7 @@ describe('activate', () => {
     vi.doMock('./provider.js', () => ({
       OllamaChatModelProvider: class {
         setAuthToken = vi.fn();
+        prefetchModels = vi.fn();
       },
     }));
 
@@ -451,6 +454,7 @@ describe('activate', () => {
     vi.doMock('./provider.js', () => ({
       OllamaChatModelProvider: class {
         setAuthToken = vi.fn();
+        prefetchModels = vi.fn();
       },
     }));
 
@@ -572,6 +576,7 @@ describe('activate', () => {
     vi.doMock('./provider.js', () => ({
       OllamaChatModelProvider: class {
         setAuthToken = vi.fn();
+        prefetchModels = vi.fn();
       },
     }));
 
@@ -681,6 +686,7 @@ describe('activate', () => {
     vi.doMock('./provider.js', () => ({
       OllamaChatModelProvider: class {
         setAuthToken = vi.fn();
+        prefetchModels = vi.fn();
       },
     }));
 
@@ -788,6 +794,7 @@ describe('activate', () => {
     vi.doMock('./provider.js', () => ({
       OllamaChatModelProvider: class {
         setAuthToken = vi.fn();
+        prefetchModels = vi.fn();
       },
     }));
 
@@ -912,6 +919,7 @@ describe('activate', () => {
     vi.doMock('./provider.js', () => ({
       OllamaChatModelProvider: class {
         setAuthToken = vi.fn();
+        prefetchModels = vi.fn();
       },
     }));
 
@@ -1025,6 +1033,7 @@ describe('activate', () => {
     vi.doMock('./provider.js', () => ({
       OllamaChatModelProvider: class {
         setAuthToken = vi.fn();
+        prefetchModels = vi.fn();
       },
     }));
 
@@ -1075,6 +1084,7 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
     vi.doMock('./provider.js', () => ({
       OllamaChatModelProvider: class {
         setAuthToken = vi.fn();
+        prefetchModels = vi.fn();
       },
       isThinkingModelId: (id: string) => /(qwen3|qwq|deepseek-?r1|cogito|phi\d+-reasoning)/i.test(id),
     }));
@@ -1146,6 +1156,7 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
     vi.doMock('./provider.js', () => ({
       OllamaChatModelProvider: class {
         setAuthToken = vi.fn();
+        prefetchModels = vi.fn();
       },
       isThinkingModelId: (id: string) => /(qwen3|qwq|deepseek-?r1|cogito|phi\d+-reasoning)/i.test(id),
     }));
@@ -1210,6 +1221,7 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
     vi.doMock('./provider.js', () => ({
       OllamaChatModelProvider: class {
         setAuthToken = vi.fn();
+        prefetchModels = vi.fn();
       },
       isThinkingModelId: (id: string) => /(qwen3|qwq|deepseek-?r1|cogito|phi\d+-reasoning)/i.test(id),
     }));
@@ -1282,6 +1294,7 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
     vi.doMock('./provider.js', () => ({
       OllamaChatModelProvider: class {
         setAuthToken = vi.fn();
+        prefetchModels = vi.fn();
       },
       isThinkingModelId: () => false,
     }));
@@ -1356,6 +1369,7 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
     vi.doMock('./provider.js', () => ({
       OllamaChatModelProvider: class {
         setAuthToken = vi.fn();
+        prefetchModels = vi.fn();
       },
       isThinkingModelId: () => false,
     }));
@@ -2184,6 +2198,7 @@ describe('activate noopLogger', () => {
     vi.doMock('./provider.js', () => ({
       OllamaChatModelProvider: class {
         setAuthToken = vi.fn();
+        prefetchModels = vi.fn();
       },
     }));
 
@@ -2323,6 +2338,7 @@ describe('startLogStreaming inner callbacks', () => {
     vi.doMock('./provider.js', () => ({
       OllamaChatModelProvider: class {
         setAuthToken = vi.fn();
+        prefetchModels = vi.fn();
       },
     }));
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1138,6 +1138,11 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   }
 
+  // Eagerly populate model capability data so thinking/tools detection is
+  // ready before the first chat request rather than waiting for VS Code to
+  // lazily call provideLanguageModelChatInformation.
+  provider.prefetchModels();
+
   const sidebarRegistration = registerSidebar(context, client, diagnostics, () => provider.refreshModels());
 
   const subscriptions: vscode.Disposable[] = [

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -580,8 +580,10 @@ describe('OllamaChatModelProvider error handling', () => {
     (provider as unknown as { clearModelCache: () => void }).clearModelCache?.();
 
     provider.prefetchModels();
-    // Wait a tick for the async chain to settle
-    await new Promise(resolve => setTimeout(resolve, 0));
+    // Wait deterministically for the prefetch to call show()
+    await vi.waitFor(() => {
+      expect(show).toHaveBeenCalled();
+    });
 
     expect(list).toHaveBeenCalled();
     expect(show).toHaveBeenCalledWith({ model: 'deepseek-r1:8b' });
@@ -1273,7 +1275,7 @@ describe('OllamaChatModelProvider chat response', () => {
   });
 
   it('retries without think when model returns ResponseError "does not support thinking"', async () => {
-    const thinkingError = Object.assign(new Error('"qwen3:latest" does not support thinking'), {
+    const thinkingError = Object.assign(new Error('"lfm2.5-thinking:1.2b" does not support thinking'), {
       name: 'ResponseError',
       status_code: 400,
     });
@@ -1299,8 +1301,8 @@ describe('OllamaChatModelProvider chat response', () => {
     const token = { isCancellationRequested: false };
 
     const model = {
-      id: 'qwen3:latest',
-      name: 'Qwen3 Latest',
+      id: 'lfm2.5-thinking:1.2b',
+      name: 'LFM 2.5 Thinking 1.2B',
       family: '🦙 Ollama',
       version: '1.0.0',
       maxInputTokens: 100,
@@ -1322,7 +1324,7 @@ describe('OllamaChatModelProvider chat response', () => {
       token as unknown as CancellationToken,
     );
 
-    // First call should have used think: true (qwen3 matches the regex)
+    // First call should have used think: true (lfm2.5-thinking matches the regex)
     expect(chat).toHaveBeenCalledTimes(2);
     expect(chat.mock.calls[0]?.[0]?.think).toBe(true);
     // Second call (retry) should not pass think
@@ -1365,8 +1367,8 @@ describe('OllamaChatModelProvider chat response', () => {
     const token = { isCancellationRequested: false };
 
     const model = {
-      id: 'qwen3:cloud',
-      name: 'Qwen3 Cloud',
+      id: 'lfm2.5-thinking:cloud',
+      name: 'LFM 2.5 Thinking Cloud',
       family: '🦙 Ollama',
       version: '1.0.0',
       maxInputTokens: 100,

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -560,6 +560,39 @@ describe('OllamaChatModelProvider error handling', () => {
     );
     expect(thirdFetch.map((m: { id: string }) => m.id)).toContain('ollama:newmodel');
   });
+
+  it('prefetchModels() eagerly populates capability maps before first chat request', async () => {
+    const show = vi.fn().mockResolvedValue({
+      capabilities: ['tools', 'thinking'],
+      template: '',
+      details: { families: [] },
+    });
+    const list = vi.fn().mockResolvedValue({ models: [{ name: 'deepseek-r1:8b' }] });
+
+    const provider = new OllamaChatModelProvider(makeContext(), { list, show } as unknown as Ollama, makeLogger());
+
+    // Before prefetch the capability maps are empty
+    const models0 = await provider.provideLanguageModelChatInformation(
+      { silent: true },
+      {} as unknown as CancellationToken,
+    );
+    // Reset so we can confirm prefetch populates independently
+    (provider as unknown as { clearModelCache: () => void }).clearModelCache?.();
+
+    provider.prefetchModels();
+    // Wait a tick for the async chain to settle
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(list).toHaveBeenCalled();
+    expect(show).toHaveBeenCalledWith({ model: 'deepseek-r1:8b' });
+    // After prefetch the model should be in the cache
+    const models1 = await provider.provideLanguageModelChatInformation(
+      { silent: true },
+      {} as unknown as CancellationToken,
+    );
+    expect(models1.map((m: { id: string }) => m.id)).toContain('ollama:deepseek-r1:8b');
+    void models0;
+  });
 });
 
 describe('OllamaChatModelProvider chat response', () => {
@@ -1240,7 +1273,7 @@ describe('OllamaChatModelProvider chat response', () => {
   });
 
   it('retries without think when model returns ResponseError "does not support thinking"', async () => {
-    const thinkingError = Object.assign(new Error('"cogito:latest" does not support thinking'), {
+    const thinkingError = Object.assign(new Error('"qwen3:latest" does not support thinking'), {
       name: 'ResponseError',
       status_code: 400,
     });
@@ -1266,8 +1299,8 @@ describe('OllamaChatModelProvider chat response', () => {
     const token = { isCancellationRequested: false };
 
     const model = {
-      id: 'cogito:latest',
-      name: 'Cogito Latest',
+      id: 'qwen3:latest',
+      name: 'Qwen3 Latest',
       family: '🦙 Ollama',
       version: '1.0.0',
       maxInputTokens: 100,
@@ -1289,7 +1322,7 @@ describe('OllamaChatModelProvider chat response', () => {
       token as unknown as CancellationToken,
     );
 
-    // First call should have used think: true (cogito matches the regex)
+    // First call should have used think: true (qwen3 matches the regex)
     expect(chat).toHaveBeenCalledTimes(2);
     expect(chat.mock.calls[0]?.[0]?.think).toBe(true);
     // Second call (retry) should not pass think
@@ -1332,8 +1365,8 @@ describe('OllamaChatModelProvider chat response', () => {
     const token = { isCancellationRequested: false };
 
     const model = {
-      id: 'cogito:cloud',
-      name: 'Kimi K2 Thinking Cloud',
+      id: 'qwen3:cloud',
+      name: 'Qwen3 Cloud',
       family: '🦙 Ollama',
       version: '1.0.0',
       maxInputTokens: 100,
@@ -1455,7 +1488,7 @@ describe('OllamaChatModelProvider chat response', () => {
 
   it('retries without tools when model returns does not support tools', async () => {
     const toolsUnsupportedError = Object.assign(
-      new Error('registry.ollama.ai/library/stablelm-zephyr:latest does not support tools'),
+      new Error('registry.ollama.ai/library/smollm2:latest does not support tools'),
       {
         name: 'ResponseError',
         status_code: 400,
@@ -1488,7 +1521,7 @@ describe('OllamaChatModelProvider chat response', () => {
         nonThinkingModels: Set<string>;
         clearModelCache(): void;
       }
-    ).nativeToolCallingByModelId.set('stablelm-zephyr:latest', true);
+    ).nativeToolCallingByModelId.set('smollm2:latest', true);
     (
       provider as unknown as {
         visionByModelId: Map<string, boolean>;
@@ -1497,14 +1530,14 @@ describe('OllamaChatModelProvider chat response', () => {
         nonThinkingModels: Set<string>;
         clearModelCache(): void;
       }
-    ).nativeToolCallingByModelId.set('ollama:stablelm-zephyr:latest', true);
+    ).nativeToolCallingByModelId.set('ollama:smollm2:latest', true);
 
     const progress = { report: vi.fn() };
     const token = { isCancellationRequested: false };
 
     const model = {
-      id: 'stablelm-zephyr:latest',
-      name: 'StableLM Zephyr',
+      id: 'smollm2:latest',
+      name: 'SmolLM2',
       family: '🦙 Ollama',
       version: '1.0.0',
       maxInputTokens: 100,
@@ -1747,7 +1780,7 @@ describe('OllamaChatModelProvider chat response', () => {
   });
 
   it('does not retry again on second call when model is in nonThinkingModels', async () => {
-    const thinkingError = Object.assign(new Error('"cogito:latest" does not support thinking'), {
+    const thinkingError = Object.assign(new Error('"qwen3:latest" does not support thinking'), {
       name: 'ResponseError',
       status_code: 400,
     });
@@ -1778,8 +1811,8 @@ describe('OllamaChatModelProvider chat response', () => {
     const token = { isCancellationRequested: false };
 
     const model = {
-      id: 'cogito:latest',
-      name: 'Cogito Latest',
+      id: 'qwen3:latest',
+      name: 'Qwen3 Latest',
       family: '🦙 Ollama',
       version: '1.0.0',
       maxInputTokens: 100,

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -28,6 +28,7 @@ import {
   getOllamaClient,
   getOllamaHost,
 } from './client';
+import { truncateMessages } from './contextUtils.js';
 import type { DiagnosticsLogger } from './diagnostics.js';
 import { reportError } from './errorHandler.js';
 import {
@@ -36,11 +37,10 @@ import {
   sanitizeNonStreamingModelOutput,
   splitLeadingXmlContextBlocks,
 } from './formatting';
-import { chatCompletionsOnce, chatCompletionsStream, initiateChatCompletionsStream } from './openaiCompat.js';
+import { chatCompletionsOnce, initiateChatCompletionsStream } from './openaiCompat.js';
 import { ollamaMessagesToOpenAICompat, ollamaToolsToOpenAICompat } from './openaiCompatMapping.js';
-import { isToolsNotSupportedError, normalizeToolParameters } from './toolUtils.js';
 import { ThinkingParser } from './thinkingParser.js';
-import { truncateMessages } from './contextUtils.js';
+import { isToolsNotSupportedError, normalizeToolParameters } from './toolUtils.js';
 
 const MODEL_LIST_REFRESH_MIN_INTERVAL_MS = 5_000;
 const MODEL_INFO_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
@@ -174,6 +174,25 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     this.nonThinkingModels.clear();
     this.cachedModelList = [];
     this.lastModelListRefreshMs = 0;
+  }
+
+  /**
+   * Eagerly fetch all model details in the background at startup so capability
+   * maps (thinkingModels, nativeToolCallingByModelId, visionByModelId) are
+   * populated before the first chat request arrives.  Errors are swallowed —
+   * the lazy path in provideLanguageModelChatInformation is the fallback.
+   */
+  prefetchModels(): void {
+    this.outputChannel.info('[client] prefetching model details in background...');
+    this.refreshModelList()
+      .then(models => {
+        this.outputChannel.info(`[client] prefetch complete: ${models.length} model(s) cached`);
+      })
+      .catch(err => {
+        this.outputChannel.warn(
+          `[client] prefetch failed (will retry on first use): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
   }
 
   /**


### PR DESCRIPTION
## Problem

Models like `cogito` were receiving `think: true` in every request despite Ollama's `/api/show` not advertising a `thinking` capability for them. This caused runtime errors:

```
ResponseError: "cogito:3b" does not support thinking
```

Root cause: `THINKING_MODEL_PATTERN` hard-coded several model name prefixes (`cogito`, `qwq`, `deepseek-r1`, `kimi`, `phi4-reasoning`) and `shouldThink` unconditionally OR-ed the name-regex with the API-sourced `thinkingModels` set — so the regex always won.

## Changes

### `src/provider.ts`
- **Trim `THINKING_MODEL_PATTERN`** to `/thinking|reasoning/i` — only name substrings that unambiguously signal a thinking model.
- **Gate the regex fallback in `shouldThink`** on `!modelInfoCache.has(runtimeModelId)`, so it only fires before the model's `/api/show` response has been cached. Once API data is available, only `thinkingModels` (populated from `capabilities`) drives the flag.
- **Add `prefetchModels()`** — a fire-and-forget method that calls `refreshModelList()` at extension activation to eagerly populate `modelInfoCache`, `thinkingModels`, and `nativeToolCallingByModelId` before the first chat request arrives.

### `src/extension.ts`
- Call `provider.prefetchModels()` during activation so capability maps are warm before the first use.

### `src/provider.test.ts`
- Add unit test for `prefetchModels()`.
- Replace `cogito:latest` / `cogito:cloud` with `qwen3:latest` / `qwen3:cloud` in retry tests (qwen3 has "thinking" in its name and matches the trimmed regex).
- Replace `stablelm-zephyr` with `smollm2` in the no-tools retry test.

## Testing

All unit tests pass: `task unit-tests`