### PR TITLE
fix(chat): stream LM fallback response chunks incrementally

### DIFF
--- a/.beans/ollama-models-vscode-ach5--fix-ollama-final-response-not-streaming-while-thin.md
+++ b/.beans/ollama-models-vscode-ach5--fix-ollama-final-response-not-streaming-while-thin.md
@@ -1,11 +1,11 @@
 ---
 # ollama-models-vscode-ach5
 title: Fix Ollama final response not streaming while thinking streams
-status: in-progress
+status: completed
 type: bug
 priority: high
 created_at: 2026-03-16T22:03:11Z
-updated_at: 2026-03-16T22:12:37Z
+updated_at: 2026-03-16T22:14:07Z
 ---
 
 ## Context
@@ -25,3 +25,8 @@ The thinking stream from Ollama is visible progressively, but the assistant fina
 
 ## Tracking
 - Branch: `fix/ach5-stream-final-response`
+
+## Follow-up (Cancellation)
+- Added `token.isCancellationRequested` guard inside the VS Code LM API `for await (const chunk of response.stream)` loop and break early on cancellation.
+- Added regression test to verify chunks after cancellation are not emitted.
+- Verified with targeted `src/extension.test.ts` run (pass).

--- a/.beans/ollama-models-vscode-ach5--fix-ollama-final-response-not-streaming-while-thin.md
+++ b/.beans/ollama-models-vscode-ach5--fix-ollama-final-response-not-streaming-while-thin.md
@@ -1,0 +1,27 @@
+---
+# ollama-models-vscode-ach5
+title: Fix Ollama final response not streaming while thinking streams
+status: completed
+type: bug
+priority: high
+created_at: 2026-03-16T22:03:11Z
+updated_at: 2026-03-16T22:05:45Z
+---
+
+## Context
+The thinking stream from Ollama is visible progressively, but the assistant final response is buffered and only appears after completion.
+
+## Todo
+- [x] Reproduce/inspect current streaming flow for thinking vs final response
+- [x] Identify buffering point in provider/extension output path
+- [x] Implement fix so final response tokens stream incrementally
+- [x] Add or update tests to prevent regression
+- [x] Run relevant tests and verify behavior
+
+## Summary of Changes
+- Fixed VS Code LM fallback streaming path to emit `LanguageModelTextPart` chunks immediately as they arrive, instead of buffering until stream completion.
+- Kept assistant text accumulation for conversation continuity in tool-call rounds, while avoiding duplicate end-of-round replay.
+- Added a regression test proving the first text chunk is rendered before stream completion.
+
+## Tracking
+- Branch: `fix/ach5-stream-final-response`

--- a/.beans/ollama-models-vscode-ach5--fix-ollama-final-response-not-streaming-while-thin.md
+++ b/.beans/ollama-models-vscode-ach5--fix-ollama-final-response-not-streaming-while-thin.md
@@ -1,11 +1,11 @@
 ---
 # ollama-models-vscode-ach5
 title: Fix Ollama final response not streaming while thinking streams
-status: completed
+status: in-progress
 type: bug
 priority: high
 created_at: 2026-03-16T22:03:11Z
-updated_at: 2026-03-16T22:05:45Z
+updated_at: 2026-03-16T22:12:37Z
 ---
 
 ## Context

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1848,6 +1848,61 @@ describe('handleChatRequest model selection', () => {
     expect(mockSelectChatModels).not.toHaveBeenCalled();
   });
 
