### PR TITLE
fix: call handleBuiltInOllamaConflict during extension activation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1186,8 +1186,16 @@ export async function activate(context: vscode.ExtensionContext) {
   // lazily call provideLanguageModelChatInformation.
   provider.prefetchModels();
 
-  // Detect and prompt to disable VS Code's built-in Ollama provider
-  void handleBuiltInOllamaConflict(undefined, undefined, undefined, undefined, context);
+  // Detect and prompt to disable VS Code's built-in Ollama provider (non-blocking)
+  void (async () => {
+    try {
+      await handleBuiltInOllamaConflict(undefined, undefined, undefined, undefined, context);
+    } catch (error) {
+      diagnostics.debug(
+        `[client] Built-in Ollama conflict check failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  })();
 
   const sidebarRegistration = registerSidebar(context, client, diagnostics, () => provider.refreshModels());
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1186,6 +1186,9 @@ export async function activate(context: vscode.ExtensionContext) {
   // lazily call provideLanguageModelChatInformation.
   provider.prefetchModels();
 
+  // Detect and prompt to disable VS Code's built-in Ollama provider
+  void handleBuiltInOllamaConflict(undefined, undefined, undefined, undefined, context);
+
   const sidebarRegistration = registerSidebar(context, client, diagnostics, () => provider.refreshModels());
 
   const subscriptions: vscode.Disposable[] = [


### PR DESCRIPTION
## Problem
VS Code's built-in Ollama provider was remaining active even though this extension was supposed to override it. Both providers (vendor: `'ollama'` and vendor: `'selfagency-opilot'`) were showing up in the Copilot Chat model picker simultaneously, causing duplicate models to appear.

## Root Cause
The `handleBuiltInOllamaConflict()` function existed and could detect and disable the built-in provider, but it was **never being called** during extension activation. This meant the conflict detection logic never ran.

## Solution
Call `handleBuiltInOllamaConflict(context)` during provider registration in the `activate()` function. This ensures:
1. The built-in Ollama provider is detected
2. User is prompted to disable it
3. The setting is automatically cleared to disable the provider
4. VS Code is reloaded to apply the change

## Changes
- Added call to `handleBuiltInOllamaConflict(context)` in `src/extension.ts` after model prefetching, right before sidebar registration