### PR TITLE
feat(config): introduce opilot.* settings with legacy ollama.* migration

### DIFF
--- a/.beans/ollama-models-vscode-y0js--migrate-settings-namespace-from-ollama-to-opilot-w.md
+++ b/.beans/ollama-models-vscode-y0js--migrate-settings-namespace-from-ollama-to-opilot-w.md
@@ -1,20 +1,23 @@
 ---
 # ollama-models-vscode-y0js
 title: Migrate settings namespace from ollama.* to opilot.* with compatibility fallback
-status: completed
+status: in-progress
 type: feature
 priority: high
 created_at: 2026-03-16T22:24:14Z
-updated_at: 2026-03-16T22:52:01Z
+updated_at: 2026-03-16T22:57:37Z
 ---
 
 ## Context
+
 Opilot branding uses `opilot`, but configuration keys are currently under `ollama.*`.
 
 ## Goal
+
 Introduce `opilot.*` settings while preserving backward compatibility with existing `ollama.*` users.
 
 ## Todo
+
 - [x] Audit all settings reads/writes and manifest contributions
 - [x] Add `opilot.*` settings and deprecate `ollama.*` keys
 - [x] Implement runtime fallback + migration from `ollama.*` to `opilot.*`
@@ -22,9 +25,11 @@ Introduce `opilot.*` settings while preserving backward compatibility with exist
 - [x] Run tests and validate migration behavior
 
 ## Tracking
+
 - Branch: `feat/y0js-opilot-settings-namespace`
 
 ## Summary of Changes
+
 - Added new `opilot.*` settings in extension contributions.
 - Marked legacy `ollama.*` settings as deprecated in the manifest.
 - Implemented runtime namespace compatibility (`opilot` first, `ollama` fallback) via `src/settings.ts`.
@@ -33,4 +38,5 @@ Introduce `opilot.*` settings while preserving backward compatibility with exist
 - Updated tests for contributions and settings-open behavior.
 
 ## Tracking Update
+
 - PR: https://github.com/selfagency/opilot/pull/73

--- a/.beans/ollama-models-vscode-y0js--migrate-settings-namespace-from-ollama-to-opilot-w.md
+++ b/.beans/ollama-models-vscode-y0js--migrate-settings-namespace-from-ollama-to-opilot-w.md
@@ -1,11 +1,11 @@
 ---
 # ollama-models-vscode-y0js
 title: Migrate settings namespace from ollama.* to opilot.* with compatibility fallback
-status: in-progress
+status: completed
 type: feature
 priority: high
 created_at: 2026-03-16T22:24:14Z
-updated_at: 2026-03-16T22:51:35Z
+updated_at: 2026-03-16T22:52:01Z
 ---
 
 ## Context
@@ -23,3 +23,14 @@ Introduce `opilot.*` settings while preserving backward compatibility with exist
 
 ## Tracking
 - Branch: `feat/y0js-opilot-settings-namespace`
+
+## Summary of Changes
+- Added new `opilot.*` settings in extension contributions.
+- Marked legacy `ollama.*` settings as deprecated in the manifest.
+- Implemented runtime namespace compatibility (`opilot` first, `ollama` fallback) via `src/settings.ts`.
+- Added activation-time auto-migration of legacy settings to `opilot.*`.
+- Updated docs/examples to prefer `opilot.*` keys while preserving compatibility.
+- Updated tests for contributions and settings-open behavior.
+
+## Tracking Update
+- PR: https://github.com/selfagency/opilot/pull/73

--- a/.beans/ollama-models-vscode-y0js--migrate-settings-namespace-from-ollama-to-opilot-w.md
+++ b/.beans/ollama-models-vscode-y0js--migrate-settings-namespace-from-ollama-to-opilot-w.md
@@ -1,0 +1,25 @@
+---
+# ollama-models-vscode-y0js
+title: Migrate settings namespace from ollama.* to opilot.* with compatibility fallback
+status: in-progress
+type: feature
+priority: high
+created_at: 2026-03-16T22:24:14Z
+updated_at: 2026-03-16T22:51:35Z
+---
+
+## Context
+Opilot branding uses `opilot`, but configuration keys are currently under `ollama.*`.
+
+## Goal
+Introduce `opilot.*` settings while preserving backward compatibility with existing `ollama.*` users.
+
+## Todo
+- [x] Audit all settings reads/writes and manifest contributions
+- [x] Add `opilot.*` settings and deprecate `ollama.*` keys
+- [x] Implement runtime fallback + migration from `ollama.*` to `opilot.*`
+- [x] Update docs/tests to reflect new namespace and compatibility behavior
+- [x] Run tests and validate migration behavior
+
+## Tracking
+- Branch: `feat/y0js-opilot-settings-namespace`

--- a/README.md
+++ b/README.md
@@ -55,22 +55,24 @@
 4. Pull a model from the **Library** panel (e.g., `llama3.2:3b`)
 5. Open Copilot Chat, click the model picker, and select your Ollama model — or type `@ollama` to chat
 
-The extension auto-detects your local Ollama instance at `http://localhost:11434`. To use cloud models, run `ollama login` first. To use a remote instance, set `ollama.host` in VS Code settings.
+The extension auto-detects your local Ollama instance at `http://localhost:11434`. To use cloud models, run `ollama login` first. To use a remote instance, set `opilot.host` in VS Code settings (legacy `ollama.host` is still supported).
 
 ## ⚙️ Configuration
 
-Open VS Code Settings (`Ctrl+,` / `Cmd+,`) and search for "Ollama":
+Open VS Code Settings (`Ctrl+,` / `Cmd+,`) and search for "Opilot":
 
-- **`ollama.host`** - Ollama server address (default: `http://localhost:11434`)
-- **`ollama.streamLogs`** - Stream Ollama server logs to output channel (default: `true`)
-- **`ollama.localModelRefreshInterval`** - Auto-refresh interval for local and running models, in seconds (default: `30`)
-- **`ollama.libraryRefreshInterval`** - Reserved refresh interval for library and cloud model catalogs, in seconds (default: `21600`); panels currently refresh on startup and via the manual refresh button
-- **`ollama.completionModel`** - Model used for inline code completions (e.g. `qwen2.5-coder:1.5b`). Leave empty to disable.
-- **`ollama.enableInlineCompletions`** - Enable or disable inline code completions (default: `true`)
-- **`ollama.modelfilesPath`** - Folder where modelfiles are stored (default: `~/.ollama/modelfiles`)
-- **`ollama.diagnostics.logLevel`** - Verbosity of the Ollama output channel (`debug`, `info`, `warn`, `error`; default: `info`)
+- **`opilot.host`** - Ollama server address (default: `http://localhost:11434`)
+- **`opilot.streamLogs`** - Stream Ollama server logs to output channel (default: `true`)
+- **`opilot.localModelRefreshInterval`** - Auto-refresh interval for local and running models, in seconds (default: `30`)
+- **`opilot.libraryRefreshInterval`** - Reserved refresh interval for library and cloud model catalogs, in seconds (default: `21600`); panels currently refresh on startup and via the manual refresh button
+- **`opilot.completionModel`** - Model used for inline code completions (e.g. `qwen2.5-coder:1.5b`). Leave empty to disable.
+- **`opilot.enableInlineCompletions`** - Enable or disable inline code completions (default: `true`)
+- **`opilot.modelfilesPath`** - Folder where modelfiles are stored (default: `~/.ollama/modelfiles`)
+- **`opilot.diagnostics.logLevel`** - Verbosity of the Ollama output channel (`debug`, `info`, `warn`, `error`; default: `info`)
 
