### PR TITLE
fix: add go-task/setup-task to docs-deploy workflow

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Setup task runner
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
+        with:
+          version: "3.x"
+
       - name: Build docs
         run: task docs-build
 


### PR DESCRIPTION
## Summary

Docs-deploy workflow fails with `task: command not found` — same root cause as the CI fix in PR #107. The runner doesn't have the `task` binary installed.

### Changes
- Added `go-task/setup-task@v2.1.0` step before `task docs-build`
- Uses same pinned commit hash as `ci.yml` and `release.yml`

### Verification
- Release workflow already has setup-task and passes CI
- CI workflow uses the same action with the same version