+  it('streams text chunks immediately in VS Code LM API path (no buffering until completion)', async () => {
+    const LMTextPart = class {
+      constructor(public value: string) {}
+    };
+
+    let releaseSecondChunk: (() => void) | undefined;
+    const waitForSecondChunk = new Promise<void>(resolve => {
+      releaseSecondChunk = resolve;
+    });
+
+    const mockSendRequest = vi.fn().mockResolvedValue({
+      stream: (async function* () {
+        yield new LMTextPart('first chunk ');
+        await waitForSecondChunk;
+        yield new LMTextPart('second chunk');
+      })(),
+    });
+
+    vi.doMock('vscode', () => ({
+      LanguageModelTextPart: LMTextPart,
+      ChatRequestTurn: class {},
+      ChatResponseTurn: class {},
+      ChatResponseMarkdownPart: class {},
+      LanguageModelChatMessage: {
+        User: (content: string) => ({ content }),
+        Assistant: (content: string) => ({ content }),
+      },
+      lm: { selectChatModels: vi.fn().mockResolvedValue([]), tools: [] },
+      workspace: { getConfiguration: vi.fn().mockReturnValue({ get: vi.fn() }) },
+    }));
+
+    const ext = await import('./extension.js');
+    const mockMarkdown = vi.fn();
+    const mockRequest = {
+      prompt: 'test',
+      model: { vendor: 'selfagency-opilot', sendRequest: mockSendRequest },
+    };
+
+    const pending = ext.handleChatRequest(
+      mockRequest as any,
+      { history: [] } as any,
+      { markdown: mockMarkdown } as any,
+      { isCancellationRequested: false } as any,
+    );
+
+    // Allow the first streamed chunk to flow before the stream completes.
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(mockMarkdown).toHaveBeenCalledWith('first chunk ');
+
+    releaseSecondChunk?.();
+    await pending;
+
+    expect(mockMarkdown).toHaveBeenCalledWith('second chunk');
+  });
+
   it('invokes tools and feeds results back when toolInvocationToken is present', async () => {
     vi.resetModules();
 

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1903,6 +1903,47 @@ describe('handleChatRequest model selection', () => {
     expect(mockMarkdown).toHaveBeenCalledWith('second chunk');
   });
 
+  it('stops consuming LM API stream chunks when cancellation is requested', async () => {
+    const LMTextPart = class {
+      constructor(public value: string) {}
+    };
+
+    const mockToken = { isCancellationRequested: false };
+
+    const mockSendRequest = vi.fn().mockResolvedValue({
+      stream: (async function* () {
+        yield new LMTextPart('first chunk');
+        mockToken.isCancellationRequested = true;
+        yield new LMTextPart('second chunk should not render');
+      })(),
+    });
+
+    vi.doMock('vscode', () => ({
+      LanguageModelTextPart: LMTextPart,
+      ChatRequestTurn: class {},
+      ChatResponseTurn: class {},
+      ChatResponseMarkdownPart: class {},
+      LanguageModelChatMessage: {
+        User: (content: string) => ({ content }),
+        Assistant: (content: string) => ({ content }),
+      },
+      lm: { selectChatModels: vi.fn().mockResolvedValue([]), tools: [] },
+      workspace: { getConfiguration: vi.fn().mockReturnValue({ get: vi.fn() }) },
+    }));
+
+    const ext = await import('./extension.js');
+    const mockMarkdown = vi.fn();
+    const mockRequest = {
+      prompt: 'test',
+      model: { vendor: 'selfagency-opilot', sendRequest: mockSendRequest },
+    };
+
+    await ext.handleChatRequest(mockRequest as any, { history: [] } as any, { markdown: mockMarkdown } as any, mockToken as any);
+
+    expect(mockMarkdown).toHaveBeenCalledWith('first chunk');
+    expect(mockMarkdown).not.toHaveBeenCalledWith('second chunk should not render');
+  });
+
   it('invokes tools and feeds results back when toolInvocationToken is present', async () => {
     vi.resetModules();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1085,6 +1085,9 @@ export async function handleChatRequest(
       for await (const chunk of response.stream) {
         if (chunk instanceof vscode.LanguageModelTextPart) {
           assistantTextParts.push(chunk);
+          // Stream textual output immediately so users see incremental tokens
+          // instead of waiting for the full round to complete.
+          stream.markdown(chunk.value);
         } else if (chunk instanceof vscode.LanguageModelToolCallPart) {
           pendingToolCalls.push(chunk);
         }
@@ -1092,10 +1095,8 @@ export async function handleChatRequest(
 
       const hasTaskComplete = pendingToolCalls.some(tc => tc.name === TASK_COMPLETE_TOOL_NAME);
       if (pendingToolCalls.length === 0 || !request.toolInvocationToken || hasTaskComplete) {
-        // No more tool calls (or task_complete was invoked) — stream buffered text and finish.
-        for (const part of assistantTextParts) {
-          stream.markdown(part.value);
-        }
+        // No more tool calls (or task_complete was invoked) — text was already
+        // streamed incrementally while reading response.stream.
         // Invoke task_complete for VS Code Autopilot bookkeeping.
         if (hasTaskComplete && request.toolInvocationToken) {
           const tc = pendingToolCalls.find(c => c.name === TASK_COMPLETE_TOOL_NAME)!;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1083,6 +1083,10 @@ export async function handleChatRequest(
       const pendingToolCalls: vscode.LanguageModelToolCallPart[] = [];
       const assistantTextParts: vscode.LanguageModelTextPart[] = [];
       for await (const chunk of response.stream) {
+        if (token.isCancellationRequested) {
+          break;
+        }
+
         if (chunk instanceof vscode.LanguageModelTextPart) {
           assistantTextParts.push(chunk);
           // Stream textual output immediately so users see incremental tokens


### PR DESCRIPTION
## Summary
- stream `LanguageModelTextPart` chunks immediately in the VS Code LM fallback path
- stop LM API stream consumption early when `token.isCancellationRequested` is set
- remove end-of-round replay of buffered text to avoid delayed final output
- add regression tests for immediate streaming and cancellation behavior

## Testing
- targeted test run for `src/extension.test.ts` (pass)

## Context
Fixes the issue where thinking content streamed, but final response text appeared only after completion, and aligns cancellation behavior between direct-client and LM API paths.