### PR TITLE
Fix false image attachments from generic chat data parts

### DIFF
--- a/.beans/ollama-models-vscode-qmvj--fix-false-image-attachment-sent-to-non-vision-chat.md
+++ b/.beans/ollama-models-vscode-qmvj--fix-false-image-attachment-sent-to-non-vision-chat.md
@@ -1,12 +1,12 @@
 ---
 # ollama-models-vscode-qmvj
 title: Fix false image attachment sent to non-vision chat models
-status: completed
+status: in-progress
 type: bug
 priority: high
 branch: fix/qmvj-false-image-attachment
 created_at: 2026-03-16T19:01:45Z
-updated_at: 2026-03-16T19:01:45Z
+updated_at: 2026-03-16T19:15:58Z
 ---
 
 Investigate why chat requests to text-only models like qwen3.5:4b can include image inputs and trigger Ollama errors such as `image: unknown format` even when the user did not intentionally send an image. Add coverage and fix the request mapping so only valid image content is forwarded.
@@ -17,7 +17,9 @@ Investigate why chat requests to text-only models like qwen3.5:4b can include im
 - [x] Trace how chat content is mapped to image inputs
 - [x] Add a regression test for text-only requests that carry non-image media metadata
 - [x] Fix request mapping so only valid image payloads are forwarded
-- [x] Run targeted tests and compile validation
+- [ ] Add regression coverage for unsupported binary attachments
+- [ ] Push branch and open PR
+- [ ] Run targeted tests and compile validation
 
 ## Summary of Changes
 

--- a/.beans/ollama-models-vscode-qmvj--fix-false-image-attachment-sent-to-non-vision-chat.md
+++ b/.beans/ollama-models-vscode-qmvj--fix-false-image-attachment-sent-to-non-vision-chat.md
@@ -1,0 +1,27 @@
+---
+# ollama-models-vscode-qmvj
+title: Fix false image attachment sent to non-vision chat models
+status: completed
+type: bug
+priority: high
+branch: fix/qmvj-false-image-attachment
+created_at: 2026-03-16T19:01:45Z
+updated_at: 2026-03-16T19:01:45Z
+---
+
+Investigate why chat requests to text-only models like qwen3.5:4b can include image inputs and trigger Ollama errors such as `image: unknown format` even when the user did not intentionally send an image. Add coverage and fix the request mapping so only valid image content is forwarded.
+
+## Todo
+
+- [x] Create bean and issue branch
+- [x] Trace how chat content is mapped to image inputs
+- [x] Add a regression test for text-only requests that carry non-image media metadata
+- [x] Fix request mapping so only valid image payloads are forwarded
+- [x] Run targeted tests and compile validation
+
+## Summary of Changes
+
+- Confirmed that `LanguageModelDataPart` in the VS Code API is generic and can carry image, JSON, or text payloads.
+- Updated `src/provider.ts` so only `image/*` parts are sent through Ollama's `images` field.
+- Added decoding for text and JSON data parts so they stay in message content instead of being mislabeled as images.
+- Added a regression test covering vision-capable models receiving non-image data parts.

--- a/.beans/ollama-models-vscode-qmvj--fix-false-image-attachment-sent-to-non-vision-chat.md
+++ b/.beans/ollama-models-vscode-qmvj--fix-false-image-attachment-sent-to-non-vision-chat.md
@@ -1,10 +1,11 @@
 ---
 # ollama-models-vscode-qmvj
 title: Fix false image attachment sent to non-vision chat models
-status: in-progress
+status: completed
 type: bug
 priority: high
 branch: fix/qmvj-false-image-attachment
+pr: 70
 created_at: 2026-03-16T19:01:45Z
 updated_at: 2026-03-16T19:15:58Z
 ---
@@ -17,13 +18,14 @@ Investigate why chat requests to text-only models like qwen3.5:4b can include im
 - [x] Trace how chat content is mapped to image inputs
 - [x] Add a regression test for text-only requests that carry non-image media metadata
 - [x] Fix request mapping so only valid image payloads are forwarded
