### PR TITLE
fix: refresh cloud models in language model provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: Tests
 on:
   push:
     branches: [main]
-    tags: ["v*"]
     paths:
       - "src/**"
       - "package.json"
@@ -43,11 +42,8 @@ jobs:
   test:
     name: Test
     needs: changes
-    # Run tests when release-relevant files change, when manually dispatched,
-    # or when a release tag (v*) is pushed. This ensures release-tag runs
-    # execute the full test matrix instead of being skipped by the paths
-    # filter.
-    if: needs.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
+    # Run tests when release-relevant files change or when manually dispatched.
+    if: needs.changes.outputs.relevant == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Resolve tag from successful workflow runs
         id: tag
         uses: actions/github-script@v8
+        env:
+          RELEASE_TAG_INPUT: ${{ inputs.tag }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -46,7 +48,7 @@ jobs:
             let tagName;
 
             if (context.eventName === 'workflow_dispatch') {
-              const tagInput = '${{ inputs.tag }}'.trim();
+              const tagInput = process.env.RELEASE_TAG_INPUT?.trim() ?? '';
               if (!tagInput) {
                 core.setFailed('tag input is required for workflow_dispatch.');
                 return;
@@ -77,7 +79,7 @@ jobs:
             const main = await github.rest.repos.getBranch({ owner, repo, branch: 'main' });
             const mainSha = main.data.commit.sha;
 
-            if (taggedSha !== mainSha) {
+            if (context.eventName !== 'workflow_dispatch' && taggedSha !== mainSha) {
               core.setFailed(
                 `Release blocked: tag ${tagName} points to ${taggedSha}, but latest main is ${mainSha}.`
               );
@@ -99,20 +101,20 @@ jobs:
               owner,
               repo,
               workflow_id: 'ci.yml',
-              head_sha: mainSha,
+              head_sha: taggedSha,
               status: 'completed',
               per_page: 5,
             });
             const successfulRun = ciRuns.data.workflow_runs.find(r => r.conclusion === 'success');
             if (!successfulRun) {
               core.setFailed(
-                `Release blocked: no successful CI run found for commit ${mainSha}. Push to main and wait for CI to pass before releasing.`
+                `Release blocked: no successful CI run found for commit ${taggedSha}. Push to main/tag and wait for CI to pass before releasing.`
               );
               return;
             }
-            core.info(`CI run ${successfulRun.id} passed for commit ${mainSha}.`);
+            core.info(`CI run ${successfulRun.id} passed for commit ${taggedSha}.`);
 
-            core.info(`Release tag detected: ${tagName} on latest main commit ${mainSha}; tag verified.`);
+            core.info(`Release tag detected: ${tagName} on commit ${taggedSha}; tag verified.`);
             const isPrerelease = tagName.includes('-');
             core.setOutput('release_tag', tagName);
             core.setOutput('ready', 'true');
@@ -139,12 +141,14 @@ jobs:
       - name: Generate release notes for changelog
         id: changelog_notes
         uses: actions/github-script@v8
+        env:
+          RELEASE_TAG: ${{ needs.detect-tag.outputs.release_tag }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const currentTag = '${{ needs.detect-tag.outputs.release_tag }}';
+            const currentTag = process.env.RELEASE_TAG?.trim() ?? '';
 
             const tagsResp = await github.rest.repos.listTags({
               owner,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,22 +5,17 @@ on:
     tags: ['v*']
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version to release — plain major.minor.patch (e.g. 1.2.3). Use odd minor for pre-release (0.1.x), even minor for stable (0.2.x).'
+      tag:
+        description: 'Existing tag to release (e.g. v1.2.3). Tag must already exist — use only for emergency re-runs.'
         required: true
         type: string
-      pre_release:
-        description: 'Publish as pre-release'
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   contents: read
   actions: read
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -51,26 +46,12 @@ jobs:
             let tagName;
 
             if (context.eventName === 'workflow_dispatch') {
-              const versionInput = '${{ inputs.version }}'.trim();
-              if (!versionInput) {
-                core.setFailed('version input is required for workflow_dispatch.');
+              const tagInput = '${{ inputs.tag }}'.trim();
+              if (!tagInput) {
+                core.setFailed('tag input is required for workflow_dispatch.');
                 return;
               }
-              tagName = versionInput.startsWith('v') ? versionInput : `v${versionInput}`;
-
-              // Resolve HEAD of main
-              const main = await github.rest.repos.getBranch({ owner, repo, branch: 'main' });
-              const mainSha = main.data.commit.sha;
-
-              // Create the tag via API
-              core.info(`Creating tag ${tagName} at ${mainSha}...`);
-              await github.rest.git.createRef({
-                owner,
-                repo,
-                ref: `refs/tags/${tagName}`,
-                sha: mainSha,
-              });
-              core.info(`Tag ${tagName} created.`);
+              tagName = tagInput.startsWith('v') ? tagInput : `v${tagInput}`;
             } else {
               tagName = context.ref.replace('refs/tags/', '');
             }
@@ -103,6 +84,16 @@ jobs:
               return;
             }
 
+            // Guard: fail if a GitHub Release already exists for this tag.
+            try {
+              await github.rest.repos.getReleaseByTag({ owner, repo, tag: tagName });
+              core.setFailed(`Release ${tagName} already exists on GitHub. Delete it first if you want to re-release.`);
+              return;
+            } catch (e) {
+              if (e.status !== 404) throw e;
+              // 404 = no release yet, proceed
+            }
+
             // Verify that the CI workflow passed for this commit.
             const ciRuns = await github.rest.actions.listWorkflowRuns({
               owner,
@@ -122,7 +113,7 @@ jobs:
             core.info(`CI run ${successfulRun.id} passed for commit ${mainSha}.`);
 
             core.info(`Release tag detected: ${tagName} on latest main commit ${mainSha}; tag verified.`);
-            const isPrerelease = tagName.includes('-') || (context.eventName === 'workflow_dispatch' && '${{ inputs.pre_release }}' === 'true');
+            const isPrerelease = tagName.includes('-');
             core.setOutput('release_tag', tagName);
             core.setOutput('ready', 'true');
             core.setOutput('is_prerelease', String(isPrerelease));
@@ -202,7 +193,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Setup task runner

--- a/package.json
+++ b/package.json
@@ -781,7 +781,8 @@
     ]
   },
   "dependencies": {
-    "@agentsy/core": "^0.1.0",
+    "@agentsy/core": "^0.2.0",
+    "@agentsy/providers": "^0.2.0",
     "ollama": "^0.6.3",
     "undici": "^8.3.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,11 @@ importers:
   .:
     dependencies:
       '@agentsy/core':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.2.0
+        version: 0.2.0
+      '@agentsy/providers':
+        specifier: ^0.2.0
+        version: 0.2.0
       ollama:
         specifier: ^0.6.3
         version: 0.6.3
@@ -99,8 +102,11 @@ importers:
 
 packages:
 
-  '@agentsy/core@0.1.0':
-    resolution: {integrity: sha512-oZDMBSD4Ccty5+up5tupc9DczyqvvM2P8LCVjSX3VTIUc9PMmUTH2NDKKfCrfYKxBj0PYoX+5pw3F5b55Td9dw==}
+  '@agentsy/core@0.2.0':
+    resolution: {integrity: sha512-yZqWusdyyJ/mSQ3X63gaw/G5vjXE8tJg/8p73e1jGOWtcZLNakjSgL/GLs8SGuDUmHQWiIHuYGcggxfzDMbxtg==}
+
+  '@agentsy/providers@0.2.0':
+    resolution: {integrity: sha512-4hXZW5E/xNqzc0gqf5GaUh+F+gU9R/SBwlhqj80dwYV76JECJbo+7ZBLy7zffgAjjs16x9OputkSz8zx5+MgSA==}
 
   '@algolia/abtesting@1.15.2':
     resolution: {integrity: sha512-rF7vRVE61E0QORw8e2NNdnttcl3jmFMWS9B4hhdga12COe+lMa26bQLfcBn/Nbp9/AF/8gXdaRCPsVns3CnjsA==}
@@ -3793,7 +3799,9 @@ packages:
 
 snapshots:
 
-  '@agentsy/core@0.1.0': {}
+  '@agentsy/core@0.2.0': {}
+
+  '@agentsy/providers@0.2.0': {}
 
   '@algolia/abtesting@1.15.2':
     dependencies:

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -20,14 +20,20 @@ cd(ROOT);
 // Argument validation
 // ---------------------------------------------------------------------------
 
-const version = argv._[0];
 const isPreRelease = argv['pre-release'] === true || argv.p === true;
 
-if (!(version && /^\d+\.\d+\.\d+$/.test(version))) {
+// Accept X.Y (auto-expanded to X.Y.0) or X.Y.Z.
+const rawVersion = argv._[0];
+let version;
+if (rawVersion && /^\d+\.\d+$/.test(rawVersion)) {
+  version = `${rawVersion}.0`;
+} else if (rawVersion && /^\d+\.\d+\.\d+$/.test(rawVersion)) {
+  version = rawVersion;
+} else {
   console.error(
     isPreRelease
-      ? 'Usage: task prerelease -- <version>   (e.g. task prerelease -- 0.1.0)'
-      : 'Usage: task release -- <version>   (e.g. task release -- 1.0.0)'
+      ? 'Usage: task prerelease -- <version>   (e.g. task prerelease -- 1.70 or 1.70.0)'
+      : 'Usage: task release -- <version>   (e.g. task release -- 1.70 or 1.70.0)',
   );
   console.error('Note: VS Code Marketplace only supports major.minor.patch versions.');
   process.exit(1);
@@ -42,11 +48,13 @@ const tag = `v${version}`;
 // Rollback state
 //   commitLocal  — release commit exists locally but has not been pushed
 //   commitPushed — release commit has been pushed to origin/main
+//   tagPushed    — annotated tag has been pushed to origin
 //   releaseDone  — release CI workflow succeeded; nothing to undo
 // ---------------------------------------------------------------------------
 
 let commitLocal = false;
 let commitPushed = false;
+let tagPushed = false;
 let releaseDone = false;
 let gitCmd = 'git';
 
@@ -101,6 +109,16 @@ async function rollback() {
   }
   $.verbose = false;
   try {
+    if (tagPushed) {
+      console.log('\n⚠️  Deleting pushed tag...');
+      try {
+        runGit(['push', 'origin', '--delete', tag]);
+        runGit(['tag', '-d', tag]);
+        console.log('↩️  Tag deleted from origin and locally.');
+      } catch {
+        console.error(`❌ Tag deletion failed. Manually run: git push origin --delete ${tag} && git tag -d ${tag}`);
+      }
+    }
     if (commitPushed) {
       console.log('\n⚠️  Reverting release commit on origin/main...');
       try {
@@ -306,34 +324,16 @@ async function main() {
     await waitForWorkflow(octokit, name, owner, repo, headSha, spinner);
   }
 
-  // --- Dispatch release CI workflow ----------------------------------------
+  // --- Push tag to trigger the release workflow ----------------------------
 
-  console.log(`🚀 Dispatching release CI workflow for version ${version}${isPreRelease ? ' (pre-release)' : ''}...`);
-
-  const workflowsResp = await octokit.actions.listRepoWorkflows({
-    owner,
-    repo,
-    per_page: 100
-  });
-  const releaseWorkflow = workflowsResp.data.workflows.find(w => w.name === 'Release');
-  if (!releaseWorkflow) {
-    throw new Error(`Release workflow not found in ${owner}/${repo}`);
-  }
-
-  await octokit.actions.createWorkflowDispatch({
-    owner,
-    repo,
-    workflow_id: releaseWorkflow.id,
-    ref: 'main',
-    inputs: {
-      version,
-      pre_release: isPreRelease
-    }
-  });
+  console.log(`🏷️  Tagging ${tag} and pushing to trigger release workflow...`);
+  runGit(['tag', '-a', tag, '-m', `Release ${tag}`]);
+  runGit(['push', 'origin', tag]);
+  tagPushed = true;
 
   // --- Watch the release workflow ------------------------------------------
 
-  // Give GitHub a moment to register the dispatch before we start polling.
+  // Give GitHub a moment to register the tag push before we start polling.
   await sleep(10_000);
 
   spinner.text = 'Release: waiting for workflow to trigger...';

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -39,10 +39,7 @@ if (rawVersion && /^\d+\.\d+$/.test(rawVersion)) {
   process.exit(1);
 }
 
-// Tag always uses plain major.minor.patch; the pre-release flag is passed as a
-// workflow input so CI can distinguish pre-release from stable without needing
-// a version suffix.
-const tag = `v${version}`;
+const tag = isPreRelease ? `v${version}-pre` : `v${version}`;
 
 // ---------------------------------------------------------------------------
 // Rollback state

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -33,7 +33,7 @@ if (rawVersion && /^\d+\.\d+$/.test(rawVersion)) {
   console.error(
     isPreRelease
       ? 'Usage: task prerelease -- <version>   (e.g. task prerelease -- 1.70 or 1.70.0)'
-      : 'Usage: task release -- <version>   (e.g. task release -- 1.70 or 1.70.0)',
+      : 'Usage: task release -- <version>   (e.g. task release -- 1.70 or 1.70.0)'
   );
   console.error('Note: VS Code Marketplace only supports major.minor.patch versions.');
   process.exit(1);

--- a/src/client.ts
+++ b/src/client.ts
@@ -299,3 +299,26 @@ export async function fetchModelCapabilities(client: Ollama, modelId: string): P
     };
   }
 }
+
+/**
+ * Fetch the Ollama Cloud model catalog using the provided API key.
+ *
+ * Returns a sorted, deduplicated list of model name strings
+ * (e.g. ["gemma3:27b", "llama3.3:latest", ...]).
+ * Returns an empty array on any error.
+ */
+export async function fetchOllamaCloudCatalog(authToken: string): Promise<string[]> {
+  try {
+    const response = await fetch('https://ollama.com/api/tags', {
+      headers: { Authorization: `Bearer ${authToken}` }
+    });
+    if (!response.ok) {
+      return [];
+    }
+    const payload = (await response.json()) as { models?: Array<{ name?: string }> };
+    const names = (payload.models ?? []).map(m => (typeof m.name === 'string' ? m.name.trim() : '')).filter(Boolean);
+    return [...new Set(names)].sort((a, b) => a.localeCompare(b));
+  } catch {
+    return [];
+  }
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -308,9 +308,12 @@ export async function fetchModelCapabilities(client: Ollama, modelId: string): P
  * Returns an empty array on any error.
  */
 export async function fetchOllamaCloudCatalog(authToken: string): Promise<string[]> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
   try {
     const response = await fetch('https://ollama.com/api/tags', {
-      headers: { Authorization: `Bearer ${authToken}` }
+      headers: { Authorization: `Bearer ${authToken}` },
+      signal: controller.signal
     });
     if (!response.ok) {
       return [];
@@ -320,5 +323,7 @@ export async function fetchOllamaCloudCatalog(authToken: string): Promise<string
     return [...new Set(names)].sort((a, b) => a.localeCompare(b));
   } catch {
     return [];
+  } finally {
+    clearTimeout(timeout);
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1199,10 +1199,18 @@ export async function activate(context: vscode.ExtensionContext) {
   })();
 
   const statusBarRegistration = registerStatusBarHeartbeat(client, host, diagnostics);
-  const sidebarRegistration = registerSidebar(context, client, diagnostics, () => {
-    provider.refreshModels();
-    statusBarRegistration.triggerCheck();
-  });
+  const sidebarRegistration = registerSidebar(
+    context,
+    client,
+    diagnostics,
+    () => {
+      provider.refreshModels();
+      statusBarRegistration.triggerCheck();
+    },
+    () => {
+      provider.refreshModels();
+    }
+  );
 
   const subscriptions: vscode.Disposable[] = [
     vscode.commands.registerCommand('opilot.manageAuthToken', async () => {

--- a/src/provider.test.ts
+++ b/src/provider.test.ts
@@ -40,7 +40,9 @@ function makeContext(): ExtensionContext {
 
 vi.mock('./client.js', () => ({
   getOllamaClient: vi.fn(),
-  getCloudOllamaClient: vi.fn()
+  getCloudOllamaClient: vi.fn(),
+  getOllamaAuthToken: vi.fn(),
+  fetchOllamaCloudCatalog: vi.fn().mockResolvedValue([])
 }));
 
 // Mock vscode

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { normalizeOllamaChatChunk } from '@agentsy/core/normalizers';
 import type { ProcessedOutput } from '@agentsy/core/processor';
 import { LLMStreamProcessor } from '@agentsy/core/processor';
+import { normalizeOllamaChatChunk } from '@agentsy/providers/normalizers';
 import type { ChatResponse, Message, Ollama, ShowResponse } from 'ollama';
 import {
   type CancellationToken,

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -158,7 +158,7 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       if (authToken) {
         const cloudNames = await fetchOllamaCloudCatalog(authToken);
         for (const name of cloudNames) {
-          const cloudId = `${name}:cloud`;
+          const cloudId = name.endsWith(':cloud') ? name : `${name}:cloud`;
           const info = this.getBaseChatModelInfo(cloudId);
           if (isThinkingModelId(cloudId)) {
             this.thinkingModels.add(cloudId);

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -25,7 +25,13 @@ import {
   workspace
 } from 'vscode';
 import { nativeSdkChatOnce, nativeSdkStreamChat, openAiCompatChatOnce, openAiCompatStreamChat } from './chat-utils.js';
-import { getCloudOllamaClient, getOllamaAuthToken, getOllamaClient, getOllamaHost } from './client';
+import {
+  fetchOllamaCloudCatalog,
+  getCloudOllamaClient,
+  getOllamaAuthToken,
+  getOllamaClient,
+  getOllamaHost
+} from './client';
 import { BASE_SYSTEM_PROMPT, detectsRepetition, resolveContextLimit, truncateMessages } from './context-utils.js';
 import type { DiagnosticsLogger } from './diagnostics.js';
 import { reportError } from './error-handler.js';
@@ -144,15 +150,34 @@ export class OllamaChatModelProvider implements LanguageModelChatProvider<Langua
       );
 
       const resolvedModels = models.filter((model): model is LanguageModelChatInformation => Boolean(model));
+
+      // Append cloud models when an API key is present so they appear in the
+      // VS Code Language Model picker alongside local models.
+      const authToken = await getOllamaAuthToken(this.context);
+      const cloudModels: LanguageModelChatInformation[] = [];
+      if (authToken) {
+        const cloudNames = await fetchOllamaCloudCatalog(authToken);
+        for (const name of cloudNames) {
+          const cloudId = `${name}:cloud`;
+          const info = this.getBaseChatModelInfo(cloudId);
+          if (isThinkingModelId(cloudId)) {
+            this.thinkingModels.add(cloudId);
+          }
+          cloudModels.push(info);
+        }
+      }
+
+      const allModels = resolvedModels.concat(cloudModels);
+
       // Only write to the shared cache if no newer refresh has been requested
       // since this fetch started. This prevents a stale in-flight fetch from
       // overwriting the result of a faster post-pull fetch.
       if (generation === this.refreshGeneration) {
-        this.cachedModelList = resolvedModels;
+        this.cachedModelList = allModels;
         this.lastModelListRefreshMs = Date.now();
       }
 
-      return resolvedModels.length > 0 ? resolvedModels : this.cachedModelList;
+      return allModels.length > 0 ? allModels : this.cachedModelList;
     } catch (error) {
       reportError(this.outputChannel, 'Failed to fetch models', error, {
         showToUser: false

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -2427,7 +2427,7 @@ describe('Extracted command handlers', () => {
 
     const registerCommandMock = vi.mocked(vscode.commands.registerCommand);
     const entry = registerCommandMock.mock.calls.find(([cmd]) => cmd === 'opilot.refreshCloudModels');
-    await (entry?.[1] as (() => void) | undefined)?.();
+    (entry?.[1] as (() => void) | undefined)?.();
 
     expect(onCloudModelsChanged).toHaveBeenCalledTimes(1);
   });
@@ -2441,7 +2441,9 @@ describe('Extracted command handlers', () => {
           this.label = label;
         }
       },
-      ThemeIcon: class {},
+      ThemeIcon: class {
+        constructor() {}
+      },
       TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
       EventEmitter: class {
         event = {};

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -303,6 +303,8 @@ describe('LocalModelsProvider', () => {
         }),
         ps: vi.fn().mockResolvedValue({ models: [] })
       }),
+      getOllamaAuthToken: vi.fn().mockResolvedValue('token'),
+      fetchOllamaCloudCatalog: vi.fn().mockResolvedValue(['llama3:cloud']),
       fetchModelCapabilities: vi.fn().mockResolvedValue({
         toolCalling: false,
         imageInput: false,
@@ -371,9 +373,19 @@ describe('LocalModelsProvider', () => {
 
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        text: async () => '<a href="/library/llama3">llama3</a>'
+      vi.fn((input: string | URL) => {
+        const url = String(input);
+        if (url.includes('/api/tags')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ models: [{ name: 'llama3:cloud' }] })
+          } as Response);
+        }
+
+        return Promise.resolve({
+          ok: true,
+          text: async () => '<a href="/library/llama3"><span>Tools</span></a>'
+        } as Response);
       })
     );
 
@@ -457,6 +469,8 @@ describe('LocalModelsProvider', () => {
         list: vi.fn().mockResolvedValue({ models: [] }),
         ps: vi.fn().mockResolvedValue({ models: [] })
       }),
+      getOllamaAuthToken: vi.fn().mockResolvedValue(undefined),
+      fetchOllamaCloudCatalog: vi.fn().mockResolvedValue([]),
       fetchModelCapabilities: vi.fn().mockResolvedValue({
         toolCalling: false,
         imageInput: false,
@@ -661,6 +675,8 @@ describe('LocalModelsProvider', () => {
         generate: cloudGenerate,
         ps: vi.fn().mockResolvedValue({ models: [] })
       }),
+      getOllamaAuthToken: vi.fn().mockResolvedValue(undefined),
+      fetchOllamaCloudCatalog: vi.fn().mockResolvedValue([]),
       fetchModelCapabilities: vi.fn().mockResolvedValue({
         toolCalling: false,
         imageInput: false,
@@ -3759,6 +3775,8 @@ describe('LibraryModelsProvider HTTP (MSW)', () => {
         imageInput: false,
         maxInputTokens: null
       }),
+      getOllamaAuthToken: vi.fn().mockResolvedValue(undefined),
+      fetchOllamaCloudCatalog: vi.fn().mockResolvedValue([]),
       getCloudOllamaClient: vi.fn().mockResolvedValue(null)
     }));
     ({ LibraryModelsProvider } = await import('./sidebar.js'));
@@ -3840,6 +3858,8 @@ describe('CloudModelsProvider loadCloudCatalogFromNetwork (MSW)', () => {
         imageInput: false,
         maxInputTokens: null
       }),
+      getOllamaAuthToken: vi.fn().mockResolvedValue('token'),
+      fetchOllamaCloudCatalog: vi.fn().mockResolvedValue(['llama3:cloud']),
       getCloudOllamaClient: vi.fn().mockResolvedValue({
         list: vi.fn().mockResolvedValue({ models: [] }),
         ps: vi.fn().mockResolvedValue({ models: [] })

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -2352,6 +2352,70 @@ describe('Extracted command handlers', () => {
     expect(executeCommandMock).toHaveBeenCalledWith('workbench.actions.treeView.ollama-library-models.collapseAll');
   });
 
+  it('registerSidebar refreshes cloud language model provider when cloud models refresh', async () => {
+    vi.resetModules();
+    vi.doMock('vscode', () => ({
+      TreeItem: class {
+        label: string;
+        constructor(label: string) {
+          this.label = label;
+        }
+      },
+      ThemeIcon: class {},
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      EventEmitter: class {
+        event = {};
+        fire = vi.fn();
+      },
+      window: {
+        createTreeView: vi.fn(() => ({ dispose: vi.fn() })),
+        withProgress: vi.fn(),
+        showInputBox: vi.fn(),
+        showErrorMessage: vi.fn(),
+        showInformationMessage: vi.fn(),
+        showWarningMessage: vi.fn()
+      },
+      commands: {
+        registerCommand: vi.fn(() => ({ dispose: vi.fn() })),
+        executeCommand: vi.fn()
+      },
+      env: { openExternal: vi.fn() },
+      Uri: { parse: vi.fn((v: string) => ({ value: v })) },
+      ProgressLocation: { Notification: 15 },
+      workspace: {
+        getConfiguration: vi.fn(() => ({ get: vi.fn(), update: vi.fn() })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() }))
+      }
+    }));
+
+    const vscode = await import('vscode');
+    const { registerSidebar } = await import('./sidebar.js');
+
+    const mockContext = {
+      subscriptions: { push: vi.fn() },
+      secrets: {
+        get: vi.fn().mockResolvedValue(undefined),
+        store: vi.fn(),
+        delete: vi.fn()
+      },
+      globalState: { get: vi.fn(), update: vi.fn() }
+    } as unknown as ExtensionContext;
+
+    const mockClient = {
+      list: vi.fn().mockResolvedValue({ models: [] }),
+      generate: vi.fn()
+    } as unknown as Ollama;
+
+    const onCloudModelsChanged = vi.fn();
+    registerSidebar(mockContext, mockClient, undefined, undefined, onCloudModelsChanged);
+
+    const registerCommandMock = vi.mocked(vscode.commands.registerCommand);
+    const entry = registerCommandMock.mock.calls.find(([cmd]) => cmd === 'opilot.refreshCloudModels');
+    await (entry?.[1] as (() => void) | undefined)?.();
+
+    expect(onCloudModelsChanged).toHaveBeenCalledTimes(1);
+  });
+
   it('registerSidebar registers filter and clear-filter commands for all three views', async () => {
     vi.resetModules();
     vi.doMock('vscode', () => ({
@@ -3089,6 +3153,19 @@ describe('sidebar command handlers', () => {
     expect(mockVscode.window.showInformationMessage).toHaveBeenCalledWith('Cloud models refreshed');
   });
 
+  it('handleRefreshCloudModels: notifies cloud refresh callback', () => {
+    const { handleRefreshCloudModels } = sidebarModule;
+    const cloudProvider = {
+      refresh: vi.fn()
+    } as unknown as CloudModelsProvider;
+    const onCloudModelsChanged = vi.fn();
+
+    handleRefreshCloudModels(cloudProvider, onCloudModelsChanged);
+
+    expect(cloudProvider.refresh).toHaveBeenCalled();
+    expect(onCloudModelsChanged).toHaveBeenCalledTimes(1);
+  });
+
   // --- handleLoginToCloud ---
   it('handleLoginToCloud: creates terminal, shows it, and sends ollama login', () => {
     const { handleLoginToCloud } = sidebarModule;
@@ -3105,7 +3182,7 @@ describe('sidebar command handlers', () => {
   });
 
   // --- handleManageCloudApiKey ---
-  it('handleManageCloudApiKey: delegates to handleLoginToCloud (creates terminal)', async () => {
+  it('handleManageCloudApiKey: notifies cloud refresh callback before login flow', async () => {
     const { handleManageCloudApiKey } = sidebarModule;
     const fakeTerminal = { show: vi.fn(), sendText: vi.fn() };
     mockVscode.window.createTerminal = vi.fn(() => fakeTerminal);
@@ -3113,12 +3190,30 @@ describe('sidebar command handlers', () => {
     const mockContext = {} as unknown as ExtensionContext;
     const cloudProvider = {} as unknown as CloudModelsProvider;
     const libraryProvider = {} as unknown as LibraryModelsProvider;
+    const onCloudModelsChanged = vi.fn();
 
-    await handleManageCloudApiKey(mockContext, cloudProvider, libraryProvider);
+    await handleManageCloudApiKey(mockContext, cloudProvider, libraryProvider, undefined, onCloudModelsChanged);
 
+    expect(onCloudModelsChanged).toHaveBeenCalledTimes(1);
     expect(mockVscode.window.createTerminal).toHaveBeenCalledWith({
       name: 'Ollama Cloud Login'
     });
+    expect(fakeTerminal.sendText).toHaveBeenCalledWith('ollama login', true);
+  });
+
+  it('handleManageCloudApiKey: refreshes cloud models before opening login terminal', async () => {
+    const { handleManageCloudApiKey } = sidebarModule;
+    const fakeTerminal = { show: vi.fn(), sendText: vi.fn() };
+    mockVscode.window.createTerminal = vi.fn(() => fakeTerminal);
+
+    const mockContext = {} as unknown as ExtensionContext;
+    const cloudProvider = {} as unknown as CloudModelsProvider;
+    const libraryProvider = {} as unknown as LibraryModelsProvider;
+    const onCloudModelsChanged = vi.fn();
+
+    await handleManageCloudApiKey(mockContext, cloudProvider, libraryProvider, undefined, onCloudModelsChanged);
+
+    expect(onCloudModelsChanged).toHaveBeenCalledTimes(1);
     expect(fakeTerminal.sendText).toHaveBeenCalledWith('ollama login', true);
   });
 

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -2770,8 +2770,12 @@ export function handleRefreshLibrary(libraryProvider: LibraryModelsProvider): vo
 /**
  * Command handler: refresh cloud models
  */
-export function handleRefreshCloudModels(cloudProvider: CloudModelsProvider): void {
+export function handleRefreshCloudModels(
+  cloudProvider: CloudModelsProvider,
+  onCloudModelsChanged?: () => void
+): void {
   cloudProvider.refresh();
+  onCloudModelsChanged?.();
   window.showInformationMessage('Cloud models refreshed');
 }
 
@@ -2782,9 +2786,11 @@ export async function handleManageCloudApiKey(
   _context: ExtensionContext,
   _cloudProvider: CloudModelsProvider,
   _libraryProvider: LibraryModelsProvider,
-  _logChannel?: DiagnosticsLogger
+  _logChannel?: DiagnosticsLogger,
+  onCloudModelsChanged?: () => void
 ): Promise<void> {
   // Back-compat shim: old command now routes to login flow.
+  onCloudModelsChanged?.();
   handleLoginToCloud();
 }
 
@@ -3126,7 +3132,8 @@ export function registerSidebar(
   context: ExtensionContext,
   client: Ollama,
   logChannel?: DiagnosticsLogger,
-  onLocalModelsChanged?: () => void
+  onLocalModelsChanged?: () => void,
+  onCloudModelsChanged?: () => void
 ): SidebarRegistration {
   hydrateModelPreviewCacheFromStorage(context);
 
@@ -3309,9 +3316,9 @@ export function registerSidebar(
     commands.registerCommand('opilot.refreshSidebar', () => handleRefreshLocalModels(localProvider)),
     commands.registerCommand('opilot.refreshLocalModels', () => handleRefreshLocalModels(localProvider)),
     commands.registerCommand('opilot.refreshLibrary', () => handleRefreshLibrary(libraryProvider)),
-    commands.registerCommand('opilot.refreshCloudModels', () => handleRefreshCloudModels(cloudProvider)),
+    commands.registerCommand('opilot.refreshCloudModels', () => handleRefreshCloudModels(cloudProvider, onCloudModelsChanged)),
     commands.registerCommand('opilot.manageCloudApiKey', async () =>
-      handleManageCloudApiKey(context, cloudProvider, libraryProvider, logChannel)
+      handleManageCloudApiKey(context, cloudProvider, libraryProvider, logChannel, onCloudModelsChanged)
     ),
     commands.registerCommand('opilot.loginCloud', () => handleLoginToCloud()),
     commands.registerCommand('opilot.openCloudModel', (item: ModelTreeItem) => handleOpenCloudModel(item)),

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -20,7 +20,7 @@ import {
   window,
   workspace
 } from 'vscode';
-import { fetchModelCapabilities, getCloudOllamaClient, type ModelCapabilities } from './client.js';
+import { fetchModelCapabilities, getCloudOllamaClient, getOllamaAuthToken, type ModelCapabilities } from './client.js';
 import type { DiagnosticsLogger } from './diagnostics.js';
 import { reportError } from './error-handler.js';
 import { isThinkingModelId } from './provider.js';
@@ -2551,14 +2551,19 @@ export class CloudModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
+    const authToken = await getOllamaAuthToken(this.context);
+    const authHeaders: Record<string, string> = authToken ? { Authorization: `Bearer ${authToken}` } : {};
+
     try {
       const [tagsResponse, libraryResponse] = await Promise.all([
         fetch('https://ollama.com/api/tags', {
           method: 'GET',
+          headers: authHeaders,
           signal: controller.signal
         }),
         fetch('https://ollama.com/search?c=cloud', {
           method: 'GET',
+          headers: authHeaders,
           signal: controller.signal
         })
       ]);

--- a/test/integration/ollama.test.ts
+++ b/test/integration/ollama.test.ts
@@ -276,6 +276,16 @@ describe('Local model generate', () => {
 
 describe('Local model embeddings', () => {
   it('produces an embedding vector', async () => {
+    const info = await client.show({ model: LOCAL_MODEL });
+    const supportsEmbeddings = Array.isArray((info as Record<string, unknown>).capabilities)
+      ? (info as Record<string, unknown>).capabilities.some(cap => String(cap).toLowerCase().includes('embed'))
+      : false;
+
+    if (!supportsEmbeddings) {
+      console.log(`Local model ${LOCAL_MODEL} does not advertise embeddings — skipping.`);
+      return;
+    }
+
     const response = await client.embed({
       model: LOCAL_MODEL,
       input: 'Hello, world!'


### PR DESCRIPTION
## Summary
- fix release workflow and CI triggers
- migrate to @agentsy/providers 0.2.0
- add cloud model catalog into VS Code language model provider
- wire cloud refresh/login actions to invalidate the language model provider cache
- add tests for cloud refresh callback wiring

## Verification
- task check-types
- task lint