### PR TITLE
feat: handle VS Code 1.111 Autopilot task_complete tool and bump engine to 1.111

### DIFF
--- a/.beans/ollama-models-vscode-lvli--vs1111-handle-autopilot-task-complete-tool-and-bum.md
+++ b/.beans/ollama-models-vscode-lvli--vs1111-handle-autopilot-task-complete-tool-and-bum.md
@@ -1,0 +1,10 @@
+---
+# ollama-models-vscode-lvli
+title: 'vs1111: handle Autopilot task_complete tool and bump engine to 1.111'
+status: in-progress
+type: feat
+priority: normal
+created_at: 2026-03-09T17:29:36Z
+updated_at: 2026-03-09T17:29:43Z
+---
+

--- a/.beans/ollama-models-vscode-lvli--vs1111-handle-autopilot-task-complete-tool-and-bum.md
+++ b/.beans/ollama-models-vscode-lvli--vs1111-handle-autopilot-task-complete-tool-and-bum.md
@@ -5,6 +5,5 @@ status: in-progress
 type: feat
 priority: normal
 created_at: 2026-03-09T17:29:36Z
-updated_at: 2026-03-09T17:29:43Z
+updated_at: 2026-03-09T17:33:33Z
 ---
-

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "saxophone": "^0.8.0"
   },
   "devDependencies": {
-    "@go-task/cli": "^3.49.0",
+    "@go-task/cli": "^3.49.1",
     "@octokit/rest": "^22.0.1",
     "@types/node": "^25.3.5",
     "@types/vscode": "^1.109.0",
@@ -634,7 +634,7 @@
   ],
   "icon": "logo.png",
   "engines": {
-    "vscode": "^1.109.0"
+    "vscode": "^1.111.0"
   },
   "packageManager": "pnpm@10.31.0+sha512.e3927388bfaa8078ceb79b748ffc1e8274e84d75163e67bc22e06c0d3aed43dd153151cbf11d7f8301ff4acb98c68bdc5cadf6989532801ffafe3b3e4a63c268",
   "pnpm": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
       "task precommit -- "
     ],
     "**/*.{json,yml,yaml,md}": [
-      "oxfmt --write"
+      "oxfmt --write -- "
     ]
   },
   "contributes": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         version: 0.8.0
     devDependencies:
       '@go-task/cli':
-        specifier: ^3.49.0
-        version: 3.49.0
+        specifier: ^3.49.1
+        version: 3.49.1
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
@@ -501,8 +501,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@go-task/cli@3.49.0':
-    resolution: {integrity: sha512-2OA4uweJyMhf3sG8rFCs/Fsj4WsnkWVtj6Caxz0tgzt1v0a8hof3LfSGm4+Q219qhuhjhNschCstGRsobGEl6g==}
+  '@go-task/cli@3.49.1':
+    resolution: {integrity: sha512-kmFcIfiKfuEYeuj4Rslp+yGUSIq29CeuxZjnYUv6vsAHY1Kz6KTpUbl0Q0PPOG5vAME1iFrp+7rdrziQTkBmQw==}
     hasBin: true
 
   '@iconify-json/simple-icons@1.2.72':
@@ -3417,7 +3417,7 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@go-task/cli@3.49.0':
+  '@go-task/cli@3.49.1':
     dependencies:
       axios: 1.13.6
       jszip: 3.10.1

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1808,6 +1808,212 @@ describe('handleChatRequest model selection', () => {
     expect(mockSendRequest).toHaveBeenCalledTimes(2);
     expect(mockMarkdown).toHaveBeenCalledWith('recovered');
   });
