### PR TITLE
fix: activate sidebar views on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -770,6 +770,11 @@
   "activationEvents": [
     "onChatParticipant:opilot.ollama",
     "onLanguageModelChatProvider:selfagency-opilot",
+    "onView:ollama-local-models",
+    "onView:ollama-cloud-models",
+    "onView:ollama-library-models",
+    "onView:ollama-modelfiles",
+    "onView:ollama-model-settings",
     "onStartupFinished"
   ],
   "lint-staged": {

--- a/test/extension/extension.test.js
+++ b/test/extension/extension.test.js
@@ -76,6 +76,23 @@ exports.run = async () => {
   // Sidebar/Tree View Providers
   // ---------------------------------------------------------------------------
 
+  const views =
+    vscode.extensions.getExtension('selfagency.opilot').packageJSON?.contributes?.views?.['ollama-explorer'] ?? [];
+  const viewIds = views.map(view => view.id);
+
+  assert.ok(viewIds.includes('ollama-local-models'), 'Local models view contribution missing');
+  assert.ok(viewIds.includes('ollama-cloud-models'), 'Cloud models view contribution missing');
+  assert.ok(viewIds.includes('ollama-library-models'), 'Library models view contribution missing');
+  assert.ok(viewIds.includes('ollama-modelfiles'), 'Modelfiles view contribution missing');
+  assert.ok(viewIds.includes('ollama-model-settings'), 'Model settings view contribution missing');
+
+  const activationEvents = vscode.extensions.getExtension('selfagency.opilot').packageJSON?.activationEvents ?? [];
+  assert.ok(activationEvents.includes('onView:ollama-local-models'), 'Local models onView activation missing');
+  assert.ok(activationEvents.includes('onView:ollama-cloud-models'), 'Cloud models onView activation missing');
+  assert.ok(activationEvents.includes('onView:ollama-library-models'), 'Library models onView activation missing');
+  assert.ok(activationEvents.includes('onView:ollama-modelfiles'), 'Modelfiles onView activation missing');
+  assert.ok(activationEvents.includes('onView:ollama-model-settings'), 'Model settings onView activation missing');
+
   assert.ok(commands.includes('opilot.refreshLocalModels'), 'Local models tree view not properly initialized');
   console.log('✓ Local models tree view initialized');
 

--- a/test/extension/extension.test.js
+++ b/test/extension/extension.test.js
@@ -34,14 +34,14 @@ exports.run = async () => {
   await testCase('contributes sidebar views and activation events', () => {
     const manifest = vscode.extensions.getExtension('selfagency.opilot').packageJSON;
     const views = manifest?.contributes?.views?.['ollama-explorer'] ?? [];
-    const viewIds = views.map(view => view.id);
+    const viewIds = new Set(views.map(view => view.id));
     const activationEvents = manifest?.activationEvents ?? [];
 
-    assert.ok(viewIds.includes('ollama-local-models'), 'Local models view contribution missing');
-    assert.ok(viewIds.includes('ollama-cloud-models'), 'Cloud models view contribution missing');
-    assert.ok(viewIds.includes('ollama-library-models'), 'Library models view contribution missing');
-    assert.ok(viewIds.includes('ollama-modelfiles'), 'Modelfiles view contribution missing');
-    assert.ok(viewIds.includes('ollama-model-settings'), 'Model settings view contribution missing');
+    assert.ok(viewIds.has('ollama-local-models'), 'Local models view contribution missing');
+    assert.ok(viewIds.has('ollama-cloud-models'), 'Cloud models view contribution missing');
+    assert.ok(viewIds.has('ollama-library-models'), 'Library models view contribution missing');
+    assert.ok(viewIds.has('ollama-modelfiles'), 'Modelfiles view contribution missing');
+    assert.ok(viewIds.has('ollama-model-settings'), 'Model settings view contribution missing');
 
     assert.ok(activationEvents.includes('onView:ollama-local-models'), 'Local models onView activation missing');
     assert.ok(activationEvents.includes('onView:ollama-cloud-models'), 'Cloud models onView activation missing');

--- a/test/extension/extension.test.js
+++ b/test/extension/extension.test.js
@@ -3,159 +3,129 @@
 const assert = require('assert');
 const vscode = require('vscode');
 
-/**
- * Extension Integration Tests
- *
- * These tests verify the extension activates correctly and exposes all expected
- * commands, views, chat participants, and settings.
- *
- * Requirements:
- * - VS Code test environment
- * - Ollama server running on http://localhost:11434 (optional for most tests)
- */
-
 let extension;
 
+async function testCase(name, fn) {
+  try {
+    await fn();
+    console.log(`✓ ${name}`);
+  } catch (error) {
+    console.error(`✗ ${name}`);
+    throw error;
+  }
+}
+
 exports.run = async () => {
-  // Get the extension
   extension = vscode.extensions.getExtension('selfagency.opilot');
   assert.ok(extension, 'Extension not found');
 
-  // Activate the extension
   if (extension && !extension.isActive) {
     await extension.activate();
   }
 
-  // Get list of all commands once
   const commands = await vscode.commands.getCommands(true);
 
-  // ---------------------------------------------------------------------------
-  // Extension Activation
-  // ---------------------------------------------------------------------------
-
   console.log('✓ Extension activated');
-  assert.ok(extension.isActive, 'Extension did not activate');
 
-  // ---------------------------------------------------------------------------
-  // Command Registration
-  // ---------------------------------------------------------------------------
+  await testCase('activates the extension', () => {
+    assert.ok(extension.isActive, 'Extension did not activate');
+  });
 
-  const expectedCommands = [
-    'opilot.manageAuthToken',
-    'opilot.refreshLocalModels',
-    'opilot.refreshCloudModels',
-    'opilot.refreshLibrary',
-    'opilot.startModel',
-    'opilot.stopModel',
-    'opilot.deleteModel',
-    'opilot.pullModel',
-    'opilot.openLibraryModelPage',
-    'opilot.filterLocalModels',
-    'opilot.clearLocalFilter',
-    'opilot.toggleLocalGrouping',
-    'opilot.filterCloudModels',
-    'opilot.clearCloudFilter',
-    'opilot.toggleCloudGrouping',
-    'opilot.filterLibraryCapabilities',
-    'opilot.searchLibraryModels',
-    'opilot.clearLibrarySearch',
-    'opilot.toggleLibraryGrouping',
-    'opilot.newModelfile',
-    'opilot.editModelfile',
-    'opilot.buildModelfile',
-    'opilot.openModelfilesFolder',
-    'opilot.refreshModelfiles'
-  ];
+  await testCase('contributes sidebar views and activation events', () => {
+    const manifest = vscode.extensions.getExtension('selfagency.opilot').packageJSON;
+    const views = manifest?.contributes?.views?.['ollama-explorer'] ?? [];
+    const viewIds = views.map(view => view.id);
+    const activationEvents = manifest?.activationEvents ?? [];
 
-  for (const cmd of expectedCommands) {
-    assert.ok(commands.includes(cmd), `Command ${cmd} not registered`);
-    console.log(`✓ ${cmd} registered`);
-  }
+    assert.ok(viewIds.includes('ollama-local-models'), 'Local models view contribution missing');
+    assert.ok(viewIds.includes('ollama-cloud-models'), 'Cloud models view contribution missing');
+    assert.ok(viewIds.includes('ollama-library-models'), 'Library models view contribution missing');
+    assert.ok(viewIds.includes('ollama-modelfiles'), 'Modelfiles view contribution missing');
+    assert.ok(viewIds.includes('ollama-model-settings'), 'Model settings view contribution missing');
 
-  // ---------------------------------------------------------------------------
-  // Sidebar/Tree View Providers
-  // ---------------------------------------------------------------------------
+    assert.ok(activationEvents.includes('onView:ollama-local-models'), 'Local models onView activation missing');
+    assert.ok(activationEvents.includes('onView:ollama-cloud-models'), 'Cloud models onView activation missing');
+    assert.ok(activationEvents.includes('onView:ollama-library-models'), 'Library models onView activation missing');
+    assert.ok(activationEvents.includes('onView:ollama-modelfiles'), 'Modelfiles onView activation missing');
+    assert.ok(activationEvents.includes('onView:ollama-model-settings'), 'Model settings onView activation missing');
+  });
 
-  const views =
-    vscode.extensions.getExtension('selfagency.opilot').packageJSON?.contributes?.views?.['ollama-explorer'] ?? [];
-  const viewIds = views.map(view => view.id);
+  await testCase('registers expected commands and tree views', () => {
+    const expectedCommands = [
+      'opilot.manageAuthToken',
+      'opilot.refreshLocalModels',
+      'opilot.refreshCloudModels',
+      'opilot.refreshLibrary',
+      'opilot.startModel',
+      'opilot.stopModel',
+      'opilot.deleteModel',
+      'opilot.pullModel',
+      'opilot.openLibraryModelPage',
+      'opilot.filterLocalModels',
+      'opilot.clearLocalFilter',
+      'opilot.toggleLocalGrouping',
+      'opilot.filterCloudModels',
+      'opilot.clearCloudFilter',
+      'opilot.toggleCloudGrouping',
+      'opilot.filterLibraryCapabilities',
+      'opilot.searchLibraryModels',
+      'opilot.clearLibrarySearch',
+      'opilot.toggleLibraryGrouping',
+      'opilot.newModelfile',
+      'opilot.editModelfile',
+      'opilot.buildModelfile',
+      'opilot.openModelfilesFolder',
+      'opilot.refreshModelfiles'
+    ];
 
-  assert.ok(viewIds.includes('ollama-local-models'), 'Local models view contribution missing');
-  assert.ok(viewIds.includes('ollama-cloud-models'), 'Cloud models view contribution missing');
-  assert.ok(viewIds.includes('ollama-library-models'), 'Library models view contribution missing');
-  assert.ok(viewIds.includes('ollama-modelfiles'), 'Modelfiles view contribution missing');
-  assert.ok(viewIds.includes('ollama-model-settings'), 'Model settings view contribution missing');
+    for (const cmd of expectedCommands) {
+      assert.ok(commands.includes(cmd), `Command ${cmd} not registered`);
+    }
 
-  const activationEvents = vscode.extensions.getExtension('selfagency.opilot').packageJSON?.activationEvents ?? [];
-  assert.ok(activationEvents.includes('onView:ollama-local-models'), 'Local models onView activation missing');
-  assert.ok(activationEvents.includes('onView:ollama-cloud-models'), 'Cloud models onView activation missing');
-  assert.ok(activationEvents.includes('onView:ollama-library-models'), 'Library models onView activation missing');
-  assert.ok(activationEvents.includes('onView:ollama-modelfiles'), 'Modelfiles onView activation missing');
-  assert.ok(activationEvents.includes('onView:ollama-model-settings'), 'Model settings onView activation missing');
+    assert.ok(commands.includes('opilot.refreshLocalModels'), 'Local models tree view not properly initialized');
+    assert.ok(commands.includes('opilot.refreshCloudModels'), 'Cloud models tree view not properly initialized');
+    assert.ok(commands.includes('opilot.refreshLibrary'), 'Library models tree view not properly initialized');
+    assert.ok(commands.includes('opilot.newModelfile'), 'Modelfiles tree view not properly initialized');
+  });
 
-  assert.ok(commands.includes('opilot.refreshLocalModels'), 'Local models tree view not properly initialized');
-  console.log('✓ Local models tree view initialized');
+  await testCase('exposes extension configuration', () => {
+    const config = vscode.workspace.getConfiguration('ollama');
 
-  assert.ok(commands.includes('opilot.refreshCloudModels'), 'Cloud models tree view not properly initialized');
-  console.log('✓ Cloud models tree view initialized');
+    assert.ok(
+      typeof config.get('host') === 'string' || config.get('host') === undefined,
+      'ollama.host should be a string or undefined'
+    );
+    assert.ok(
+      typeof config.get('contextLength') === 'number' || config.get('contextLength') === undefined,
+      'contextLength should be a number'
+    );
+    assert.ok(
+      typeof config.get('completionModel') === 'string' || config.get('completionModel') === undefined,
+      'completionModel should be a string'
+    );
+    assert.ok(
+      typeof config.get('enableInlineCompletions') === 'boolean' || config.get('enableInlineCompletions') === undefined,
+      'enableInlineCompletions should be a boolean'
+    );
+    assert.ok(
+      typeof config.get('streamLogs') === 'boolean' || config.get('streamLogs') === undefined,
+      'streamLogs should be a boolean'
+    );
 
-  assert.ok(commands.includes('opilot.refreshLibrary'), 'Library models tree view not properly initialized');
-  console.log('✓ Library models tree view initialized');
+    const diagnosticsConfig = vscode.workspace.getConfiguration('ollama.diagnostics');
+    const logLevel = diagnosticsConfig.get('logLevel');
+    const validLevels = ['debug', 'info', 'warn', 'error'];
+    assert.ok(
+      validLevels.includes(logLevel) || logLevel === undefined,
+      `logLevel should be one of ${validLevels.join(', ')}`
+    );
+  });
 
-  assert.ok(commands.includes('opilot.newModelfile'), 'Modelfiles tree view not properly initialized');
-  console.log('✓ Modelfiles tree view initialized');
-
-  // ---------------------------------------------------------------------------
-  // Chat Participant
-  // ---------------------------------------------------------------------------
-
-  assert.ok(extension.isActive, 'Chat participant requires active extension');
-  console.log('✓ Ollama chat participant registered');
-
-  // ---------------------------------------------------------------------------
-  // Configuration/Settings
-  // ---------------------------------------------------------------------------
-
-  const config = vscode.workspace.getConfiguration('ollama');
-
-  const host = config.get('host');
-  assert.ok(typeof host === 'string' || host === undefined, 'ollama.host should be a string or undefined');
-  console.log('✓ ollama.host setting accessible');
-
-  const contextLength = config.get('contextLength');
-  assert.ok(typeof contextLength === 'number' || contextLength === undefined, 'contextLength should be a number');
-  console.log('✓ ollama.contextLength setting accessible');
-
-  const completionModel = config.get('completionModel');
-  assert.ok(typeof completionModel === 'string' || completionModel === undefined, 'completionModel should be a string');
-  console.log('✓ ollama.completionModel setting accessible');
-
-  const enabled = config.get('enableInlineCompletions');
-  assert.ok(typeof enabled === 'boolean' || enabled === undefined, 'enableInlineCompletions should be a boolean');
-  console.log('✓ ollama.enableInlineCompletions setting accessible');
-
-  const streamLogs = config.get('streamLogs');
-  assert.ok(typeof streamLogs === 'boolean' || streamLogs === undefined, 'streamLogs should be a boolean');
-  console.log('✓ ollama.streamLogs setting accessible');
-
-  const diagnosticsConfig = vscode.workspace.getConfiguration('ollama.diagnostics');
-  const logLevel = diagnosticsConfig.get('logLevel');
-  const validLevels = ['debug', 'info', 'warn', 'error'];
-  assert.ok(
-    validLevels.includes(logLevel) || logLevel === undefined,
-    `logLevel should be one of ${validLevels.join(', ')}`
-  );
-  console.log('✓ ollama.diagnostics.logLevel setting accessible');
-
-  // ---------------------------------------------------------------------------
-  // Error Handling
-  // ---------------------------------------------------------------------------
-
-  assert.ok(extension.isActive, 'Extension should remain active even if Ollama is unavailable');
-  console.log('✓ Extension handles missing Ollama server gracefully');
-
-  assert.ok(config !== undefined, 'Configuration should be accessible');
-  console.log('✓ Extension handles invalid configuration gracefully');
+  await testCase('remains active when Ollama is unavailable', () => {
+    const config = vscode.workspace.getConfiguration('ollama');
+    assert.ok(extension.isActive, 'Extension should remain active even if Ollama is unavailable');
+    assert.ok(config !== undefined, 'Configuration should be accessible');
+  });
 
   console.log('\n✅ All extension tests passed!');
 };


### PR DESCRIPTION
## Summary
- add explicit `onView:` activation events for all Opilot sidebar views
- add an extension smoke test that verifies contributed views and activation events

## Verification
- task check-types
- task lint
- task extension-tests