-To use a remote Ollama instance, update `ollama.host` to point to your remote server.
+Legacy `ollama.*` settings continue to work and are migrated automatically on activation.
+
+To use a remote Ollama instance, update `opilot.host` to point to your remote server.
 
 ## 💬 Usage
 
@@ -95,13 +97,13 @@ The participant is sticky — once invoked, it stays active for the thread.
 
 ### Inline Code Completions
 
-Set `ollama.completionModel` to a locally-installed model to get inline code completions as you type. Smaller, fast models work best:
+Set `opilot.completionModel` to a locally-installed model to get inline code completions as you type. Smaller, fast models work best:
 
 - `qwen2.5-coder:1.5b`
 - `deepseek-coder:1.3b`
 - `starcoder2:3b`
 
-Completions use fill-in-the-middle (FIM) when the model supports it, and can be toggled with `ollama.enableInlineCompletions`.
+Completions use fill-in-the-middle (FIM) when the model supports it, and can be toggled with `opilot.enableInlineCompletions`.
 
 ### Sidebar: Model Management
 
@@ -116,7 +118,7 @@ The Ollama activity bar icon opens a sidebar with four panels:
 - Inline buttons per model: **Start** (▶), **Stop** (⏹), **Delete** (🗑)
 - Running models show VRAM usage and how long they've been loaded
 - Model capability badges: 🧠 thinking, 🛠️ tools, 👁️ vision, 🧩 embedding
-- Auto-refreshes every 30 seconds (configurable via `ollama.localModelRefreshInterval`); refresh interval restarts automatically when the setting changes
+- Auto-refreshes every 30 seconds (configurable via `opilot.localModelRefreshInterval`); refresh interval restarts automatically when the setting changes
 
 ### Model Settings Panel
 

--- a/docs/users/settings.md
+++ b/docs/users/settings.md
@@ -2,14 +2,16 @@
 title: Settings Reference
 ---
 
-All settings are in the `ollama.*` namespace. Open them via:
+Settings now use the `opilot.*` namespace. Legacy `ollama.*` keys are still supported and automatically migrated on activation.
+
+Open settings via:
 
 - **File → Preferences → Settings** then search "Ollama"
 - Or edit `settings.json` directly
 
 ## Connection
 
-### `ollama.host`
+### `opilot.host`
 
 | Type     | Default                    |
 | -------- | -------------------------- |
@@ -20,12 +22,12 @@ The URL of your Ollama server. Supports local and remote instances.
 **Examples:**
 
 ```json
-"ollama.host": "http://localhost:11434"
-"ollama.host": "https://my-ollama-server.example.com"
-"ollama.host": "http://192.168.1.50:11434"
+"opilot.host": "http://localhost:11434"
+"opilot.host": "https://my-ollama-server.example.com"
+"opilot.host": "http://192.168.1.50:11434"
 ```
 
-For remote instances that require authentication, also set `ollama.authToken` (via the **Manage Ollama Auth Token** command — it is stored securely in the VS Code secret store, not in settings.json).
+For remote instances that require authentication, also set an auth token via the **Manage Ollama Auth Token** command — it is stored securely in the VS Code secret store, not in settings.json.
 
 ## Model Parameters
 
@@ -52,7 +54,7 @@ Use the webview for these values rather than editing the file directly.
 
 ## Sidebar Refresh Intervals
 
-### `ollama.localModelRefreshInterval`
+### `opilot.localModelRefreshInterval`
 
 | Type     | Default |
 | -------- | ------- |
@@ -62,7 +64,7 @@ How often (in seconds) to auto-refresh the **local models** and **running models
 
 This interval also drives the status bar heartbeat polling cadence.
 
-### `ollama.libraryRefreshInterval`
+### `opilot.libraryRefreshInterval`
 
 | Type     | Default |
 | -------- | ------- |
@@ -72,7 +74,7 @@ How often (in seconds) to auto-refresh the **Ollama Library** and **Cloud** mode
 
 ## Logging
 
-### `ollama.streamLogs`
+### `opilot.streamLogs`
 
 | Type      | Default |
 | --------- | ------- |
@@ -86,7 +88,7 @@ When enabled, streams Ollama server log output to the **Opilot** output channel 
 
 Disable if stream output is noisy or you prefer a quiet channel.
 
-### `ollama.diagnostics.logLevel`
+### `opilot.diagnostics.logLevel`
 
 | Type     | Default  | Options                                  |
 | -------- | -------- | ---------------------------------------- |
@@ -105,7 +107,7 @@ Use `"debug"` when troubleshooting connection or provider issues.
 
 ## Modelfiles
 
-### `ollama.modelfilesPath`
+### `opilot.modelfilesPath`
 
 | Type     | Default      |
 | -------- | ------------ |
@@ -114,12 +116,12 @@ Use `"debug"` when troubleshooting connection or provider issues.
 Path to the folder containing your Modelfiles. Leave empty to use the default: `~/.ollama/modelfiles`.
 
 ```json
-"ollama.modelfilesPath": "/Users/yourname/projects/my-modelfiles"
+"opilot.modelfilesPath": "/Users/yourname/projects/my-modelfiles"
 ```
 
 ## Inline Completions
 
-### `ollama.completionModel`
+### `opilot.completionModel`
 
 | Type     | Default         |
 | -------- | --------------- |
@@ -130,12 +132,12 @@ The Ollama model to use for inline code completions. Must be a locally installed
 Best results with small, fast code models:
 
 ```json
-"ollama.completionModel": "qwen2.5-coder:1.5b"
-"ollama.completionModel": "deepseek-coder:1.3b"
-"ollama.completionModel": "starcoder2:3b"
+"opilot.completionModel": "qwen2.5-coder:1.5b"
+"opilot.completionModel": "deepseek-coder:1.3b"
+"opilot.completionModel": "starcoder2:3b"
 ```
 