+
+  it('invokes task_complete and exits without extra rounds (VS Code LM API path)', async () => {
+    vi.resetModules();
+
+    vi.doMock('./client.js', () => ({ getOllamaClient: vi.fn(), testConnection: vi.fn() }));
+    vi.doMock('./diagnostics.js', () => ({
+      createDiagnosticsLogger: () => ({
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+        exception: vi.fn(),
+      }),
+      getConfiguredLogLevel: vi.fn(() => 'info'),
+    }));
+    vi.doMock('./provider.js', () => ({
+      OllamaChatModelProvider: class {
+        setAuthToken = vi.fn();
+        prefetchModels = vi.fn();
+      },
+      isThinkingModelId: () => false,
+    }));
+    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
+    vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
+
+    const LMTextPart = class {
+      constructor(public value: string) {}
+    };
+    const LMToolCallPart = class {
+      constructor(
+        public callId: string,
+        public name: string,
+        public input: Record<string, unknown>,
+      ) {}
+    };
+    const LMToolResultPart = class {
+      constructor(
+        public callId: string,
+        public content: unknown,
+      ) {}
+    };
+
+    // Single round: stream yields buffered text + task_complete; no second round should occur.
+    const mockSendRequest = vi.fn().mockResolvedValueOnce({
+      stream: (async function* () {
+        yield new LMTextPart('all done');
+        yield new LMToolCallPart('tc-1', 'task_complete', {});
+      })(),
+    });
+
+    const mockInvokeTool = vi.fn().mockResolvedValue({ content: [] });
+    const mockSelectChatModels = vi
+      .fn()
+      .mockResolvedValue([{ vendor: 'selfagency-opilot', sendRequest: mockSendRequest }]);
+
+    vi.doMock('vscode', () => ({
+      LanguageModelTextPart: LMTextPart,
+      LanguageModelToolCallPart: LMToolCallPart,
+      LanguageModelToolResultPart: LMToolResultPart,
+      ChatRequestTurn: class {},
+      ChatResponseTurn: class {},
+      ChatResponseMarkdownPart: class {},
+      LanguageModelChatMessage: {
+        User: (content: unknown) => ({ role: 'user', content }),
+        Assistant: (content: unknown) => ({ role: 'assistant', content }),
+      },
+      lm: {
+        selectChatModels: mockSelectChatModels,
+        tools: [{ name: 'task_complete', description: 'signal done', inputSchema: {} }],
+        invokeTool: mockInvokeTool,
+      },
+      workspace: { getConfiguration: vi.fn().mockReturnValue({ get: vi.fn() }) },
+      Uri: {
+        file: vi.fn((path: string) => ({ fsPath: path })),
+        joinPath: vi.fn((_base: any, p: string) => ({ fsPath: p })),
+      },
+      chat: { createChatParticipant: vi.fn(() => ({ iconPath: undefined, dispose: vi.fn() })) },
+      commands: { registerCommand: vi.fn(() => ({ dispose: vi.fn() })), executeCommand: vi.fn() },
+    }));
+
+    const ext = await import('./extension.js');
+    const mockMarkdown = vi.fn();
+    const mockRequest = {
+      prompt: 'finish',
+      model: { vendor: 'copilot' },
+      toolInvocationToken: 'tok-tc',
+    };
+
+    await ext.handleChatRequest(
+      mockRequest as any,
+      { history: [] } as any,
+      { markdown: mockMarkdown } as any,
+      { isCancellationRequested: false } as any,
+    );
+
+    // Only one round — task_complete terminates the loop immediately.
+    expect(mockSendRequest).toHaveBeenCalledTimes(1);
+    // Buffered text flushed before exiting.
+    expect(mockMarkdown).toHaveBeenCalledWith('all done');
+    // task_complete was invoked for VS Code bookkeeping.
+    expect(mockInvokeTool).toHaveBeenCalledWith(
+      'task_complete',
+      expect.objectContaining({ toolInvocationToken: 'tok-tc' }),
+      expect.anything(),
+    );
+  });
+});
+
+describe('handleChatRequest native Ollama task_complete', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('invokes task_complete, renders final content, and exits without an extra tool round', async () => {
+    vi.doMock('./client.js', () => ({ getOllamaClient: vi.fn(), testConnection: vi.fn() }));
+    vi.doMock('./diagnostics.js', () => ({
+      createDiagnosticsLogger: () => ({
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+        exception: vi.fn(),
+      }),
+      getConfiguredLogLevel: vi.fn(() => 'info'),
+    }));
+    vi.doMock('./provider.js', () => ({
+      OllamaChatModelProvider: class {
+        setAuthToken = vi.fn();
+        prefetchModels = vi.fn();
+      },
+      isThinkingModelId: () => false,
+    }));
+    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
+    vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
+
+    const mockInvokeTool = vi.fn().mockResolvedValue({ content: [] });
+
+    vi.doMock('vscode', () => ({
+      LanguageModelTextPart: class {
+        constructor(public value: string) {}
+      },
+      LanguageModelChatMessageRole: { User: 1, Assistant: 2 },
+      ChatRequestTurn: class {},
+      ChatResponseTurn: class {},
+      ChatResponseMarkdownPart: class {},
+      LanguageModelChatMessage: {
+        User: (content: string) => ({ role: 1, content }),
+        Assistant: (content: string) => ({ role: 2, content }),
+      },
+      lm: {
+        selectChatModels: vi.fn().mockResolvedValue([]),
+        tools: [{ name: 'task_complete', description: 'signal done', inputSchema: {} }],
+        invokeTool: mockInvokeTool,
+      },
+      workspace: { getConfiguration: vi.fn().mockReturnValue({ get: vi.fn() }) },
+      Uri: {
+        file: vi.fn((path: string) => ({ fsPath: path })),
+        joinPath: vi.fn((_base: any, p: string) => ({ fsPath: p })),
+      },
+      chat: { createChatParticipant: vi.fn(() => ({ iconPath: undefined, dispose: vi.fn() })) },
+      commands: { registerCommand: vi.fn(() => ({ dispose: vi.fn() })), executeCommand: vi.fn() },
+    }));
+
+    const ext = await import('./extension.js');
+    const mockMarkdown = vi.fn();
+    const stream = { markdown: mockMarkdown };
+    const token = { isCancellationRequested: false };
+
+    // Round 1: model returns task_complete + final content (plain ChatResponse, stream: false).
+    // Round 2 should never be reached.
+    const mockChat = vi
+      .fn()
+      .mockResolvedValueOnce({
+        message: {
+          content: 'Task finished.',
+          tool_calls: [{ function: { name: 'task_complete', arguments: {} } }],
+        },
+      })
+      // If a second round were called this would make the test fail clearly.
+      .mockResolvedValueOnce({
+        message: { content: 'should not appear' },
+        done: true,
+      });
+
+    const mockClient = { chat: mockChat };
+    const request = {
+      prompt: 'finish',
+      model: { vendor: 'selfagency-opilot', id: 'llama3.2:latest' },
+      toolInvocationToken: 'tok-native',
+    };
+
+    await ext.handleChatRequest(request as any, { history: [] } as any, stream as any, token as any, mockClient as any);
+
+    // Only one round of chat — task_complete signals completion.
+    expect(mockChat).toHaveBeenCalledTimes(1);
+    // Final content from the model was rendered.
+    expect(mockMarkdown).toHaveBeenCalledWith(expect.stringContaining('Task finished.'));
+    // task_complete was invoked for VS Code bookkeeping.
+    expect(mockInvokeTool).toHaveBeenCalledWith(
+      'task_complete',
+      expect.objectContaining({ toolInvocationToken: 'tok-native' }),
+      expect.anything(),
+    );
+    // No empty tool-result message was pushed (no second chat call).
+    expect(mockMarkdown).not.toHaveBeenCalledWith(expect.stringContaining('should not appear'));
+  });
 });
 
 describe('handleBuiltInOllamaConflict', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,8 @@ import {
 
 const LANGUAGE_MODEL_VENDOR = 'selfagency-opilot';
 const PROVIDER_MODEL_ID_PREFIX = 'ollama:';
+/** VS Code Autopilot signals task completion by having the model call this tool. */
+const TASK_COMPLETE_TOOL_NAME = 'task_complete';
 let builtInOllamaConflictPromptInProgress = false;
 
 export function toRuntimeModelId(modelId: string): string {
@@ -693,8 +695,25 @@ export async function handleChatRequest(
           });
 
           // Invoke each tool via VS Code's tool API and append result messages.
+          let calledTaskComplete = false;
           for (const toolCall of toolCalls) {
             const toolName = toolCall.function.name;
+            // task_complete is VS Code's Autopilot signal — invoke it for bookkeeping
+            // then break the loop; no tool-result message is needed.
+            if (toolName === TASK_COMPLETE_TOOL_NAME) {
+              calledTaskComplete = true;
+              try {
+                await vscode.lm.invokeTool(
+                  toolName,
+                  {
+                    input: toolCall.function.arguments as Record<string, unknown>,
+                    toolInvocationToken: request.toolInvocationToken!,
+                  },
+                  token,
+                );
+              } catch { /* ignore — task_complete failure should not block response */ }
+              continue;
+            }
             const toolInput = toolCall.function.arguments;
             let resultText: string;
             try {
@@ -716,6 +735,14 @@ export async function handleChatRequest(
               tool_name: toolName,
               tool_call_id: (toolCall as { id?: string }).id,
             } as never);
+          }
+
+          // task_complete signals the agent is done — display any final content and exit.
+          if (calledTaskComplete) {
+            if (roundResponse.message.content) {
+              stream.markdown(sanitizeNonStreamingModelOutput(roundResponse.message.content));
+            }
+            return;
           }
         }
         // MAX_TOOL_ROUNDS reached — fall through to the streaming pass below.
@@ -991,10 +1018,22 @@ export async function handleChatRequest(
         }
       }
 
