### PR TITLE
fix: per-model num_ctx sidebar settings no longer overridden by Ollama app context window

### DIFF
--- a/.beans/ollama-models-vscode-pcqe--fix-per-model-num-ctx-sidebar-settings-being-overr.md
+++ b/.beans/ollama-models-vscode-pcqe--fix-per-model-num-ctx-sidebar-settings-being-overr.md
@@ -1,6 +1,19 @@
 ---
-id: ollama-models-vscode-pcqe
+# ollama-models-vscode-pcqe
 title: fix per model num ctx sidebar settings being overr
-status: todo
+status: completed
 type: task
+priority: normal
+created_at: 2026-04-06T15:01:09Z
+updated_at: 2026-04-06T15:02:16Z
 ---
+
+## Summary of Changes
+
+- `contextUtils.ts`: flipped `resolveContextLimit` priority — `num_ctx` sidebar override now beats model-reported `maxInputTokens`
+- `contextUtils.test.ts`: updated tests for new priority
+- `provider.ts`: `OllamaChatModelProvider` now accepts a `getModelSettings` getter and wires per-model options through all truncation and API call paths
+- `extension.ts`: passes live `modelSettingsStore` getter to provider
+
+Branch: `fix/ollama-models-vscode-pcqe-per-model-num-ctx-overridden`  
+PR: https://github.com/selfagency/opilot/pull/85

--- a/.beans/ollama-models-vscode-pcqe--fix-per-model-num-ctx-sidebar-settings-being-overr.md
+++ b/.beans/ollama-models-vscode-pcqe--fix-per-model-num-ctx-sidebar-settings-being-overr.md
@@ -1,0 +1,6 @@
+---
+id: ollama-models-vscode-pcqe
+title: fix per model num ctx sidebar settings being overr
+status: todo
+type: task
+---