-### `ollama.enableInlineCompletions`
+### `opilot.enableInlineCompletions`
 
 | Type      | Default |
 | --------- | ------- |
@@ -144,7 +146,7 @@ Best results with small, fast code models:
 Master toggle for inline code completions. Set to `false` to temporarily disable without clearing your `completionModel`.
 
 ```json
-"ollama.enableInlineCompletions": false
+"opilot.enableInlineCompletions": false
 ```
 
 ## Recommended Configuration
@@ -153,12 +155,12 @@ A sensible starting configuration for local development:
 
 ```json
 {
-  "ollama.host": "http://localhost:11434",
-  "ollama.localModelRefreshInterval": 30,
-  "ollama.libraryRefreshInterval": 21600,
-  "ollama.streamLogs": true,
-  "ollama.diagnostics.logLevel": "info",
-  "ollama.completionModel": "qwen2.5-coder:1.5b",
-  "ollama.enableInlineCompletions": true
+  "opilot.host": "http://localhost:11434",
+  "opilot.localModelRefreshInterval": 30,
+  "opilot.libraryRefreshInterval": 21600,
+  "opilot.streamLogs": true,
+  "opilot.diagnostics.logLevel": "info",
+  "opilot.completionModel": "qwen2.5-coder:1.5b",
+  "opilot.enableInlineCompletions": true
 }
 ```