-      if (pendingToolCalls.length === 0 || !request.toolInvocationToken) {
-        // No more tool calls — stream any buffered text and finish.
+      const hasTaskComplete = pendingToolCalls.some(tc => tc.name === TASK_COMPLETE_TOOL_NAME);
+      if (pendingToolCalls.length === 0 || !request.toolInvocationToken || hasTaskComplete) {
+        // No more tool calls (or task_complete was invoked) — stream buffered text and finish.
         for (const part of assistantTextParts) {
           stream.markdown(part.value);
+        }
+        // Invoke task_complete for VS Code Autopilot bookkeeping.
+        if (hasTaskComplete && request.toolInvocationToken) {
+          const tc = pendingToolCalls.find(c => c.name === TASK_COMPLETE_TOOL_NAME)!;
+          try {
+            await vscode.lm.invokeTool(
+              TASK_COMPLETE_TOOL_NAME,
+              { input: tc.input as Record<string, unknown>, toolInvocationToken: request.toolInvocationToken },
+              token,
+            );
+          } catch { /* ignore */ }
         }
         break;
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -711,8 +711,10 @@ export async function handleChatRequest(
                   },
                   token,
                 );
-              } catch { /* ignore — task_complete failure should not block response */ }
-              continue;
+              } catch {
+                /* ignore — task_complete failure should not block response */
+              }
+              break;
             }
             const toolInput = toolCall.function.arguments;
             let resultText: string;