--- a/src/contextUtils.test.ts
+++ b/src/contextUtils.test.ts
@@ -154,9 +154,14 @@ describe('detectsRepetition', () => {
 });
 
 describe('resolveContextLimit', () => {
-  it('returns modelReported when > 0', () => {
+  it('returns modelOptNumCtx when set (highest priority, overrides model-reported)', () => {
+    expect(resolveContextLimit(4096, 8192)).toBe(8192);
+    expect(resolveContextLimit(4096, 2048, 16384)).toBe(2048);
+  });
+
+  it('returns modelReported when modelOptNumCtx is not set', () => {
     expect(resolveContextLimit(4096)).toBe(4096);
-    expect(resolveContextLimit(4096, 2048, 16384)).toBe(4096);
+    expect(resolveContextLimit(4096, 0, 16384)).toBe(4096);
   });
 
   it('returns modelOptNumCtx when modelReported is 0', () => {

--- a/src/contextUtils.ts
+++ b/src/contextUtils.ts
@@ -136,14 +136,14 @@ export const DEFAULT_CONTEXT_TOKENS = 8192;
  * Resolve the effective context-window token limit for message truncation.
  *
  * Priority:
- * 1. Model-reported maxInputTokens (from Ollama /api/show metadata)
- * 2. Per-model num_ctx override from model settings
+ * 1. Per-model num_ctx override from model settings (user explicitly set this — wins over all)
+ * 2. Model-reported maxInputTokens (from Ollama /api/show metadata)
  * 3. User-configured opilot.maxContextTokens setting
  * 4. Built-in default of 8 192 tokens
  */
 export function resolveContextLimit(modelReported: number, modelOptNumCtx?: number, settingMax?: number): number {
-  if (modelReported > 0) return modelReported;
   if (modelOptNumCtx && modelOptNumCtx > 0) return modelOptNumCtx;
+  if (modelReported > 0) return modelReported;
   if (settingMax && settingMax > 0) return settingMax;
   return DEFAULT_CONTEXT_TOKENS;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1380,7 +1380,7 @@ export async function activate(context: vscode.ExtensionContext) {
         };
   diagnostics.info('[model-settings] View provider registered');
 
-  const provider = new OllamaChatModelProvider(context, client, diagnostics);
+  const provider = new OllamaChatModelProvider(context, client, diagnostics, () => modelSettingsStore);
   let lmProviderDisposable: vscode.Disposable | undefined;
   try {
     lmProviderDisposable = vscode.lm.registerLanguageModelChatProvider(LANGUAGE_MODEL_VENDOR, provider);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -2,7 +2,7 @@ import { appendToBlockquote } from '@selfagency/llm-stream-parser/markdown';
 import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { Ollama, type ChatResponse, type Message, type ShowResponse } from 'ollama';
+import { Ollama, type ChatResponse, type Message, type Options, type ShowResponse } from 'ollama';
 import {
   CancellationToken,
   EventEmitter,
@@ -34,6 +34,7 @@ import {
 } from './formatting';
 import { chatCompletionsOnce, initiateChatCompletionsStream } from './openaiCompat.js';
 import { ollamaMessagesToOpenAICompat, ollamaToolsToOpenAICompat } from './openaiCompatMapping.js';
+import { getModelOptionsForModel, type ModelOptionOverrides, type ModelSettingsStore } from './modelSettings.js';
 import { getSetting } from './settings.js';
 import { ThinkingParser } from './thinkingParser.js';
 import { isToolsNotSupportedError, normalizeToolParameters } from './toolUtils.js';
@@ -77,7 +78,20 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     readonly context: ExtensionContext,
     private client: Ollama,
     private outputChannel: DiagnosticsLogger,
+    private getModelSettings?: () => ModelSettingsStore,
   ) {}
+
+  private buildSdkOptions(overrides: ModelOptionOverrides): Partial<Options> | undefined {
+    const { temperature, top_p, top_k, num_ctx, num_predict, think_budget } = overrides;
+    const opts: Record<string, number> = {};
+    if (temperature !== undefined) opts['temperature'] = temperature;
+    if (top_p !== undefined) opts['top_p'] = top_p;
+    if (top_k !== undefined) opts['top_k'] = top_k;
+    if (num_ctx !== undefined) opts['num_ctx'] = num_ctx;
+    if (num_predict !== undefined) opts['num_predict'] = num_predict;
+    if (think_budget !== undefined) opts['think_budget'] = think_budget;
+    return Object.keys(opts).length > 0 ? (opts as Partial<Options>) : undefined;
+  }
 
   /**
    * Provide information about available chat models
@@ -552,7 +566,9 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     shouldThink: boolean,
     fallbackClient: Ollama,
     signal?: AbortSignal,
+    modelOptions?: ModelOptionOverrides,
   ): Promise<AsyncIterable<ChatResponse>> {
+    const { temperature, top_p, top_k, num_ctx, num_predict, think_budget } = modelOptions ?? {};
     let stream: AsyncIterable<import('./openaiCompat.js').OpenAICompatChatCompletionChunk>;
     try {
       const baseUrl = getOllamaHost();
@@ -570,15 +586,23 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
           messages: ollamaMessagesToOpenAICompat(messages),
           tools: ollamaToolsToOpenAICompat(tools),
           ...(shouldThink ? { think: true } : {}),
+          ...(temperature !== undefined ? { temperature } : {}),
+          ...(top_p !== undefined ? { top_p } : {}),
+          ...(num_predict !== undefined ? { max_tokens: num_predict } : {}),
+          ...(top_k !== undefined ? { top_k } : {}),
+          ...(num_ctx !== undefined ? { num_ctx } : {}),
+          ...(think_budget !== undefined ? { think_budget } : {}),
         },
       });
     } catch {
+      const sdkOptions = modelOptions ? this.buildSdkOptions(modelOptions) : undefined;
       return fallbackClient.chat({
         model: runtimeModelId,
         messages,
         stream: true,
         tools,
         ...(shouldThink ? { think: true } : {}),
+        ...(sdkOptions ? { options: sdkOptions } : {}),
       });
     }
 
@@ -612,7 +636,9 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     shouldThink: boolean,
     fallbackClient: Ollama,
     signal?: AbortSignal,
+    modelOptions?: ModelOptionOverrides,
   ): Promise<ChatResponse> {
+    const { temperature, top_p, top_k, num_ctx, num_predict, think_budget } = modelOptions ?? {};
     let response: import('./openaiCompat.js').OpenAICompatChatCompletionResponse;
     try {
       const baseUrl = getOllamaHost();
@@ -627,15 +653,23 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
           messages: ollamaMessagesToOpenAICompat(messages),
           tools: ollamaToolsToOpenAICompat(tools),
           ...(shouldThink ? { think: true } : {}),
+          ...(temperature !== undefined ? { temperature } : {}),
+          ...(top_p !== undefined ? { top_p } : {}),
+          ...(num_predict !== undefined ? { max_tokens: num_predict } : {}),
+          ...(top_k !== undefined ? { top_k } : {}),
+          ...(num_ctx !== undefined ? { num_ctx } : {}),
+          ...(think_budget !== undefined ? { think_budget } : {}),
         },
       });
     } catch {
+      const sdkOptions = modelOptions ? this.buildSdkOptions(modelOptions) : undefined;
       return (await fallbackClient.chat({
         model: runtimeModelId,
         messages,
         stream: false,
         tools,
         ...(shouldThink ? { think: true } : {}),
+        ...(sdkOptions ? { options: sdkOptions } : {}),
       })) as ChatResponse;
     }
 
@@ -661,13 +695,16 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     tools: Parameters<typeof this.client.chat>[0]['tools'] | undefined,
     shouldThink: boolean,
     client: Ollama,
+    modelOptions?: ModelOptionOverrides,
   ): Promise<AsyncIterable<ChatResponse>> {
+    const sdkOptions = modelOptions ? this.buildSdkOptions(modelOptions) : undefined;
     return client.chat({
       model: runtimeModelId,
       messages,
       stream: true,
       tools,
       ...(shouldThink ? { think: true } : {}),
+      ...(sdkOptions ? { options: sdkOptions } : {}),
     });
   }
 
@@ -677,13 +714,16 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     tools: Parameters<typeof this.client.chat>[0]['tools'] | undefined,
     shouldThink: boolean,
     client: Ollama,
+    modelOptions?: ModelOptionOverrides,
   ): Promise<ChatResponse> {
+    const sdkOptions = modelOptions ? this.buildSdkOptions(modelOptions) : undefined;
     return (await client.chat({
       model: runtimeModelId,
       messages,
       stream: false,
       tools,
       ...(shouldThink ? { think: true } : {}),
+      ...(sdkOptions ? { options: sdkOptions } : {}),
     })) as ChatResponse;
   }
 
@@ -737,9 +777,13 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
     this.outputChannel.info(
       `[context] before truncation: ${effectiveMessages.length} messages, ${JSON.stringify(effectiveMessages, null, 2).length} chars, model.maxInputTokens=${model.maxInputTokens}`,
     );
+    const modelSettings = this.getModelSettings?.();
+    const modelOptions: ModelOptionOverrides = modelSettings
+      ? getModelOptionsForModel(modelSettings, runtimeModelId)
+      : {};
     const maxInputTokens = resolveContextLimit(
       model.maxInputTokens ?? 0,
-      undefined,
+      modelOptions.num_ctx,
       getSetting<number>('maxContextTokens', 0),
     );
     const ollamaMessages = truncateMessages(effectiveMessages, maxInputTokens);
@@ -789,9 +833,9 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       // Choose API path: native Ollama SDK for local models, OpenAI-compat for cloud
       const streamFn = isCloudModel
         ? (think: boolean, t?: typeof tools) =>
-            this.openAiCompatStreamChat(runtimeModelId, ollamaMessages as Message[], t, think, perRequestClient)
+            this.openAiCompatStreamChat(runtimeModelId, ollamaMessages as Message[], t, think, perRequestClient, undefined, modelOptions)
         : (think: boolean, t?: typeof tools) =>
-            this.nativeSdkStreamChat(runtimeModelId, ollamaMessages as Message[], t, think, perRequestClient);
+            this.nativeSdkStreamChat(runtimeModelId, ollamaMessages as Message[], t, think, perRequestClient, modelOptions);
 
       try {
         this.outputChannel.info(
@@ -974,6 +1018,8 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
                 effectiveTools,
                 think,
                 perRequestClient,
+                undefined,
+                modelOptions,
               )
           : (think: boolean) =>
               this.nativeSdkChatOnce(
@@ -982,6 +1028,7 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
                 effectiveTools,
                 think,
                 perRequestClient,
+                modelOptions,
               );
 
         const fallback = await fallbackFn(shouldThink);
@@ -1050,6 +1097,8 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
               attempt.tools,
               attempt.think,
               perRequestClient,
+              undefined,
+              modelOptions,
             );
 
             const hasContent =


### PR DESCRIPTION
## Problem

Per-model `num_ctx` settings configured in the Opilot sidebar were silently ignored. The Ollama app's configured context window (reported as `model.maxInputTokens`) always took precedence, so user overrides had no effect.

A second issue: `OllamaChatModelProvider` — the path used by VS Code's Language Model API — was not passing per-model settings to Ollama API calls at all (neither for truncation nor for generation options).

## Root cause

`resolveContextLimit` prioritised `modelReported` (Ollama app value) above `modelOptNumCtx` (user's explicit sidebar override). Since the user's intent is clearly to override the default, the sidebar value must win.

## Changes

### `src/contextUtils.ts`
- New priority order: `num_ctx` override → model-reported `maxInputTokens` → `opilot.maxContextTokens` setting → built-in default of 8 192

### `src/contextUtils.test.ts`
- Updated tests to assert that an explicit `num_ctx` overrides a larger or smaller model-reported value

### `src/provider.ts`
- `OllamaChatModelProvider` constructor now accepts an optional `getModelSettings: () => ModelSettingsStore` getter
- Added `buildSdkOptions` instance helper (mirrors the equivalent function in `extension.ts`)
- Per-model `ModelOptionOverrides` is resolved at the start of `provideLanguageModelChatResponse` and passed to:
  - `resolveContextLimit` (truncation)
  - `nativeSdkStreamChat` / `nativeSdkChatOnce` — forwarded as `options: {}` to the Ollama SDK
  - `openAiCompatStreamChat` / `openAiCompatChatOnce` — forwarded as individual OpenAI-compat fields (`temperature`, `top_p`, `top_k`, `num_ctx`, `max_tokens`, `think_budget`)
  - Cloud rescue ladder `openAiCompatChatOnce` calls

### `src/extension.ts`
- Passes `() => modelSettingsStore` to `OllamaChatModelProvider` so it always reads the latest sidebar state

## Testing

All 137 existing unit tests pass (`task unit-tests`).

Closes bean `ollama-models-vscode-pcqe`.