-- [ ] Add regression coverage for unsupported binary attachments
-- [ ] Push branch and open PR
-- [ ] Run targeted tests and compile validation
+- [x] Add regression coverage for unsupported binary attachments
+- [x] Push branch and open PR
+- [x] Run targeted tests and compile validation
 
 ## Summary of Changes
 
-- Confirmed that `LanguageModelDataPart` in the VS Code API is generic and can carry image, JSON, or text payloads.
+- Confirmed that `LanguageModelDataPart` in the VS Code API is generic and can carry image, JSON, text, and other binary payloads.
 - Updated `src/provider.ts` so only `image/*` parts are sent through Ollama's `images` field.
 - Added decoding for text and JSON data parts so they stay in message content instead of being mislabeled as images.
 - Added a regression test covering vision-capable models receiving non-image data parts.
+- Added regression coverage proving unsupported binary attachments like PDFs are stripped rather than forwarded as images or decoded as text.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -902,7 +902,9 @@ export async function handleChatRequest(
         typeof modelOptions.think === 'boolean' ? modelOptions.think : isThinkingModelId(modelId);
 
       // Check if user wants to hide thinking content (only show header)
-      const hideThinkingContent = vscode.workspace.getConfiguration('ollama').get<boolean>('hideThinkingContent', false);
+      const hideThinkingContent = vscode.workspace
+        .getConfiguration('ollama')
+        .get<boolean>('hideThinkingContent', false);
 
       let shouldThink = shouldThinkInitial;
       let response: AsyncIterable<ChatResponse>;

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -39,8 +39,8 @@ vi.doMock('vscode', () => ({
   LanguageModelChatMessageRole: { User: 1, Assistant: 2 },
   LanguageModelDataPart: class DataPart {
     constructor(
-      public mimeType: string,
       public data: Uint8Array,
+      public mimeType: string,
     ) {}
   },
   LanguageModelTextPart: class TextPart {

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -810,6 +810,66 @@ describe('OllamaChatModelProvider chat response', () => {
     expect(userMsg?.content).toContain('plain text attachment');
   });
 
+  it('strips unsupported binary data parts for vision-capable models', async () => {
+    const chat = vi.fn().mockImplementation(async function* () {
+      yield { message: { content: 'ok' }, done: true };
+    });
+
+    vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as unknown as Ollama);
+
+    const logger = makeLogger();
+    const provider = new OllamaChatModelProvider(
+      makeContext(),
+      { list: vi.fn(), show: vi.fn() } as unknown as Ollama,
+      logger,
+    );
+
+    (
+      provider as unknown as {
+        visionByModelId: Map<string, boolean>;
+      }
+    ).visionByModelId.set('vision-model', true);
+
+    const progress = { report: vi.fn() };
+    const token = { isCancellationRequested: false };
+
+    const model = {
+      id: 'vision-model',
+      name: 'Vision',
+      family: '🦙 Ollama',
+      version: '1.0.0',
+      maxInputTokens: 100,
+      maxOutputTokens: 100,
+      capabilities: { imageInput: true, toolCalling: true },
+    };
+
+    const message = {
+      role: LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [
+        new LanguageModelTextPart('summarize the attachment'),
+        new LanguageModelDataPart(new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]), 'application/pdf'),
+      ],
+    };
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [message as unknown as LanguageModelChatRequestMessage],
+      { tools: [], toolMode: 'auto' } as unknown as ProvideLanguageModelChatResponseOptions,
+      progress as unknown as Progress<LanguageModelResponsePart>,
+      token as unknown as CancellationToken,
+    );
+
+    expect(chat).toHaveBeenCalled();
+    const chatArgs = chat.mock.calls[0]?.[0];
+    const userMsg = chatArgs?.messages?.find((m: any) => m.role === 'user');
+    expect(userMsg?.images).toBeUndefined();
+    expect(userMsg?.content).toBe('summarize the attachment');
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('stripped 1 non-image binary data part(s) from messages'),
+    );
+  });
+
   it('strips images for non-vision models', async () => {
     const chat = vi.fn().mockImplementation(async function* () {
       yield { message: { content: 'text response' } };

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -751,6 +751,65 @@ describe('OllamaChatModelProvider chat response', () => {
     expect(userMsg?.images).toHaveLength(1);
   });
 
+  it('does not treat text data parts as images for vision-capable models', async () => {
+    const chat = vi.fn().mockImplementation(async function* () {
+      yield { message: { content: 'ok' }, done: true };
+    });
+
+    vi.mocked(getOllamaClient).mockResolvedValueOnce({ chat, abort: vi.fn() } as unknown as Ollama);
+
+    const provider = new OllamaChatModelProvider(
+      makeContext(),
+      { list: vi.fn(), show: vi.fn() } as unknown as Ollama,
+      makeLogger(),
+    );
+
+    (
+      provider as unknown as {
+        visionByModelId: Map<string, boolean>;
+      }
+    ).visionByModelId.set('vision-model', true);
+
+    const progress = { report: vi.fn() };
+    const token = { isCancellationRequested: false };
+
+    const model = {
+      id: 'vision-model',
+      name: 'Vision',
+      family: '🦙 Ollama',
+      version: '1.0.0',
+      maxInputTokens: 100,
+      maxOutputTokens: 100,
+      capabilities: { imageInput: true, toolCalling: true },
+    };
+
+    const message = {
+      role: LanguageModelChatMessageRole.User,
+      name: undefined,
+      content: [
+        new LanguageModelTextPart('use this context: '),
+        new LanguageModelDataPart(Buffer.from('{"kind":"note","value":"hello"}'), 'application/json'),
+        new LanguageModelDataPart(Buffer.from('plain text attachment'), 'text/plain'),
+      ],
+    };
+
+    await provider.provideLanguageModelChatResponse(
+      model,
+      [message as unknown as LanguageModelChatRequestMessage],
+      { tools: [], toolMode: 'auto' } as unknown as ProvideLanguageModelChatResponseOptions,
+      progress as unknown as Progress<LanguageModelResponsePart>,
+      token as unknown as CancellationToken,
+    );
+
+    expect(chat).toHaveBeenCalled();
+    const chatArgs = chat.mock.calls[0]?.[0];
+    const userMsg = chatArgs?.messages?.find((m: any) => m.role === 'user');
+    expect(userMsg?.images).toBeUndefined();
+    expect(userMsg?.content).toContain('use this context: ');
+    expect(userMsg?.content).toContain('{"kind":"note","value":"hello"}');
+    expect(userMsg?.content).toContain('plain text attachment');
+  });
+
   it('strips images for non-vision models', async () => {
     const chat = vi.fn().mockImplementation(async function* () {
       yield { message: { content: 'text response' } };

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1178,7 +1178,7 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
             }
           } else {
             const extractedText = this.extractTextFromDataPart(part);
-            if (extractedText) {
+            if (extractedText !== undefined) {
               textContent += extractedText;
             } else {
               strippedBinaryDataCount++;
@@ -1280,15 +1280,15 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     return (mimeType ?? '').split(';', 1)[0]?.trim().toLowerCase();
   }
 
-  private extractTextFromDataPart(part: LanguageModelDataPart): string {
+  private extractTextFromDataPart(part: LanguageModelDataPart): string | undefined {
     if (!this.isTextualMimeType(part.mimeType)) {
-      return '';
+      return undefined;
     }
 
     try {
       return new TextDecoder('utf-8').decode(part.data);
     } catch {
-      return '';
+      return undefined;
     }
   }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1143,8 +1143,10 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
    *
    * ## Vision
    *
-   * `LanguageModelDataPart` images are only included when `supportsVision` is
-   * true for the model. Stripped images are counted and logged.
+   * `LanguageModelDataPart` is a generic binary carrier in the VS Code API, so
+   * only `image/*` MIME parts are forwarded via Ollama's `images` field. Text
+   * and JSON data parts are decoded back into inline text content. Unsupported
+   * binary parts are stripped and logged.
    */
   private toOllamaMessages(
     messages: readonly LanguageModelChatRequestMessage[],
@@ -1153,6 +1155,7 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     const ollamaMessages: Parameters<typeof this.client.chat>[0]['messages'] = [];
     const systemContextParts: string[] = [];
     let strippedImageCount = 0;
+    let strippedBinaryDataCount = 0;
 
     for (const msg of messages) {
       const role = msg.role === LanguageModelChatMessageRole.User ? 'user' : 'assistant';
@@ -1166,11 +1169,20 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
         if (part instanceof LanguageModelTextPart) {
           textContent += part.value;
         } else if (part instanceof LanguageModelDataPart) {
-          if (supportsVision) {
-            const base64Data = Buffer.from(part.data).toString('base64');
-            images.push(base64Data);
+          if (this.isImageMimeType(part.mimeType)) {
+            if (supportsVision) {
+              const base64Data = Buffer.from(part.data).toString('base64');
+              images.push(base64Data);
+            } else {
+              strippedImageCount++;
+            }
           } else {
-            strippedImageCount++;
+            const extractedText = this.extractTextFromDataPart(part);
+            if (extractedText) {
+              textContent += extractedText;
+            } else {
+              strippedBinaryDataCount++;
+            }
           }
         } else if (part instanceof LanguageModelToolCallPart) {
           ollamaMsg.tool_calls = ollamaMsg.tool_calls || [];
@@ -1240,7 +1252,44 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       );
     }
 
+    if (strippedBinaryDataCount > 0) {
+      this.outputChannel.debug(
+        `[client] stripped ${strippedBinaryDataCount} non-image binary data part(s) from messages`,
+      );
+    }
+
     return ollamaMessages;
+  }
+
+  private isImageMimeType(mimeType: string | undefined): boolean {
+    return this.normalizeMimeType(mimeType).startsWith('image/');
+  }
+
+  private isTextualMimeType(mimeType: string | undefined): boolean {
+    const normalized = this.normalizeMimeType(mimeType);
+    return (
+      normalized.startsWith('text/') ||
+      normalized === 'application/json' ||
+      normalized.endsWith('+json') ||
+      normalized === 'application/xml' ||
+      normalized.endsWith('+xml')
+    );
+  }
+
+  private normalizeMimeType(mimeType: string | undefined): string {
+    return (mimeType ?? '').split(';', 1)[0]?.trim().toLowerCase();
+  }
+
+  private extractTextFromDataPart(part: LanguageModelDataPart): string {
+    if (!this.isTextualMimeType(part.mimeType)) {
+      return '';
+    }
+
+    try {
+      return new TextDecoder('utf-8').decode(part.data);
+    } catch {
+      return '';
+    }
   }
 
   private extractTextFromUnknownInputPart(part: unknown): string {
@@ -1316,6 +1365,7 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       index,
       type: ctorName,
       keys: Object.keys(partRecord),
+      mimeType: part instanceof LanguageModelDataPart ? part.mimeType : undefined,
       sample:
         this.extractTextFromUnknownInputPart(part)?.slice(0, 120) ||
         (part instanceof LanguageModelTextPart ? part.value.slice(0, 120) : ''),


### PR DESCRIPTION
## Summary
- treat only `image/*` `LanguageModelDataPart` payloads as Ollama image inputs
- decode textual `LanguageModelDataPart` payloads back into chat content instead of mislabeling them as images
- add regression coverage for both textual non-image parts and unsupported binary attachments like PDFs

## Problem
Text-only models such as `qwen3.5:4b` could fail with Ollama errors like `image: unknown format` even when the user did not intentionally send an image. The root cause was that every VS Code `LanguageModelDataPart` was being forwarded as an image for vision-capable models, even though the VS Code API uses that part type for image, JSON, text, and other binary payloads.

## Validation
- `src/provider.test.ts` (69 passed)
- `pnpm run compile`