@@ -1033,7 +1035,9 @@ export async function handleChatRequest(
               { input: tc.input as Record<string, unknown>, toolInvocationToken: request.toolInvocationToken },
               token,
             );
-          } catch { /* ignore */ }
+          } catch {
+            /* ignore */
+          }
         }
         break;
       }


### PR DESCRIPTION
## VS Code 1.111 compatibility

### 1. Autopilot `task_complete` tool handling

VS Code 1.111 introduced Autopilot mode (`chat.autopilot.enabled`). When Autopilot is active, VS Code injects a built-in `task_complete` tool into `vscode.lm.tools`. Models call it to autonomously signal they are done with a task.

**Without this change:** the `@ollama` participant's tool loop would invoke `task_complete`, push an empty tool-result message, and spin through additional rounds rather than exiting — unnecessary model calls and potentially confusing follow-up responses.

**With this change:**
- **Native Ollama tool loop**: when `task_complete` appears in the tool calls for a round, invoke it for VS Code bookkeeping, display any final content the model attached, then `return` immediately.
- **VS Code LM API tool loop**: when `task_complete` appears in `pendingToolCalls`, emit any buffered text, invoke the tool, then `break` the loop.
- `TASK_COMPLETE_TOOL_NAME = 'task_complete'` constant added at module level for consistency.

### 2. Engine version bump

`engines.vscode` updated `^1.109.0` → `^1.111.0`.

> **Note:** `@types/vscode@1.111.0` is not yet published on npm. Will be updated as a follow-up.

## Testing

All 435 unit tests pass. `task_complete` behavior can be verified manually by enabling `chat.autopilot.enabled` in VS Code Insiders and sending a request to `@ollama`.