### PR TITLE
feat(library): hardware-based model recommendations with thumbsup toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 
 ## 🔧 Requirements
 
-- **VS Code** 1.109.0 or higher
+- **VS Code** 1.111.0 or higher
 - **GitHub Copilot Chat** extension installed and active
 - **Ollama** installed locally ([Download](https://ollama.ai/download)) **or** a remote Ollama instance you control
 
@@ -212,7 +212,7 @@ For more information on Ollama's security and privacy model, see the [Ollama Git
 
 - [Node.js](https://nodejs.org/) 20+
 - [pnpm](https://pnpm.io/) (version pinned in `package.json`)
-- [VS Code](https://code.visualstudio.com/) 1.109.0+
+- [VS Code](https://code.visualstudio.com/) 1.111.0+
 
 ### Build
 

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -10,7 +10,7 @@ This guide covers everything you need to build, test, and contribute to **Opilot
 | ------------------- | ------------------------ |
 | Node.js             | 20+                      |
 | pnpm                | pinned in `package.json` |
-| VS Code             | 1.109.0+                 |
+| VS Code             | 1.111.0+                 |
 | Ollama              | latest                   |
 | GitHub Copilot Chat | latest                   |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ title: Opilot — Ollama for GitHub Copilot VS Code Extension
 
 ## Requirements
 
-- **VS Code** 1.109.0 or higher
+- **VS Code** 1.111.0 or higher
 - **GitHub Copilot Chat** extension installed and active
 - **Ollama** installed locally ([Download](https://ollama.ai/download)) **or** a remote Ollama instance you control
 - For cloud models: run `ollama login` to authenticate

--- a/package.json
+++ b/package.json
@@ -198,6 +198,18 @@
         "category": "Ollama"
       },
       {
+        "command": "opilot.toggleLibraryRecommended",
+        "title": "Show Recommended Models",
+        "icon": "$(thumbsup)",
+        "category": "Ollama"
+      },
+      {
+        "command": "opilot.toggleLibraryRecommendedOff",
+        "title": "Show All Models",
+        "icon": "$(thumbsup-filled)",
+        "category": "Ollama"
+      },
+      {
         "command": "opilot.collapseLocalModels",
         "title": "Collapse All Local Models",
         "icon": "$(collapse-all)",
@@ -491,6 +503,16 @@
           "command": "opilot.collapseLibrary",
           "when": "view == ollama-library-models",
           "group": "navigation@3"
+        },
+        {
+          "command": "opilot.toggleLibraryRecommended",
+          "when": "view == ollama-library-models && !ollama.libraryRecommendedOnly",
+          "group": "navigation@4"
+        },
+        {
+          "command": "opilot.toggleLibraryRecommendedOff",
+          "when": "view == ollama-library-models && ollama.libraryRecommendedOnly",
+          "group": "navigation@4"
         },
         {
           "command": "opilot.loginCloud",

--- a/package.json
+++ b/package.json
@@ -475,43 +475,43 @@
           "group": "navigation@5"
         },
         {
-          "command": "opilot.filterLibraryModels",
-          "when": "view == ollama-library-models && !ollama.libraryFilterActive",
-          "group": "navigation@0"
-        },
-        {
-          "command": "opilot.clearLibraryFilter",
-          "when": "view == ollama-library-models && ollama.libraryFilterActive",
-          "group": "navigation@0"
-        },
-        {
-          "command": "opilot.toggleLibraryGrouping",
-          "when": "view == ollama-library-models && ollama.libraryGrouped",
-          "group": "navigation@1"
-        },
-        {
-          "command": "opilot.toggleLibraryGroupingToTree",
-          "when": "view == ollama-library-models && !ollama.libraryGrouped",
-          "group": "navigation@1"
-        },
-        {
-          "command": "opilot.refreshLibrary",
-          "when": "view == ollama-library-models",
-          "group": "navigation@2"
-        },
-        {
-          "command": "opilot.collapseLibrary",
-          "when": "view == ollama-library-models",
-          "group": "navigation@3"
-        },
-        {
           "command": "opilot.toggleLibraryRecommended",
           "when": "view == ollama-library-models && !ollama.libraryRecommendedOnly",
-          "group": "navigation@4"
+          "group": "navigation@0"
         },
         {
           "command": "opilot.toggleLibraryRecommendedOff",
           "when": "view == ollama-library-models && ollama.libraryRecommendedOnly",
+          "group": "navigation@0"
+        },
+        {
+          "command": "opilot.filterLibraryModels",
+          "when": "view == ollama-library-models && !ollama.libraryFilterActive",
+          "group": "navigation@1"
+        },
+        {
+          "command": "opilot.clearLibraryFilter",
+          "when": "view == ollama-library-models && ollama.libraryFilterActive",
+          "group": "navigation@1"
+        },
+        {
+          "command": "opilot.toggleLibraryGrouping",
+          "when": "view == ollama-library-models && ollama.libraryGrouped",
+          "group": "navigation@2"
+        },
+        {
+          "command": "opilot.toggleLibraryGroupingToTree",
+          "when": "view == ollama-library-models && !ollama.libraryGrouped",
+          "group": "navigation@2"
+        },
+        {
+          "command": "opilot.refreshLibrary",
+          "when": "view == ollama-library-models",
+          "group": "navigation@3"
+        },
+        {
+          "command": "opilot.collapseLibrary",
+          "when": "view == ollama-library-models",
           "group": "navigation@4"
         },
         {

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1332,30 +1332,33 @@ export class LibraryModelsProvider implements TreeDataProvider<ModelTreeItem>, D
           allItems.push(model);
         }
 
-        // Fetch and add variants
-        const cachedVariants = this.variantsCache.get(model.label);
-        if (cachedVariants) {
-          const variants = this.materializeVariants(cachedVariants, localNames);
-          const filteredVariants = variants.filter(
-            v =>
-              !filterLower ||
-              v.label.toLowerCase().includes(filterLower) ||
-              (typeof v.tooltip === 'string' && v.tooltip.toLowerCase().includes(filterLower)),
-          );
-          allItems.push(...filteredVariants);
-        } else {
-          // Fetch variants asynchronously
-          void this.fetchModelVariants(model.label).then(
-            raw => {
-              if (raw) {
-                this.variantsCache.set(model.label, raw);
-                this.treeChangeEmitter.fire(null); // Refresh to show new variants
-              }
-            },
-            () => {
-              // Silently skip on error
-            },
-          );
+        // Fetch and add variants — skip when recommendedOnly to avoid firing
+        // hundreds of concurrent requests after a cache-clearing refresh.
+        if (!this.recommendedOnly) {
+          const cachedVariants = this.variantsCache.get(model.label);
+          if (cachedVariants) {
+            const variants = this.materializeVariants(cachedVariants, localNames);
+            const filteredVariants = variants.filter(
+              v =>
+                !filterLower ||
+                v.label.toLowerCase().includes(filterLower) ||
+                (typeof v.tooltip === 'string' && v.tooltip.toLowerCase().includes(filterLower)),
+            );
+            allItems.push(...filteredVariants);
+          } else {
+            // Fetch variants asynchronously
+            void this.fetchModelVariants(model.label).then(
+              raw => {
+                if (raw) {
+                  this.variantsCache.set(model.label, raw);
+                  this.treeChangeEmitter.fire(null); // Refresh to show new variants
+                }
+              },
+              () => {
+                // Silently skip on error
+              },
+            );
+          }
         }
       }
 
@@ -1374,13 +1377,14 @@ export class LibraryModelsProvider implements TreeDataProvider<ModelTreeItem>, D
     const filteredEntries = Array.from(groups.entries())
       .filter(
         ([familyName, familyModels]) =>
-          !filterLower ||
-          familyName.toLowerCase().includes(filterLower) ||
-          familyModels.some(
-            m =>
-              m.label.toLowerCase().includes(filterLower) ||
-              (typeof m.tooltip === 'string' && m.tooltip.toLowerCase().includes(filterLower)),
-          ),
+          (!filterLower ||
+            familyName.toLowerCase().includes(filterLower) ||
+            familyModels.some(
+              m =>
+                m.label.toLowerCase().includes(filterLower) ||
+                (typeof m.tooltip === 'string' && m.tooltip.toLowerCase().includes(filterLower)),
+            )) &&
+          (!this.recommendedOnly || familyModels.some(m => isRecommendedForHardware(m.label))),
       )
       .sort((a, b) => a[0].localeCompare(b[0]));
 
@@ -2685,11 +2689,6 @@ export function registerSidebar(
       void commands.executeCommand('setContext', 'ollama.libraryRecommendedOnly', initialRecommendedOnly);
       const toggleRecommended = () => {
         libraryProvider.recommendedOnly = !libraryProvider.recommendedOnly;
-        // Recommended view is always flat so individual model names are visible.
-        if (libraryProvider.recommendedOnly) {
-          libraryProvider.grouped = false;
-          void commands.executeCommand('setContext', 'ollama.libraryGrouped', false);
-        }
         void context.globalState.update('ollama.libraryRecommendedOnly', libraryProvider.recommendedOnly);
         void commands.executeCommand('setContext', 'ollama.libraryRecommendedOnly', libraryProvider.recommendedOnly);
         libraryProvider.refresh();

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1,6 +1,6 @@
 import { exec } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
+import { homedir, totalmem } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { Ollama } from 'ollama';
@@ -26,6 +26,48 @@ import { reportError } from './errorHandler.js';
 import { isThinkingModelId } from './provider.js';
 
 const execAsync = promisify(exec);
+
+/**
+ * Returns available system RAM in GB minus a fixed overhead for the OS and
+ * background processes.  On Apple Silicon (unified memory) totalmem() covers
+ * both RAM and GPU VRAM, so this is the correct budget for model inference.
+ * On discrete-GPU machines we are conservatively using RAM as the budget;
+ * it may under-recommend but will never over-recommend.
+ */
+function getAvailableMemoryGb(): number {
+  return totalmem() / 1024 ** 3 - 2;
+}
+
+/**
+ * Extract the parameter count in billions from a model name or variant tag.
+ * Examples: "llama3.2:3b" → 3, "qwen2.5:72b" → 72, "phi4" → null (no explicit size).
+ */
+export function extractParamsBillions(modelName: string): number | null {
+  // Match a size token like ":3b", "-7b", "_72b", ".6b" anywhere in the name.
+  const m = /(?:[:\-_.])(\d+(?:\.\d+)?)b\b/i.exec(modelName);
+  return m ? parseFloat(m[1]) : null;
+}
+
+/**
+ * Returns true when the model is likely to run with comfortable speed on the
+ * current machine.
+ *
+ * The formula:
+ *   memGB = params × 2 × 0.5   (FP16 weight size × INT4 quantisation factor)
+ *   fits  = memGB ≤ availableGB × 0.6
+ *
+ * The 0.6 headroom factor ensures at least 40 % of RAM remains free for the
+ * KV-cache, context buffers, and OS processes.  A model that only barely fits
+ * will saturate memory bandwidth and run at unbearably slow speeds — so we
+ * exclude it.  When the parameter count cannot be determined from the name
+ * we return false (no recommendation).
+ */
+export function isRecommendedForHardware(modelName: string): boolean {
+  const params = extractParamsBillions(modelName);
+  if (params === null) return false;
+  const memGb = params * 2 * 0.5; // INT4 quant: ~1 GB per billion params
+  return memGb <= getAvailableMemoryGb() * 0.6;
+}
 
 /**
  * Validates that a fetch response carries an HTML Content-Type.
@@ -1155,6 +1197,7 @@ export class LibraryModelsProvider implements TreeDataProvider<ModelTreeItem>, D
 
   filterText = '';
   grouped = true;
+  recommendedOnly = false;
 
   private cache: string[] = [];
   private cacheTimeMs = 0;
@@ -1316,7 +1359,11 @@ export class LibraryModelsProvider implements TreeDataProvider<ModelTreeItem>, D
         }
       }
 
-      return allItems.sort((a, b) => a.label.toLowerCase().localeCompare(b.label.toLowerCase()));
+      const filteredItems = this.recommendedOnly
+        ? allItems.filter(item => item.type === 'status' || isRecommendedForHardware(item.label))
+        : allItems;
+
+      return filteredItems.sort((a, b) => a.label.toLowerCase().localeCompare(b.label.toLowerCase()));
     }
 
     // Group models by family
@@ -1432,10 +1479,14 @@ export class LibraryModelsProvider implements TreeDataProvider<ModelTreeItem>, D
           if (preview.capabilities.vision) badges.push('👁️');
           if (preview.capabilities.embedding) badges.push('🧩');
 
+          if (isRecommendedForHardware(name)) {
+            badges.push('👍');
+          }
+
           if (badges.length > 0) {
             const existing = (item.description ?? '').toString();
             // Remove previously appended capability badges, keep size text intact.
-            const cleaned = existing.replace(/\s*(?:☁️|🧠|🛠️|👁️|🧩)(?:\s+(?:☁️|🧠|🛠️|👁️|🧩))*\s*$/, '').trim();
+            const cleaned = existing.replace(/\s*(?:☁️|🧠|🛠️|👁️|🧩|👍)(?:\s+(?:☁️|🧠|🛠️|👁️|🧩|👍))*\s*$/, '').trim();
             const badgeStr = badges.join(' ');
             item.description = cleaned ? `${cleaned} ${badgeStr}` : badgeStr;
           }
@@ -1444,6 +1495,7 @@ export class LibraryModelsProvider implements TreeDataProvider<ModelTreeItem>, D
           if (isCloudVariant) tooltipLines.push('☁️ Cloud');
           const capLine = buildCapabilityLines(preview.capabilities);
           if (capLine) tooltipLines.push(capLine);
+          if (isRecommendedForHardware(name)) tooltipLines.push('👍 Recommended for your hardware');
           if (preview.description) tooltipLines.push(preview.description);
           item.tooltip = tooltipLines.join('\n');
           this.treeChangeEmitter.fire(item);
@@ -1644,6 +1696,10 @@ export class LibraryModelsProvider implements TreeDataProvider<ModelTreeItem>, D
           if (preview.capabilities.tools) badges.push('🛠️');
           if (preview.capabilities.vision) badges.push('👁️');
           if (preview.capabilities.embedding) badges.push('🧩');
+          if (isRecommendedForHardware(name)) {
+            badges.push('👍');
+            tooltipLines.push('👍 Recommended for your hardware');
+          }
           if (badges.length > 0) {
             item.description = badges.join(' ');
           }
@@ -2622,6 +2678,26 @@ export function registerSidebar(
     })(),
     commands.registerCommand('opilot.toggleLibraryGroupingToTree', () => {
       void commands.executeCommand('opilot.toggleLibraryGrouping');
+    }),
+    (() => {
+      const initialRecommendedOnly = context.globalState.get<boolean>('ollama.libraryRecommendedOnly', false);
+      libraryProvider.recommendedOnly = initialRecommendedOnly;
+      void commands.executeCommand('setContext', 'ollama.libraryRecommendedOnly', initialRecommendedOnly);
+      const toggleRecommended = () => {
+        libraryProvider.recommendedOnly = !libraryProvider.recommendedOnly;
+        // Recommended view is always flat so individual model names are visible.
+        if (libraryProvider.recommendedOnly) {
+          libraryProvider.grouped = false;
+          void commands.executeCommand('setContext', 'ollama.libraryGrouped', false);
+        }
+        void context.globalState.update('ollama.libraryRecommendedOnly', libraryProvider.recommendedOnly);
+        void commands.executeCommand('setContext', 'ollama.libraryRecommendedOnly', libraryProvider.recommendedOnly);
+        libraryProvider.refresh();
+      };
+      return commands.registerCommand('opilot.toggleLibraryRecommended', toggleRecommended);
+    })(),
+    commands.registerCommand('opilot.toggleLibraryRecommendedOff', () => {
+      void commands.executeCommand('opilot.toggleLibraryRecommended');
     }),
     commands.registerCommand('opilot.refreshSidebar', () => handleRefreshLocalModels(localProvider)),
     commands.registerCommand('opilot.refreshLocalModels', () => handleRefreshLocalModels(localProvider)),

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1483,7 +1483,8 @@ export class LibraryModelsProvider implements TreeDataProvider<ModelTreeItem>, D
           if (preview.capabilities.vision) badges.push('👁️');
           if (preview.capabilities.embedding) badges.push('🧩');
 
-          if (isRecommendedForHardware(name)) {
+          const isRecommended = isRecommendedForHardware(name);
+          if (isRecommended) {
             badges.push('👍');
           }
 
@@ -1499,7 +1500,7 @@ export class LibraryModelsProvider implements TreeDataProvider<ModelTreeItem>, D
           if (isCloudVariant) tooltipLines.push('☁️ Cloud');
           const capLine = buildCapabilityLines(preview.capabilities);
           if (capLine) tooltipLines.push(capLine);
-          if (isRecommendedForHardware(name)) tooltipLines.push('👍 Recommended for your hardware');
+          if (isRecommended) tooltipLines.push('👍 Recommended for your hardware');
           if (preview.description) tooltipLines.push(preview.description);
           item.tooltip = tooltipLines.join('\n');
           this.treeChangeEmitter.fire(item);
@@ -2687,10 +2688,22 @@ export function registerSidebar(
       const initialRecommendedOnly = context.globalState.get<boolean>('ollama.libraryRecommendedOnly', false);
       libraryProvider.recommendedOnly = initialRecommendedOnly;
       void commands.executeCommand('setContext', 'ollama.libraryRecommendedOnly', initialRecommendedOnly);
+      // Reconcile: if recommended-only is active on startup, ensure flat (ungrouped) mode.
+      if (initialRecommendedOnly && libraryProvider.grouped) {
+        libraryProvider.grouped = false;
+        void context.globalState.update('ollama.libraryGrouped', false);
+        void commands.executeCommand('setContext', 'ollama.libraryGrouped', false);
+      }
       const toggleRecommended = () => {
         libraryProvider.recommendedOnly = !libraryProvider.recommendedOnly;
         void context.globalState.update('ollama.libraryRecommendedOnly', libraryProvider.recommendedOnly);
         void commands.executeCommand('setContext', 'ollama.libraryRecommendedOnly', libraryProvider.recommendedOnly);
+        // Enabling recommended-only forces flat mode so individual model names are visible.
+        if (libraryProvider.recommendedOnly && libraryProvider.grouped) {
+          libraryProvider.grouped = false;
+          void context.globalState.update('ollama.libraryGrouped', false);
+          void commands.executeCommand('setContext', 'ollama.libraryGrouped', false);
+        }
         libraryProvider.refresh();
       };
       return commands.registerCommand('opilot.toggleLibraryRecommended', toggleRecommended);

--- a/src/sidebar.utils.test.ts
+++ b/src/sidebar.utils.test.ts
@@ -168,4 +168,166 @@ describe('sidebar utility helpers', () => {
     expect(getLibraryModelUrl('org/model name')).toBe('https://ollama.com/library/org/model%20name');
     expect(getLibraryModelUrl('../bad')).toBe('https://ollama.com/library/%2E%2E/bad');
   });
+
+  describe('extractParamsBillions', () => {
+    it('parses colon-separated size tags', async () => {
+      const { extractParamsBillions } = await import('./sidebar.js');
+      expect(extractParamsBillions('llama3.2:3b')).toBe(3);
+      expect(extractParamsBillions('qwen2.5:72b')).toBe(72);
+      expect(extractParamsBillions('mistral:7b-instruct')).toBe(7);
+    });
+
+    it('parses dash-separated size tokens', async () => {
+      const { extractParamsBillions } = await import('./sidebar.js');
+      expect(extractParamsBillions('llama-7b')).toBe(7);
+      expect(extractParamsBillions('model-3b-instruct')).toBe(3);
+    });
+
+    it('parses underscore-separated size tokens', async () => {
+      const { extractParamsBillions } = await import('./sidebar.js');
+      expect(extractParamsBillions('model_72b')).toBe(72);
+    });
+
+    it('parses decimal parameter counts', async () => {
+      const { extractParamsBillions } = await import('./sidebar.js');
+      expect(extractParamsBillions('phi4:3.8b')).toBe(3.8);
+      expect(extractParamsBillions('gemma:0.6b')).toBe(0.6);
+    });
+
+    it('is case-insensitive for the B suffix', async () => {
+      const { extractParamsBillions } = await import('./sidebar.js');
+      expect(extractParamsBillions('model:7B')).toBe(7);
+    });
+
+    it('returns null when no size token is present', async () => {
+      const { extractParamsBillions } = await import('./sidebar.js');
+      expect(extractParamsBillions('phi4')).toBeNull();
+      expect(extractParamsBillions('llama3.2:latest')).toBeNull();
+      expect(extractParamsBillions('')).toBeNull();
+    });
+  });
+
+  describe('isRecommendedForHardware', () => {
+    it('returns false when parameter count cannot be determined', async () => {
+      vi.doMock('node:os', () => ({ totalmem: () => 32 * 1024 ** 3 }));
+      const { isRecommendedForHardware } = await import('./sidebar.js');
+      expect(isRecommendedForHardware('phi4')).toBe(false);
+      expect(isRecommendedForHardware('llama3.2:latest')).toBe(false);
+    });
+
+    it('recommends small models when enough RAM is available', async () => {
+      // 32 GB total → available = 30 GB → threshold = 18 GB
+      // 3B model: memGB = 3 * 2 * 0.5 = 3 GB → fits
+      // 7B model: memGB = 7 * 2 * 0.5 = 7 GB → fits
+      vi.doMock('node:os', () => ({ totalmem: () => 32 * 1024 ** 3 }));
+      const { isRecommendedForHardware } = await import('./sidebar.js');
+      expect(isRecommendedForHardware('llama3.2:3b')).toBe(true);
+      expect(isRecommendedForHardware('mistral:7b')).toBe(true);
+    });
+
+    it('does not recommend large models that exceed the headroom threshold', async () => {
+      // 8 GB total → available = 6 GB → threshold = 3.6 GB
+      // 7B model: memGB = 7 * 2 * 0.5 = 7 GB → does not fit
+      vi.doMock('node:os', () => ({ totalmem: () => 8 * 1024 ** 3 }));
+      const { isRecommendedForHardware } = await import('./sidebar.js');
+      expect(isRecommendedForHardware('mistral:7b')).toBe(false);
+    });
+
+    it('recommends models that just fit within the 60% threshold', async () => {
+      // 16 GB total → available = 14 GB → threshold = 8.4 GB
+      // 3B model: memGB = 3 GB → fits comfortably
+      vi.doMock('node:os', () => ({ totalmem: () => 16 * 1024 ** 3 }));
+      const { isRecommendedForHardware } = await import('./sidebar.js');
+      expect(isRecommendedForHardware('llama3.2:3b')).toBe(true);
+    });
+  });
+
+  describe('LibraryModelsProvider recommendedOnly behaviour', () => {
+    it('filters flat list to recommended models only when recommendedOnly=true', async () => {
+      // 8 GB total → available = 6 GB → threshold = 3.6 GB
+      // tiny-llama-3b: memGB = 3 * 2 * 0.5 = 3 GB → fits
+      // big-model-70b: memGB = 70 * 2 * 0.5 = 70 GB → does not fit
+      vi.doMock('node:os', () => ({ totalmem: () => 8 * 1024 ** 3 }));
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          headers: { get: () => null },
+          text: async () => '<a href="/library/tiny-llama-3b"></a><a href="/library/big-model-70b"></a>',
+        }),
+      );
+
+      const { LibraryModelsProvider } = await import('./sidebar.js');
+      const provider = new LibraryModelsProvider(undefined);
+      provider.grouped = false;
+      provider.recommendedOnly = true;
+
+      const items = await provider.getChildren();
+      const labels = items.map((i: any) => i.label);
+      expect(labels).toContain('tiny-llama-3b');
+      expect(labels).not.toContain('big-model-70b');
+      provider.dispose();
+    });
+
+    it('shows all models when recommendedOnly=false', async () => {
+      vi.doMock('node:os', () => ({ totalmem: () => 8 * 1024 ** 3 }));
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          headers: { get: () => null },
+          text: async () => '<a href="/library/tiny-llama-3b"></a><a href="/library/big-model-70b"></a>',
+        }),
+      );
+
+      const { LibraryModelsProvider } = await import('./sidebar.js');
+      const provider = new LibraryModelsProvider(undefined);
+      provider.grouped = false;
+      provider.recommendedOnly = false;
+
+      const items = await provider.getChildren();
+      const labels = items.map((i: any) => i.label);
+      expect(labels).toContain('tiny-llama-3b');
+      expect(labels).toContain('big-model-70b');
+      provider.dispose();
+    });
+
+    it('forces grouped=false on startup when both recommendedOnly and grouped are true', async () => {
+      vi.doMock('node:os', () => ({ totalmem: () => 8 * 1024 ** 3 }));
+
+      const { registerSidebar } = await import('./sidebar.js');
+      const vscode = await import('vscode');
+
+      const state: Record<string, unknown> = {
+        'ollama.libraryGrouped': true,
+        'ollama.libraryRecommendedOnly': true,
+      };
+      const globalStateUpdate = vi.fn((key: string, value: unknown) => {
+        state[key] = value;
+      });
+      const mockContext = {
+        subscriptions: { push: vi.fn() },
+        secrets: { get: vi.fn().mockResolvedValue(undefined), store: vi.fn(), delete: vi.fn() },
+        globalState: {
+          get: vi.fn((key: string, def: unknown) => (key in state ? state[key] : def)),
+          update: globalStateUpdate,
+        },
+      } as unknown as import('vscode').ExtensionContext;
+      const mockClient = {
+        list: vi.fn().mockResolvedValue({ models: [] }),
+        generate: vi.fn(),
+      } as unknown as import('ollama').Ollama;
+
+      registerSidebar(mockContext, mockClient);
+
+      // On startup, when recommendedOnly=true is restored alongside grouped=true,
+      // the reconciliation logic must persist grouped=false and update the context.
+      expect(globalStateUpdate).toHaveBeenCalledWith('ollama.libraryGrouped', false);
+      expect(vi.mocked(vscode.commands.executeCommand)).toHaveBeenCalledWith(
+        'setContext',
+        'ollama.libraryGrouped',
+        false,
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds hardware-aware model recommendations to the Library panel.

## What's new

### Recommendation logic

Models are recommended when they can run with comfortable headroom on the current machine:

```
memGB = params × 2 × 0.5   (FP16 weight size × INT4 quantisation factor)
fits  = memGB ≤ availableGB × 0.6
```

The **60% threshold** ensures at least 40% of RAM remains free for the KV-cache, context buffers, and OS processes. A model that only barely fits will saturate memory bandwidth and run at unbearably slow speeds — so it is excluded. `availableGB = totalmem() − 2 GB` (system overhead). On Apple Silicon, `totalmem()` covers unified memory (RAM + GPU), so no separate VRAM detection is needed.

### UI changes

- 👍 badge appears in the `description` column next to recommended library models and their variants
- "👍 Recommended for your hardware" line added to the tooltip
- New toolbar button at `navigation@4` on the Library panel:
  - `$(thumbsup)` — click to show only recommended models (flat filtered view)
  - `$(thumbsup-filled)` — click to return to the full list
- Recommended view forces flat mode so individual model names are visible

### Other

- VS Code minimum version updated from `1.109.0` → `1.111.0` in README and docs

## Files changed

| File | Change |
|------|--------|
| `src/sidebar.ts` | `isRecommendedForHardware()`, `extractParamsBillions()`, `recommendedOnly` field, badge injection, flat-mode filter, toggle commands |
| `package.json` | Two new commands + two menu entries |
| `README.md`, `docs/index.md`, `docs/developers/index.md` | Version bump |

## Test plan

- All 543 existing unit tests pass (`task unit-tests`)
- Build compiles clean (`task compile`)