--- a/package.json
+++ b/package.json
@@ -346,27 +346,27 @@
     "configuration": {
       "title": "Ollama",
       "properties": {
-        "ollama.host": {
+        "opilot.host": {
           "type": "string",
           "default": "http://localhost:11434",
           "description": "Ollama server URL (local or remote)"
         },
-        "ollama.localModelRefreshInterval": {
+        "opilot.localModelRefreshInterval": {
           "type": "number",
           "default": 30,
           "description": "Auto-refresh local and running models interval in seconds"
         },
-        "ollama.libraryRefreshInterval": {
+        "opilot.libraryRefreshInterval": {
           "type": "number",
           "default": 21600,
           "description": "Auto-refresh library and cloud model catalogs interval in seconds (default 6 hours)"
         },
-        "ollama.streamLogs": {
+        "opilot.streamLogs": {
           "type": "boolean",
           "default": true,
           "description": "Stream Ollama server logs to output channel"
         },
-        "ollama.diagnostics.logLevel": {
+        "opilot.diagnostics.logLevel": {
           "type": "string",
           "default": "info",
           "enum": [
@@ -377,25 +377,85 @@
           ],
           "description": "Controls Ollama extension diagnostics verbosity in the output channel"
         },
-        "ollama.modelfilesPath": {
+        "opilot.modelfilesPath": {
           "type": "string",
           "default": "",
           "description": "Path to folder containing Modelfiles. Leave empty to use ~/.ollama/modelfiles"
         },
-        "ollama.completionModel": {
+        "opilot.completionModel": {
           "type": "string",
           "default": "",
           "markdownDescription": "Model used for inline code completions. Leave empty to disable. Smaller, faster models work best (e.g. `qwen2.5-coder:1.5b`, `deepseek-coder:1.3b`)."
         },
-        "ollama.enableInlineCompletions": {
+        "opilot.enableInlineCompletions": {
           "type": "boolean",
           "default": true,
           "description": "Enable Ollama inline code completions."
         },
-        "ollama.hideThinkingContent": {
+        "opilot.hideThinkingContent": {
           "type": "boolean",
           "default": false,
           "markdownDescription": "Hide thinking/reasoning content in chat responses. When disabled (default), reasoning tokens stream as a blockquote before the response. When enabled, the thinking block is suppressed entirely."
+        },
+        "ollama.host": {
+          "type": "string",
+          "default": "http://localhost:11434",
+          "description": "Ollama server URL (local or remote)",
+          "deprecationMessage": "Deprecated: use opilot.host instead. Existing values are migrated automatically."
+        },
+        "ollama.localModelRefreshInterval": {
+          "type": "number",
+          "default": 30,
+          "description": "Auto-refresh local and running models interval in seconds",
+          "deprecationMessage": "Deprecated: use opilot.localModelRefreshInterval instead. Existing values are migrated automatically."
+        },
+        "ollama.libraryRefreshInterval": {
+          "type": "number",
+          "default": 21600,
+          "description": "Auto-refresh library and cloud model catalogs interval in seconds (default 6 hours)",
+          "deprecationMessage": "Deprecated: use opilot.libraryRefreshInterval instead. Existing values are migrated automatically."
+        },
+        "ollama.streamLogs": {
+          "type": "boolean",
+          "default": true,
+          "description": "Stream Ollama server logs to output channel",
+          "deprecationMessage": "Deprecated: use opilot.streamLogs instead. Existing values are migrated automatically."
+        },
+        "ollama.diagnostics.logLevel": {
+          "type": "string",
+          "default": "info",
+          "enum": [
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ],
+          "description": "Controls Ollama extension diagnostics verbosity in the output channel",
+          "deprecationMessage": "Deprecated: use opilot.diagnostics.logLevel instead. Existing values are migrated automatically."
+        },
+        "ollama.modelfilesPath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to folder containing Modelfiles. Leave empty to use ~/.ollama/modelfiles",
+          "deprecationMessage": "Deprecated: use opilot.modelfilesPath instead. Existing values are migrated automatically."
+        },
+        "ollama.completionModel": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Model used for inline code completions. Leave empty to disable. Smaller, faster models work best (e.g. `qwen2.5-coder:1.5b`, `deepseek-coder:1.3b`).",
+          "deprecationMessage": "Deprecated: use opilot.completionModel instead. Existing values are migrated automatically."
+        },
+        "ollama.enableInlineCompletions": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable Ollama inline code completions.",
+          "deprecationMessage": "Deprecated: use opilot.enableInlineCompletions instead. Existing values are migrated automatically."
+        },
+        "ollama.hideThinkingContent": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Hide thinking/reasoning content in chat responses. When disabled (default), reasoning tokens stream as a blockquote before the response. When enabled, the thinking block is suppressed entirely.",
+          "deprecationMessage": "Deprecated: use opilot.hideThinkingContent instead. Existing values are migrated automatically."
         }
       }
     },

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,7 +3,7 @@ import { ExtensionContext } from 'vscode';
 import { getSetting } from './settings.js';
 
 export function getOllamaHost(): string {
-  return getSetting<string>('host', 'http://localhost:11434');
+  return getSetting<string>('host', 'http://localhost:11434') || 'http://localhost:11434';
 }
 
 export async function getOllamaAuthToken(context: ExtensionContext): Promise<string | undefined> {
@@ -31,7 +31,6 @@ export async function getOllamaAuthHeaders(context: ExtensionContext): Promise<R
  *   the Ollama JS library surfaces `ResponseError` objects containing the server
  *   response body (which does not echo back request headers), and network-level
  *   `TypeError` messages that contain no credentials.
- * - The `host` value is user-controlled via `ollama.host` setting. If a user
  * - The `host` value is user-controlled via `opilot.host` (with fallback to
  *   legacy `ollama.host`). If a user
  *   embeds credentials in the URL (e.g. `http://user:pass@host`) the URL will

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,9 +1,9 @@
 import { Ollama } from 'ollama';
-import { ExtensionContext, workspace } from 'vscode';
+import { ExtensionContext } from 'vscode';
+import { getSetting } from './settings.js';
 
 export function getOllamaHost(): string {
-  const config = workspace.getConfiguration('ollama');
-  return config.get<string>('host') || 'http://localhost:11434';
+  return getSetting<string>('host', 'http://localhost:11434');
 }
 
 export async function getOllamaAuthToken(context: ExtensionContext): Promise<string | undefined> {
@@ -32,6 +32,8 @@ export async function getOllamaAuthHeaders(context: ExtensionContext): Promise<R
  *   response body (which does not echo back request headers), and network-level
  *   `TypeError` messages that contain no credentials.
  * - The `host` value is user-controlled via `ollama.host` setting. If a user
+ * - The `host` value is user-controlled via `opilot.host` (with fallback to
+ *   legacy `ollama.host`). If a user
  *   embeds credentials in the URL (e.g. `http://user:pass@host`) the URL will
  *   appear in connection-failure error dialogs — users should use the token
  *   mechanism instead.

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -1,6 +1,7 @@
 import type { Ollama } from 'ollama';
 import * as vscode from 'vscode';
 import type { DiagnosticsLogger } from './diagnostics.js';
+import { getSetting } from './settings.js';
 
 export const MAX_COMPLETION_PREFIX_CHARS = 2000;
 export const MAX_COMPLETION_SUFFIX_CHARS = 500;
@@ -19,10 +20,9 @@ export class OllamaInlineCompletionProvider implements vscode.InlineCompletionIt
   ): Promise<vscode.InlineCompletionItem[] | null> {
     if (token.isCancellationRequested) return null;
 
-    const config = vscode.workspace.getConfiguration('ollama');
-    if (!config.get<boolean>('enableInlineCompletions', true)) return null;
+    if (!getSetting<boolean>('enableInlineCompletions', true)) return null;
 
-    const modelId = config.get<string>('completionModel')?.trim() ?? '';
+    const modelId = getSetting<string>('completionModel', '')?.trim() ?? '';
     if (!modelId) return null;
 
     const offset = document.offsetAt(position);

--- a/src/contributes.test.ts
+++ b/src/contributes.test.ts
@@ -17,7 +17,13 @@ type PackageJson = {
     configuration?: {
       properties?: Record<
         string,
-        { type?: string; default?: unknown; description?: string; markdownDescription?: string }
+        {
+          type?: string;
+          default?: unknown;
+          description?: string;
+          markdownDescription?: string;
+          deprecationMessage?: string;
+        }
       >;
     };
   };
@@ -111,19 +117,39 @@ describe('package contributes integrity', () => {
     expect(missingIcon).toEqual([]);
   });
 
-  it('declares ollama.completionModel configuration property', () => {
+  it('declares opilot.completionModel configuration property', () => {
     const pkg = loadPackageJson();
-    const prop = pkg.contributes?.configuration?.properties?.['ollama.completionModel'];
+    const prop = pkg.contributes?.configuration?.properties?.['opilot.completionModel'];
     expect(prop).toBeDefined();
     expect(prop?.type).toBe('string');
   });
 
-  it('declares ollama.enableInlineCompletions configuration property', () => {
+  it('declares opilot.enableInlineCompletions configuration property', () => {
     const pkg = loadPackageJson();
-    const prop = pkg.contributes?.configuration?.properties?.['ollama.enableInlineCompletions'];
+    const prop = pkg.contributes?.configuration?.properties?.['opilot.enableInlineCompletions'];
     expect(prop).toBeDefined();
     expect(prop?.type).toBe('boolean');
     expect(prop?.default).toBe(true);
+  });
+
+  it('marks legacy ollama.* settings as deprecated', () => {
+    const pkg = loadPackageJson();
+    const properties = pkg.contributes?.configuration?.properties ?? {};
+    const legacyKeys = [
+      'ollama.host',
+      'ollama.localModelRefreshInterval',
+      'ollama.libraryRefreshInterval',
+      'ollama.streamLogs',
+      'ollama.diagnostics.logLevel',
+      'ollama.modelfilesPath',
+      'ollama.completionModel',
+      'ollama.enableInlineCompletions',
+      'ollama.hideThinkingContent',
+    ];
+
+    for (const key of legacyKeys) {
+      expect(properties[key]?.deprecationMessage).toContain('Deprecated: use opilot.');
+    }
   });
 
   it('does not declare the ollama-model-preview webview view', () => {

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { getSetting } from './settings.js';
 
 export type DiagnosticsLogLevel = 'debug' | 'info' | 'warn' | 'error';
 
@@ -18,7 +19,7 @@ export interface DiagnosticsLogger {
 }
 
 export function getConfiguredLogLevel(): DiagnosticsLogLevel {
-  const value = vscode.workspace.getConfiguration('ollama').get<string>('diagnostics.logLevel');
+  const value = getSetting<string>('diagnostics.logLevel');
   if (value === 'debug' || value === 'info' || value === 'warn' || value === 'error') {
     return value;
   }

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -529,7 +529,7 @@ describe('activate', () => {
     await new Promise(resolve => setTimeout(resolve, 10));
 
     expect(showErrorMessage).toHaveBeenCalled();
-    expect(executeCommand).toHaveBeenCalledWith('workbench.action.openSettings', 'ollama');
+    expect(executeCommand).toHaveBeenCalledWith('workbench.action.openSettings', 'opilot');
   });
 
   it('enables log streaming on autoStartLogStreaming true', async () => {
@@ -1662,7 +1662,7 @@ describe('handleConnectionTestFailure', () => {
       'Open Settings',
       'Open Logs',
     );
-    expect(executeCommand).toHaveBeenCalledWith('workbench.action.openSettings', 'ollama');
+    expect(executeCommand).toHaveBeenCalledWith('workbench.action.openSettings', 'opilot');
   });
 
   it('shows error message but does not execute command when not selected', async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -440,7 +440,7 @@ export async function handleConnectionTestFailure(
   const commands = commandsApi || vscode.commands;
 
   const selection = await window.showErrorMessage(
-    `Cannot connect to Ollama server at ${host}. Please check your ${SETTINGS_NAMESPACE}.host setting (legacy: ollama.host) and authentication token.`,
+    `Cannot connect to Ollama server at ${host}. Please check your ${SETTINGS_NAMESPACE}.host / ollama.host settings and authentication token.`,
     'Open Settings',
     'Open Logs',
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,7 @@ import { ollamaMessagesToOpenAICompat, ollamaToolsToOpenAICompat } from './opena
 import { isThinkingModelId, OllamaChatModelProvider } from './provider.js';
 import { createModelSettingsViewProvider, MODEL_SETTINGS_VIEW_ID } from './settingsWebview.js';
 import { registerSidebar, type SidebarProfilingSnapshot } from './sidebar.js';
+import { affectsSetting, getSetting, migrateLegacySettings, SETTINGS_NAMESPACE } from './settings.js';
 import { registerStatusBarHeartbeat } from './statusBar.js';
 import { ThinkingParser } from './thinkingParser.js';
 import {
@@ -381,16 +382,16 @@ export function handleConfigurationChange(
   onLogLevelChange?: () => void,
   onAutoStartChange?: (enabled: boolean) => void,
 ): void {
-  if (event.affectsConfiguration('ollama.diagnostics.logLevel')) {
+  if (affectsSetting(event, 'diagnostics.logLevel')) {
     diagnostics.info(`[client] Diagnostics log level changed to: ${getConfiguredLogLevel()}`);
     onLogLevelChange?.();
   }
 
-  if (!event.affectsConfiguration('ollama.streamLogs')) {
+  if (!affectsSetting(event, 'streamLogs')) {
     return;
   }
 
-  const enabled = vscode.workspace.getConfiguration('ollama').get<boolean>('streamLogs') ?? true;
+  const enabled = getSetting<boolean>('streamLogs', true);
   diagnostics.info(`[client] Auto-start log streaming setting changed: ${enabled ? 'enabled' : 'disabled'}`);
   onAutoStartChange?.(enabled);
 }
@@ -439,12 +440,12 @@ export async function handleConnectionTestFailure(
   const commands = commandsApi || vscode.commands;
 
   const selection = await window.showErrorMessage(
-    `Cannot connect to Ollama server at ${host}. Please check your ollama.host setting and authentication token.`,
+    `Cannot connect to Ollama server at ${host}. Please check your ${SETTINGS_NAMESPACE}.host setting (legacy: ollama.host) and authentication token.`,
     'Open Settings',
     'Open Logs',
   );
   if (selection === 'Open Settings') {
-    await commands.executeCommand('workbench.action.openSettings', 'ollama');
+    await commands.executeCommand('workbench.action.openSettings', SETTINGS_NAMESPACE);
     return;
   }
 
@@ -902,9 +903,7 @@ export async function handleChatRequest(
         typeof modelOptions.think === 'boolean' ? modelOptions.think : isThinkingModelId(modelId);
 
       // Check if user wants to hide thinking content (only show header)
-      const hideThinkingContent = vscode.workspace
-        .getConfiguration('ollama')
-        .get<boolean>('hideThinkingContent', false);
+      const hideThinkingContent = getSetting<boolean>('hideThinkingContent', false);
 
       let shouldThink = shouldThinkInitial;
       let response: AsyncIterable<ChatResponse>;
@@ -1232,10 +1231,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
   diagnostics.info('[client] activating extension...');
 
+  await migrateLegacySettings(diagnostics);
+
   const client = await getOllamaClient(context);
-  const config = vscode.workspace.getConfiguration('ollama');
-  const host = config.get<string>('host') || 'http://localhost:11434';
-  const autoStartLogStreaming = config.get<boolean>('streamLogs') ?? true;
+  const host = getSetting<string>('host', 'http://localhost:11434');
+  const autoStartLogStreaming = getSetting<boolean>('streamLogs', true);
   diagnostics.info(`[client] configured host: ${host}`);
   diagnostics.info(`[client] auto-start log streaming: ${autoStartLogStreaming ? 'enabled' : 'disabled'}`);
   diagnostics.info(`[client] diagnostics log level: ${getConfiguredLogLevel()}`);

--- a/src/modelfiles.ts
+++ b/src/modelfiles.ts
@@ -5,6 +5,7 @@ import type { CreateRequest, Message, Ollama } from 'ollama';
 import * as vscode from 'vscode';
 import type { DiagnosticsLogger } from './diagnostics.js';
 import { reportError } from './errorHandler.js';
+import { affectsSetting, getSetting } from './settings.js';
 
 // ---------------------------------------------------------------------------
 // Hover documentation for Modelfile keywords
@@ -267,7 +268,9 @@ export class ModelfilesProvider implements vscode.TreeDataProvider<ModelfileItem
     private readonly log?: DiagnosticsLogger,
   ) {
     this.folderPath = getModelfilesFolder(
-      vscode.workspace.getConfiguration('ollama'),
+      {
+        get: <T>(_key: string) => getSetting<T>('modelfilesPath') as T,
+      },
       homedir(),
       vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
     );
@@ -282,9 +285,11 @@ export class ModelfilesProvider implements vscode.TreeDataProvider<ModelfileItem
 
     context.subscriptions.push(
       vscode.workspace.onDidChangeConfiguration(e => {
-        if (e.affectsConfiguration('ollama.modelfilesPath')) {
+        if (affectsSetting(e, 'modelfilesPath')) {
           this.folderPath = getModelfilesFolder(
-            vscode.workspace.getConfiguration('ollama'),
+            {
+              get: <T>(_key: string) => getSetting<T>('modelfilesPath') as T,
+            },
             homedir(),
             vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
           );

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -34,6 +34,7 @@ import {
 } from './formatting';
 import { chatCompletionsOnce, initiateChatCompletionsStream } from './openaiCompat.js';
 import { ollamaMessagesToOpenAICompat, ollamaToolsToOpenAICompat } from './openaiCompatMapping.js';
+import { getSetting } from './settings.js';
 import { ThinkingParser } from './thinkingParser.js';
 import { isToolsNotSupportedError, normalizeToolParameters } from './toolUtils.js';
 
@@ -774,7 +775,7 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     const initialShouldThink = shouldThink;
 
     // Check if user wants to hide thinking content (only show header)
-    const hideThinkingContent = workspace.getConfiguration('ollama').get<boolean>('hideThinkingContent', false);
+    const hideThinkingContent = getSetting<boolean>('hideThinkingContent', false);
 
     try {
       let response: AsyncIterable<ChatResponse>;

--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type ScopeValues = {
+  defaultValue?: unknown;
+  globalValue?: unknown;
+  workspaceValue?: unknown;
+  workspaceFolderValues?: Record<string, unknown>;
+};
+
+type ConfigStore = Record<string, ScopeValues>;
+
+function createVscodeSettingsMock(options?: {
+  opilot?: ConfigStore;
+  legacy?: ConfigStore;
+  workspaceFolders?: string[];
+}) {
+  const opilot = options?.opilot ?? {};
+  const legacy = options?.legacy ?? {};
+  const folders = options?.workspaceFolders ?? [];
+
+  const getStore = (namespace: string): ConfigStore => {
+    if (namespace === 'opilot') return opilot;
+    if (namespace === 'ollama') return legacy;
+    return {};
+  };
+
+  const getConfiguration = vi.fn((namespace: string, scopeUri?: { fsPath?: string }) => {
+    const store = getStore(namespace);
+    return {
+      inspect: vi.fn((key: string) => {
+        const scoped = store[key] ?? {};
+        const folderKey = scopeUri?.fsPath;
+        return {
+          defaultValue: scoped.defaultValue,
+          globalValue: scoped.globalValue,
+          workspaceValue: scoped.workspaceValue,
+          workspaceFolderValue: folderKey ? scoped.workspaceFolderValues?.[folderKey] : undefined,
+        };
+      }),
+      get: vi.fn((key: string) => {
+        const scoped = store[key] ?? {};
+        const folderKey = scopeUri?.fsPath;
+        if (folderKey && scoped.workspaceFolderValues && folderKey in scoped.workspaceFolderValues) {
+          return scoped.workspaceFolderValues[folderKey];
+        }
+        if (scoped.workspaceValue !== undefined) return scoped.workspaceValue;
+        if (scoped.globalValue !== undefined) return scoped.globalValue;
+        return scoped.defaultValue;
+      }),
+      update: vi.fn(async (key: string, value: unknown, target: number) => {
+        const scoped = (store[key] ??= {});
+        if (target === 1) {
+          scoped.globalValue = value;
+          return;
+        }
+        if (target === 2) {
+          scoped.workspaceValue = value;
+          return;
+        }
+        if (target === 3) {
+          const folderKey = scopeUri?.fsPath;
+          if (!folderKey) return;
+          if (!scoped.workspaceFolderValues) scoped.workspaceFolderValues = {};
+          scoped.workspaceFolderValues[folderKey] = value;
+        }
+      }),
+    };
+  });
+
+  return {
+    workspace: {
+      getConfiguration,
+      workspaceFolders: folders.map(fsPath => ({ uri: { fsPath } })),
+    },
+    ConfigurationTarget: {
+      Global: 1,
+      Workspace: 2,
+      WorkspaceFolder: 3,
+    },
+  };
+}
+
+describe('settings helpers', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('getSetting prefers explicit opilot value over legacy value', async () => {
+    vi.doMock('vscode', () =>
+      createVscodeSettingsMock({
+        opilot: { host: { defaultValue: 'http://localhost:11434', globalValue: 'http://opilot:11434' } },
+        legacy: { host: { defaultValue: 'http://localhost:11434', globalValue: 'http://legacy:11434' } },
+      }),
+    );
+
+    const { getSetting } = await import('./settings.js');
+    expect(getSetting<string>('host')).toBe('http://opilot:11434');
+  });
+
+  it('getSetting falls back to explicit legacy value when opilot has no explicit value', async () => {
+    vi.doMock('vscode', () =>
+      createVscodeSettingsMock({
+        opilot: { host: { defaultValue: 'http://localhost:11434' } },
+        legacy: { host: { defaultValue: 'http://localhost:11434', workspaceValue: 'http://legacy-workspace:11434' } },
+      }),
+    );
+
+    const { getSetting } = await import('./settings.js');
+    expect(getSetting<string>('host')).toBe('http://legacy-workspace:11434');
+  });
+
+  it('getSetting returns opilot default when neither namespace has explicit value', async () => {
+    vi.doMock('vscode', () =>
+      createVscodeSettingsMock({
+        opilot: { host: { defaultValue: 'http://localhost:11434' } },
+        legacy: { host: { defaultValue: 'http://localhost:11434' } },
+      }),
+    );
+
+    const { getSetting } = await import('./settings.js');
+    expect(getSetting<string>('host', 'fallback')).toBe('http://localhost:11434');
+  });
+
+  it('affectsSetting matches both opilot.* and ollama.* keys', async () => {
+    vi.doMock('vscode', () => createVscodeSettingsMock());
+    const { affectsSetting } = await import('./settings.js');
+
+    const opilotEvent = {
+      affectsConfiguration: (key: string) => key === 'opilot.streamLogs',
+    } as any;
+    const legacyEvent = {
+      affectsConfiguration: (key: string) => key === 'ollama.streamLogs',
+    } as any;
+
+    expect(affectsSetting(opilotEvent, 'streamLogs')).toBe(true);
+    expect(affectsSetting(legacyEvent, 'streamLogs')).toBe(true);
+  });
+
+  it('migrateLegacySettings migrates global/workspace and per-folder values independently', async () => {
+    const folderA = '/workspace/a';
+    const folderB = '/workspace/b';
+
+    const vscodeMock = createVscodeSettingsMock({
+      workspaceFolders: [folderA, folderB],
+      opilot: {
+        host: {
+          defaultValue: 'http://localhost:11434',
+          workspaceFolderValues: {
+            [folderB]: 'http://existing-b:11434',
+          },
+        },
+      },
+      legacy: {
+        host: {
+          defaultValue: 'http://localhost:11434',
+          globalValue: 'http://legacy-global:11434',
+          workspaceValue: 'http://legacy-workspace:11434',
+          workspaceFolderValues: {
+            [folderA]: 'http://legacy-a:11434',
+            [folderB]: 'http://legacy-b:11434',
+          },
+        },
+      },
+    });
+
+    vi.doMock('vscode', () => vscodeMock);
+    const { migrateLegacySettings } = await import('./settings.js');
+
+    const migrated = await migrateLegacySettings();
+
+    expect(migrated).toContain('host');
+
+    // Global/workspace migrated
+    expect((vscodeMock.workspace.getConfiguration('opilot') as any).inspect('host').globalValue).toBe(
+      'http://legacy-global:11434',
+    );
+    expect((vscodeMock.workspace.getConfiguration('opilot') as any).inspect('host').workspaceValue).toBe(
+      'http://legacy-workspace:11434',
+    );
+
+    // Folder A migrated (no existing opilot folder value)
+    expect(
+      (vscodeMock.workspace.getConfiguration('opilot', { fsPath: folderA }) as any).inspect('host')
+        .workspaceFolderValue,
+    ).toBe('http://legacy-a:11434');
+    // Folder B preserved (existing opilot folder value)
+    expect(
+      (vscodeMock.workspace.getConfiguration('opilot', { fsPath: folderB }) as any).inspect('host')
+        .workspaceFolderValue,
+    ).toBe('http://existing-b:11434');
+  });
+});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -23,17 +23,67 @@ type LoggerLike = {
   debug?: (message: string) => void;
 };
 
+type InspectResult<T> = {
+  defaultValue?: T;
+  globalValue?: T;
+  workspaceValue?: T;
+  workspaceFolderValue?: T;
+};
+
+function inspectSetting<T>(config: unknown, key: string): InspectResult<T> | undefined {
+  if (!config || typeof config !== 'object') {
+    return undefined;
+  }
+
+  const inspect = (config as { inspect?: (k: string) => InspectResult<T> }).inspect;
+  if (typeof inspect !== 'function') {
+    return undefined;
+  }
+
+  return inspect(key);
+}
+
 export function getSetting<T>(key: SupportedSettingKey): T | undefined;
 export function getSetting<T>(key: SupportedSettingKey, defaultValue: T): T;
 export function getSetting<T>(key: SupportedSettingKey, defaultValue?: T): T | undefined {
-  const primary = vscode.workspace.getConfiguration(SETTINGS_NAMESPACE).get<T>(key);
-  if (primary !== undefined) {
-    return primary;
+  const opilotConfig = vscode.workspace.getConfiguration(SETTINGS_NAMESPACE);
+  const legacyConfig = vscode.workspace.getConfiguration(LEGACY_SETTINGS_NAMESPACE);
+
+  const opilotInspect = inspectSetting<T>(opilotConfig, key);
+  const legacyInspect = inspectSetting<T>(legacyConfig, key);
+
+  // Test/mocked environments may provide WorkspaceConfiguration#get without
+  // inspect(). Fall back to value-based precedence in that case.
+  if (!opilotInspect || !legacyInspect) {
+    const primary = opilotConfig.get<T>(key);
+    if (primary !== undefined) {
+      return primary;
+    }
+    const legacy = legacyConfig.get<T>(key);
+    if (legacy !== undefined) {
+      return legacy;
+    }
+    return defaultValue;
   }
 
-  const legacy = vscode.workspace.getConfiguration(LEGACY_SETTINGS_NAMESPACE).get<T>(key);
-  if (legacy !== undefined) {
-    return legacy;
+  const hasOpilotExplicitValue =
+    opilotInspect?.globalValue !== undefined ||
+    opilotInspect?.workspaceValue !== undefined ||
+    opilotInspect?.workspaceFolderValue !== undefined;
+  if (hasOpilotExplicitValue) {
+    return opilotConfig.get<T>(key) as T;
+  }
+
+  const hasLegacyExplicitValue =
+    legacyInspect?.globalValue !== undefined ||
+    legacyInspect?.workspaceValue !== undefined ||
+    legacyInspect?.workspaceFolderValue !== undefined;
+  if (hasLegacyExplicitValue) {
+    return legacyConfig.get<T>(key) as T;
+  }
+
+  if (opilotInspect?.defaultValue !== undefined) {
+    return opilotInspect.defaultValue as T;
   }
 
   return defaultValue;
@@ -53,8 +103,8 @@ export async function migrateLegacySettings(logger?: LoggerLike): Promise<Suppor
 
   for (const key of SUPPORTED_SETTING_KEYS) {
     try {
-      const opilotInspect = opilotConfig.inspect<unknown>(key);
-      const legacyInspect = legacyConfig.inspect<unknown>(key);
+      const opilotInspect = inspectSetting<unknown>(opilotConfig, key);
+      const legacyInspect = inspectSetting<unknown>(legacyConfig, key);
 
       if (!legacyInspect) {
         continue;
@@ -72,14 +122,29 @@ export async function migrateLegacySettings(logger?: LoggerLike): Promise<Suppor
         didMigrate = true;
       }
 
-      if (legacyInspect.workspaceFolderValue !== undefined && opilotInspect?.workspaceFolderValue === undefined) {
+      {
         const folders = vscode.workspace.workspaceFolders ?? [];
+        let migratedAnyFolder = false;
         for (const folder of folders) {
-          await vscode.workspace
-            .getConfiguration(SETTINGS_NAMESPACE, folder.uri)
-            .update(key, legacyInspect.workspaceFolderValue, vscode.ConfigurationTarget.WorkspaceFolder);
+          const legacyFolderConfig = vscode.workspace.getConfiguration(LEGACY_SETTINGS_NAMESPACE, folder.uri);
+          const opilotFolderConfig = vscode.workspace.getConfiguration(SETTINGS_NAMESPACE, folder.uri);
+
+          const legacyFolderInspect = inspectSetting<unknown>(legacyFolderConfig, key);
+          const opilotFolderInspect = inspectSetting<unknown>(opilotFolderConfig, key);
+
+          if (
+            legacyFolderInspect?.workspaceFolderValue !== undefined &&
+            opilotFolderInspect?.workspaceFolderValue === undefined
+          ) {
+            await opilotFolderConfig.update(
+              key,
+              legacyFolderInspect.workspaceFolderValue,
+              vscode.ConfigurationTarget.WorkspaceFolder,
+            );
+            migratedAnyFolder = true;
+          }
         }
-        if (folders.length > 0) {
+        if (migratedAnyFolder) {
           didMigrate = true;
         }
       }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,105 @@
+import * as vscode from 'vscode';
+
+export const SETTINGS_NAMESPACE = 'opilot';
+export const LEGACY_SETTINGS_NAMESPACE = 'ollama';
+
+export const SUPPORTED_SETTING_KEYS = [
+  'host',
+  'localModelRefreshInterval',
+  'libraryRefreshInterval',
+  'streamLogs',
+  'diagnostics.logLevel',
+  'modelfilesPath',
+  'completionModel',
+  'enableInlineCompletions',
+  'hideThinkingContent',
+] as const;
+
+type SupportedSettingKey = (typeof SUPPORTED_SETTING_KEYS)[number];
+
+type LoggerLike = {
+  info?: (message: string) => void;
+  warn?: (message: string) => void;
+  debug?: (message: string) => void;
+};
+
+export function getSetting<T>(key: SupportedSettingKey): T | undefined;
+export function getSetting<T>(key: SupportedSettingKey, defaultValue: T): T;
+export function getSetting<T>(key: SupportedSettingKey, defaultValue?: T): T | undefined {
+  const primary = vscode.workspace.getConfiguration(SETTINGS_NAMESPACE).get<T>(key);
+  if (primary !== undefined) {
+    return primary;
+  }
+
+  const legacy = vscode.workspace.getConfiguration(LEGACY_SETTINGS_NAMESPACE).get<T>(key);
+  if (legacy !== undefined) {
+    return legacy;
+  }
+
+  return defaultValue;
+}
+
+export function affectsSetting(event: vscode.ConfigurationChangeEvent, key: SupportedSettingKey): boolean {
+  return (
+    event.affectsConfiguration(`${SETTINGS_NAMESPACE}.${key}`) ||
+    event.affectsConfiguration(`${LEGACY_SETTINGS_NAMESPACE}.${key}`)
+  );
+}
+
+export async function migrateLegacySettings(logger?: LoggerLike): Promise<SupportedSettingKey[]> {
+  const migrated: SupportedSettingKey[] = [];
+  const opilotConfig = vscode.workspace.getConfiguration(SETTINGS_NAMESPACE);
+  const legacyConfig = vscode.workspace.getConfiguration(LEGACY_SETTINGS_NAMESPACE);
+
+  for (const key of SUPPORTED_SETTING_KEYS) {
+    try {
+      const opilotInspect = opilotConfig.inspect<unknown>(key);
+      const legacyInspect = legacyConfig.inspect<unknown>(key);
+
+      if (!legacyInspect) {
+        continue;
+      }
+
+      let didMigrate = false;
+
+      if (legacyInspect.globalValue !== undefined && opilotInspect?.globalValue === undefined) {
+        await opilotConfig.update(key, legacyInspect.globalValue, vscode.ConfigurationTarget.Global);
+        didMigrate = true;
+      }
+
+      if (legacyInspect.workspaceValue !== undefined && opilotInspect?.workspaceValue === undefined) {
+        await opilotConfig.update(key, legacyInspect.workspaceValue, vscode.ConfigurationTarget.Workspace);
+        didMigrate = true;
+      }
+
+      if (legacyInspect.workspaceFolderValue !== undefined && opilotInspect?.workspaceFolderValue === undefined) {
+        const folders = vscode.workspace.workspaceFolders ?? [];
+        for (const folder of folders) {
+          await vscode.workspace
+            .getConfiguration(SETTINGS_NAMESPACE, folder.uri)
+            .update(key, legacyInspect.workspaceFolderValue, vscode.ConfigurationTarget.WorkspaceFolder);
+        }
+        if (folders.length > 0) {
+          didMigrate = true;
+        }
+      }
+
+      if (didMigrate) {
+        migrated.push(key);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger?.warn?.(`[settings] failed to migrate legacy key ${LEGACY_SETTINGS_NAMESPACE}.${key}: ${message}`);
+    }
+  }
+
+  if (migrated.length > 0) {
+    logger?.info?.(
+      `[settings] migrated legacy settings (${LEGACY_SETTINGS_NAMESPACE}.* → ${SETTINGS_NAMESPACE}.*): ${migrated.join(', ')}`,
+    );
+  } else {
+    logger?.debug?.('[settings] no legacy settings required migration');
+  }
+
+  return migrated;
+}

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -24,6 +24,7 @@ import { fetchModelCapabilities, getCloudOllamaClient, type ModelCapabilities } 
 import type { DiagnosticsLogger } from './diagnostics.js';
 import { reportError } from './errorHandler.js';
 import { isThinkingModelId } from './provider.js';
+import { affectsSetting, getSetting } from './settings.js';
 
 const execAsync = promisify(exec);
 
@@ -615,7 +616,7 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
 
     // Register config listener once — not inside startAutoRefresh() which can be called multiple times
     this.configListenerDisposable = workspace.onDidChangeConfiguration(e => {
-      if (e.affectsConfiguration('ollama.localModelRefreshInterval')) {
+      if (affectsSetting(e, 'localModelRefreshInterval')) {
         this.logChannel?.debug('[client] ollama settings changed, restarting auto-refresh');
         this.stopAutoRefresh();
         this.startAutoRefresh();
@@ -919,7 +920,7 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
    * Start auto-refresh timer for local models
    */
   private startAutoRefresh(): void {
-    const localRefreshSecs = workspace.getConfiguration('ollama').get<number>('localModelRefreshInterval') || 30;
+    const localRefreshSecs = getSetting<number>('localModelRefreshInterval', 30);
 
     // Auto-refresh local/running models
     if (localRefreshSecs > 0) {

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -1,13 +1,14 @@
 import type { Ollama } from 'ollama';
 import * as vscode from 'vscode';
 import type { DiagnosticsLogger } from './diagnostics.js';
+import { affectsSetting, getSetting } from './settings.js';
 
 /** Minimum poll interval enforced regardless of setting value (5 seconds). */
 const MIN_INTERVAL_MS = 5_000;
 const DEBOUNCE_FAILURE_COUNT = 2;
 
 function getHeartbeatIntervalMs(): number {
-  const seconds = vscode.workspace.getConfiguration('ollama').get<number>('localModelRefreshInterval') ?? 30;
+  const seconds = getSetting<number>('localModelRefreshInterval', 30);
   return Math.max(seconds * 1_000, MIN_INTERVAL_MS);
 }
 
@@ -181,7 +182,7 @@ export function registerStatusBarHeartbeat(
 
   // Re-schedule if the refresh interval setting changes.
   const configListener = vscode.workspace.onDidChangeConfiguration(event => {
-    if (event.affectsConfiguration('ollama.localModelRefreshInterval')) {
+    if (affectsSetting(event, 'localModelRefreshInterval')) {
       diagnostics.debug('[statusBar] refresh interval changed, rescheduling heartbeat');
       scheduleInterval();
     }


### PR DESCRIPTION
## Summary
- introduce `opilot.*` contributed settings in `package.json`
- keep legacy `ollama.*` settings and mark them deprecated in manifest
- add runtime settings compatibility layer that reads `opilot.*` first and falls back to `ollama.*`
- auto-migrate legacy `ollama.*` values to `opilot.*` on activation
- update docs/examples to prefer `opilot.*`

## Implementation details
- new helper module `src/settings.ts`:
  - `getSetting()` (`opilot` first, `ollama` fallback)
  - `affectsSetting()` (reacts to both namespaces)
  - `migrateLegacySettings()` (global/workspace/workspaceFolder scopes)
- wired helper into runtime modules:
  - `src/client.ts`
  - `src/completions.ts`
  - `src/diagnostics.ts`
  - `src/statusBar.ts`
  - `src/modelfiles.ts`
  - `src/sidebar.ts`
  - `src/provider.ts`
  - `src/extension.ts`

## Tests
- updated config contribution assertions in `src/contributes.test.ts`
- updated settings-open expectation in `src/extension.test.ts`
- focused test run passed:
  - `src/contributes.test.ts`
  - `src/extension.test.ts`
  - `src/extension.utils.test.ts`
  - `src/modelfiles.test.ts`
  - `src/sidebar.test.ts`

## Migration behavior
On activation, existing values under `ollama.*` are copied to `opilot.*` when `opilot.*` is not already set at that scope. Legacy keys remain supported via runtime fallback.