### PR TITLE
fix: eagerly register sidebar providers before async activation

### DIFF
--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -130,7 +130,8 @@ describe('activate', () => {
     }));
 
     vi.doMock('./sidebar.js', () => ({
-      registerSidebar: vi.fn()
+      registerSidebar: vi.fn(),
+      registerSidebarProviders: vi.fn()
     }));
 
     vi.doMock('./modelfiles.js', () => ({
@@ -268,7 +269,8 @@ describe('activate', () => {
     }));
 
     vi.doMock('./sidebar.js', () => ({
-      registerSidebar: vi.fn()
+      registerSidebar: vi.fn(),
+      registerSidebarProviders: vi.fn()
     }));
 
     vi.doMock('./modelfiles.js', () => ({
@@ -412,7 +414,8 @@ describe('activate', () => {
     }));
 
     vi.doMock('./sidebar.js', () => ({
-      registerSidebar: vi.fn()
+      registerSidebar: vi.fn(),
+      registerSidebarProviders: vi.fn()
     }));
 
     vi.doMock('./modelfiles.js', () => ({
@@ -569,7 +572,8 @@ describe('activate', () => {
     }));
 
     vi.doMock('./sidebar.js', () => ({
-      registerSidebar: vi.fn()
+      registerSidebar: vi.fn(),
+      registerSidebarProviders: vi.fn()
     }));
 
     vi.doMock('./modelfiles.js', () => ({
@@ -719,7 +723,8 @@ describe('activate', () => {
     }));
 
     vi.doMock('./sidebar.js', () => ({
-      registerSidebar: vi.fn()
+      registerSidebar: vi.fn(),
+      registerSidebarProviders: vi.fn()
     }));
 
     vi.doMock('./modelfiles.js', () => ({
@@ -857,7 +862,8 @@ describe('activate', () => {
     }));
 
     vi.doMock('./sidebar.js', () => ({
-      registerSidebar: vi.fn()
+      registerSidebar: vi.fn(),
+      registerSidebarProviders: vi.fn()
     }));
 
     vi.doMock('./modelfiles.js', () => ({
@@ -990,7 +996,8 @@ describe('activate', () => {
     }));
 
     vi.doMock('./sidebar.js', () => ({
-      registerSidebar: vi.fn()
+      registerSidebar: vi.fn(),
+      registerSidebarProviders: vi.fn()
     }));
 
     vi.doMock('./modelfiles.js', () => ({
@@ -1143,7 +1150,8 @@ describe('activate', () => {
     }));
 
     vi.doMock('./sidebar.js', () => ({
-      registerSidebar: vi.fn()
+      registerSidebar: vi.fn(),
+      registerSidebarProviders: vi.fn()
     }));
 
     vi.doMock('./modelfiles.js', () => ({
@@ -1285,7 +1293,8 @@ describe('activate', () => {
     }));
 
     vi.doMock('./sidebar.js', () => ({
-      registerSidebar: vi.fn()
+      registerSidebar: vi.fn(),
+      registerSidebarProviders: vi.fn()
     }));
 
     vi.doMock('./modelfiles.js', () => ({
@@ -1343,7 +1352,7 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
       },
       isThinkingModelId: (id: string) => /(qwen3|qwq|deepseek-?r1|cogito|phi\d+-reasoning)/i.test(id)
     }));
-    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
+    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn(), registerSidebarProviders: vi.fn() }));
     vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
     vi.doMock('vscode', () => ({
       LanguageModelTextPart: class {
@@ -1426,7 +1435,7 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
       },
       isThinkingModelId: (id: string) => /(qwen3|qwq|deepseek-?r1|cogito|phi\d+-reasoning)/i.test(id)
     }));
-    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
+    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn(), registerSidebarProviders: vi.fn() }));
     vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
     vi.doMock('vscode', () => ({
       LanguageModelTextPart: class {
@@ -1515,7 +1524,7 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
       },
       isThinkingModelId: (id: string) => /(qwen3|qwq|deepseek-?r1|cogito|phi\d+-reasoning)/i.test(id)
     }));
-    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
+    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn(), registerSidebarProviders: vi.fn() }));
     vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
     vi.doMock('vscode', () => ({
       LanguageModelTextPart: class {
@@ -1599,7 +1608,7 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
       },
       isThinkingModelId: (id: string) => /(qwen3|qwq|deepseek-?r1|cogito|phi\d+-reasoning)/i.test(id)
     }));
-    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
+    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn(), registerSidebarProviders: vi.fn() }));
     vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
     vi.doMock('vscode', () => ({
       LanguageModelTextPart: class {
@@ -1698,7 +1707,7 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
       },
       isThinkingModelId: () => false
     }));
-    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
+    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn(), registerSidebarProviders: vi.fn() }));
     vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
 
     const showErrorMessage = vi.fn().mockResolvedValue(undefined);
@@ -1791,7 +1800,7 @@ describe('handleChatRequest direct Ollama path (thinking + tools)', () => {
       },
       isThinkingModelId: () => false
     }));
-    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
+    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn(), registerSidebarProviders: vi.fn() }));
     vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
     vi.doMock('vscode', () => ({
       LanguageModelTextPart: class {
@@ -2464,7 +2473,7 @@ describe('handleChatRequest model selection', () => {
       },
       isThinkingModelId: () => false
     }));
-    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
+    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn(), registerSidebarProviders: vi.fn() }));
     vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
 
     const LMTextPart = class {
@@ -2595,7 +2604,7 @@ describe('handleChatRequest model selection', () => {
       },
       isThinkingModelId: () => false
     }));
-    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
+    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn(), registerSidebarProviders: vi.fn() }));
     vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
 
     const LMTextPart = class {
@@ -2731,7 +2740,7 @@ describe('handleChatRequest native Ollama task_complete', () => {
       },
       isThinkingModelId: () => false
     }));
-    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
+    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn(), registerSidebarProviders: vi.fn() }));
     vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
 
     const mockInvokeTool = vi.fn().mockResolvedValue({ content: [] });
@@ -2849,7 +2858,7 @@ describe('handleChatRequest native Ollama task_complete', () => {
       },
       isThinkingModelId: () => false
     }));
-    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
+    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn(), registerSidebarProviders: vi.fn() }));
     vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
 
     const mockInvokeTool = vi.fn().mockRejectedValue(new Error('tool failed'));
@@ -3465,7 +3474,8 @@ describe('activate noopLogger', () => {
     }));
 
     vi.doMock('./sidebar.js', () => ({
-      registerSidebar: vi.fn()
+      registerSidebar: vi.fn(),
+      registerSidebarProviders: vi.fn()
     }));
 
     vi.doMock('./modelfiles.js', () => ({
@@ -3633,7 +3643,8 @@ describe('startLogStreaming inner callbacks', () => {
     }));
 
     vi.doMock('./sidebar.js', () => ({
-      registerSidebar: vi.fn()
+      registerSidebar: vi.fn(),
+      registerSidebarProviders: vi.fn()
     }));
 
     vi.doMock('./modelfiles.js', () => ({
@@ -3902,7 +3913,7 @@ describe('handleChatRequest cloud model path (openAiCompatStreamChat)', () => {
       },
       isThinkingModelId: () => false
     }));
-    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
+    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn(), registerSidebarProviders: vi.fn() }));
     vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
     vi.doMock('vscode', () => ({
       LanguageModelTextPart: class {
@@ -4140,7 +4151,7 @@ describe('handleChatRequest cloud model path (openAiCompatStreamChat)', () => {
       },
       isThinkingModelId: () => false
     }));
-    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn() }));
+    vi.doMock('./sidebar.js', () => ({ registerSidebar: vi.fn(), registerSidebarProviders: vi.fn() }));
     vi.doMock('./modelfiles.js', () => ({ registerModelfileManager: vi.fn() }));
 
     const ext = await import('./extension.js');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,7 @@ import { registerModelfileManager } from './modelfiles.js';
 import { isThinkingModelId, OllamaChatModelProvider } from './provider.js';
 import { affectsSetting, getSetting, migrateLegacySettings, SETTINGS_NAMESPACE } from './settings.js';
 import { createModelSettingsViewProvider, MODEL_SETTINGS_VIEW_ID } from './settings-webview.js';
-import { registerSidebar, type SidebarProfilingSnapshot } from './sidebar.js';
+import { registerSidebar, registerSidebarProviders, type SidebarProfilingSnapshot } from './sidebar.js';
 import { registerStatusBarHeartbeat } from './status-bar.js';
 import { ThinkingParser } from './thinking-parser.js';
 import {
@@ -1097,6 +1097,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
   diagnostics.info('[client] activating extension...');
 
+  // Eagerly register sidebar tree data providers so VS Code finds them
+  // before async activation completes. This prevents the "no data provider
+  // registered" error when the sidebar is visible on startup.
+  const sidebarProviders = registerSidebarProviders(context, diagnostics);
+
   await migrateLegacySettings(diagnostics);
 
   const client = await getOllamaClient(context);
@@ -1207,9 +1212,8 @@ export async function activate(context: vscode.ExtensionContext) {
       provider.refreshModels();
       statusBarRegistration.triggerCheck();
     },
-    () => {
-      provider.refreshModels();
-    }
+    undefined,
+    sidebarProviders
   );
 
   const subscriptions: vscode.Disposable[] = [

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -2287,6 +2287,220 @@ describe('Extracted command handlers', () => {
     expect(mockPull).not.toHaveBeenCalled();
   });
 
+  it('LocalModelsProvider.setClient and getClient work correctly', async () => {
+    vi.resetModules();
+
+    vi.doMock('vscode', () => ({
+      EventEmitter: class { event = {}; fire = vi.fn(); },
+      workspace: {
+        getConfiguration: vi.fn(() => ({ get: vi.fn(), update: vi.fn() })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+      window: { registerTreeDataProvider: vi.fn(() => ({ dispose: vi.fn() })) },
+      TreeItem: class { label = ''; },
+      ThemeIcon: class {},
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      commands: { registerCommand: vi.fn(() => ({ dispose: vi.fn() })) },
+      ProgressLocation: { Notification: 1 },
+    }));
+
+    const { LocalModelsProvider } = await import('./sidebar.js');
+
+    const provider = new LocalModelsProvider();
+    expect(() => (provider as any).getClient()).toThrow('Ollama client not initialized');
+
+    const mockClient = { list: vi.fn(), ps: vi.fn() } as any;
+    provider.setClient(mockClient);
+    expect((provider as any).getClient()).toBe(mockClient);
+  });
+
+  it('LocalModelsProvider.setOnLocalModelsChanged invokes callback when refresh is triggered', async () => {
+    vi.resetModules();
+
+    vi.doMock('vscode', () => ({
+      EventEmitter: class { event = {}; fire = vi.fn(); },
+      workspace: {
+        getConfiguration: vi.fn(() => ({ get: vi.fn(), update: vi.fn() })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+      window: { registerTreeDataProvider: vi.fn(() => ({ dispose: vi.fn() })) },
+      TreeItem: class { label = ''; },
+      ThemeIcon: class {},
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      commands: { registerCommand: vi.fn(() => ({ dispose: vi.fn() })), executeCommand: vi.fn() },
+      ProgressLocation: { Notification: 1 },
+    }));
+
+    const { LocalModelsProvider } = await import('./sidebar.js');
+
+    const mockClient = {
+      list: vi.fn().mockResolvedValue({ models: [] }),
+      ps: vi.fn().mockResolvedValue({ models: [] }),
+    } as any;
+    const provider = new LocalModelsProvider();
+    provider.setClient(mockClient);
+
+    const callback = vi.fn();
+    provider.setOnLocalModelsChanged(callback);
+
+    provider.refresh();
+    // Allow async getLocalModels to settle
+    await vi.waitFor(() => { expect(callback).toHaveBeenCalled(); });
+  });
+
+  it('registerSidebarProviders registers tree data providers and returns them', async () => {
+    vi.resetModules();
+
+    const registerTreeDataProvider = vi.fn(() => ({ dispose: vi.fn() }));
+    vi.doMock('vscode', () => ({
+      TreeItem: class { label = ''; },
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      EventEmitter: class { event = {}; fire = vi.fn(); },
+      ThemeIcon: class {},
+      window: { registerTreeDataProvider, createTreeView: vi.fn() },
+      workspace: {
+        getConfiguration: vi.fn(() => ({ get: vi.fn(), update: vi.fn() })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+      commands: { registerCommand: vi.fn(() => ({ dispose: vi.fn() })) },
+      ProgressLocation: { Notification: 1 },
+    }));
+
+    const { registerSidebarProviders } = await import('./sidebar.js');
+    const context = {
+      subscriptions: { push: vi.fn() },
+      globalState: { get: vi.fn().mockReturnValue(undefined), update: vi.fn() },
+    } as any;
+    const result = registerSidebarProviders(context);
+
+    expect(registerTreeDataProvider).toHaveBeenCalledTimes(3);
+    expect(registerTreeDataProvider).toHaveBeenCalledWith('ollama-local-models', expect.anything());
+    expect(registerTreeDataProvider).toHaveBeenCalledWith('ollama-cloud-models', expect.anything());
+    expect(registerTreeDataProvider).toHaveBeenCalledWith('ollama-library-models', expect.anything());
+    expect(result).toHaveProperty('localProvider');
+    expect(result).toHaveProperty('cloudProvider');
+    expect(result).toHaveProperty('libraryProvider');
+  });
+
+  it('registerSidebar accepts pre-created providers and does not create duplicate tree views', async () => {
+    vi.resetModules();
+
+    vi.doMock('vscode', () => ({
+      TreeItem: class { label = ''; },
+      ThemeIcon: class {},
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      EventEmitter: class { event = {}; fire = vi.fn(); },
+      window: { createTreeView: vi.fn(() => ({ dispose: vi.fn() })), registerTreeDataProvider: vi.fn(() => ({ dispose: vi.fn() })) },
+      workspace: {
+        getConfiguration: vi.fn(() => ({ get: vi.fn(), update: vi.fn() })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+      commands: { registerCommand: vi.fn(() => ({ dispose: vi.fn() })), executeCommand: vi.fn() },
+      env: { openExternal: vi.fn() },
+      Uri: { parse: vi.fn((v: string) => ({ value: v })) },
+      ProgressLocation: { Notification: 15 },
+    }));
+
+    const vscode = await import('vscode');
+    const { registerSidebar, registerSidebarProviders } = await import('./sidebar.js');
+
+    const mockContext = {
+      subscriptions: { push: vi.fn() },
+      secrets: { get: vi.fn().mockResolvedValue(undefined), store: vi.fn(), delete: vi.fn() },
+      globalState: { get: vi.fn(), update: vi.fn() },
+    } as any;
+
+    const mockClient = {
+      list: vi.fn().mockResolvedValue({ models: [] }),
+      generate: vi.fn(),
+    } as any;
+
+    const providers = registerSidebarProviders(mockContext);
+    const logChannel = { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() } as any;
+    registerSidebar(mockContext, mockClient, logChannel, undefined, undefined, providers);
+
+    expect(vscode.window.createTreeView).not.toHaveBeenCalled();
+  });
+
+  it('registerSidebar returns getProfilingSnapshot and dispose works for eager providers', async () => {
+    vi.resetModules();
+
+    vi.doMock('vscode', () => ({
+      TreeItem: class { label = ''; },
+      ThemeIcon: class {},
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      EventEmitter: class { event = {}; fire = vi.fn(); },
+      window: { createTreeView: vi.fn(() => ({ dispose: vi.fn() })), registerTreeDataProvider: vi.fn(() => ({ dispose: vi.fn() })) },
+      workspace: {
+        getConfiguration: vi.fn(() => ({ get: vi.fn(), update: vi.fn() })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+      commands: { registerCommand: vi.fn(() => ({ dispose: vi.fn() })), executeCommand: vi.fn() },
+      env: { openExternal: vi.fn() },
+      Uri: { parse: vi.fn((v: string) => ({ value: v })) },
+      ProgressLocation: { Notification: 15 },
+    }));
+
+    const { registerSidebar, registerSidebarProviders } = await import('./sidebar.js');
+
+    const mockContext: any = {
+      subscriptions: { push: vi.fn() },
+      secrets: { get: vi.fn().mockResolvedValue(undefined), store: vi.fn(), delete: vi.fn() },
+      globalState: { get: vi.fn(), update: vi.fn() },
+    };
+
+    const mockClient = { list: vi.fn().mockResolvedValue({ models: [] }), generate: vi.fn() } as any;
+
+    const providers = registerSidebarProviders(mockContext);
+    const logChannel = { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() } as any;
+    const result = registerSidebar(mockContext, mockClient, logChannel, undefined, undefined, providers);
+
+    const snapshot = result.getProfilingSnapshot();
+    expect(snapshot).toHaveProperty('local');
+    expect(snapshot).toHaveProperty('library');
+    expect(snapshot).toHaveProperty('cloud');
+    expect(snapshot).toHaveProperty('preview');
+  });
+
+  it('registerSidebar without pre-created providers falls back to createTreeView', async () => {
+    vi.resetModules();
+
+    const createTreeView = vi.fn(() => ({ dispose: vi.fn() }));
+    vi.doMock('vscode', () => ({
+      TreeItem: class { label = ''; },
+      ThemeIcon: class {},
+      TreeItemCollapsibleState: { None: 0, Collapsed: 1, Expanded: 2 },
+      EventEmitter: class { event = {}; fire = vi.fn(); },
+      window: { createTreeView, registerTreeDataProvider: vi.fn(() => ({ dispose: vi.fn() })) },
+      workspace: {
+        getConfiguration: vi.fn(() => ({ get: vi.fn(), update: vi.fn() })),
+        onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+      },
+      commands: { registerCommand: vi.fn(() => ({ dispose: vi.fn() })), executeCommand: vi.fn() },
+      env: { openExternal: vi.fn() },
+      Uri: { parse: vi.fn((v: string) => ({ value: v })) },
+      ProgressLocation: { Notification: 15 },
+    }));
+
+    const { registerSidebar } = await import('./sidebar.js');
+
+    const mockContext: any = {
+      subscriptions: { push: vi.fn() },
+      secrets: { get: vi.fn().mockResolvedValue(undefined), store: vi.fn(), delete: vi.fn() },
+      globalState: { get: vi.fn(), update: vi.fn() },
+    };
+
+    const mockClient = { list: vi.fn().mockResolvedValue({ models: [] }), generate: vi.fn() } as any;
+
+    registerSidebar(mockContext, mockClient);
+
+    // Without providers, createTreeView should be called for each view
+    expect(createTreeView).toHaveBeenCalledTimes(3);
+    expect(createTreeView).toHaveBeenCalledWith('ollama-local-models', expect.anything());
+    expect(createTreeView).toHaveBeenCalledWith('ollama-library-models', expect.anything());
+    expect(createTreeView).toHaveBeenCalledWith('ollama-cloud-models', expect.anything());
+  });
+
   it('registerSidebar registers collapse commands for all three views', async () => {
     vi.resetModules();
 

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -714,8 +714,8 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
 
   constructor(
     private client: Ollama | undefined = undefined,
-    private context?: ExtensionContext,
-    private logChannel?: DiagnosticsLogger,
+    private readonly context?: ExtensionContext,
+    private readonly logChannel?: DiagnosticsLogger,
     private onLocalModelsChanged?: () => void,
   ) {
     this.hydrateLocalCapabilitiesFromStorage();

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -713,10 +713,10 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
   private static readonly LOCAL_CAPABILITIES_STORAGE_KEY = 'ollama.localModelCapabilities.v1';
 
   constructor(
-    private readonly client: Ollama,
-    private readonly context?: ExtensionContext,
-    private readonly logChannel?: DiagnosticsLogger,
-    private readonly onLocalModelsChanged?: () => void
+    private client: Ollama | undefined = undefined,
+    private context?: ExtensionContext,
+    private logChannel?: DiagnosticsLogger,
+    private onLocalModelsChanged?: () => void,
   ) {
     this.hydrateLocalCapabilitiesFromStorage();
     this.startAutoRefresh();
@@ -729,6 +729,24 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
         this.startAutoRefresh();
       }
     });
+  }
+
+  /** Set or replace the Ollama client (used for deferred initialization after async setup). */
+  setClient(client: Ollama): void {
+    this.client = client;
+  }
+
+  /** Set the callback invoked when local models change (wired after eager registration). */
+  setOnLocalModelsChanged(callback: (() => void) | undefined): void {
+    this.onLocalModelsChanged = callback;
+  }
+
+  /** Get the Ollama client, throwing if it hasn't been set yet. */
+  private getClient(): Ollama {
+    if (!this.client) {
+      throw new Error('Ollama client not initialized — call setClient() first');
+    }
+    return this.client;
   }
 
   private hydrateLocalCapabilitiesFromStorage(): void {
@@ -873,7 +891,7 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
   private async getLocalModels(): Promise<ModelTreeItem[]> {
     try {
       this.logChannel?.debug('[client] loading local models via list() and ps()...');
-      const [listResponse, psResponse] = await Promise.all([this.client.list(), this.client.ps()]);
+      const [listResponse, psResponse] = await Promise.all([this.getClient().list(), this.getClient().ps()]);
 
       const runningMap = new Map<string, RunningProcessInfo>();
       for (const model of psResponse.models) {
@@ -977,7 +995,7 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
           } else if (!this.localModelCapabilitiesInFlight.has(model.name)) {
             this.localModelCapabilitiesInFlight.add(model.name);
             // Fetch capabilities once per local model name.
-            void fetchModelCapabilities(this.client, model.name)
+            void fetchModelCapabilities(this.getClient(), model.name)
               .then(caps => {
                 this.localModelCapabilitiesCache.set(model.name, caps);
                 this.persistLocalCapabilitiesToStorage();
@@ -1158,7 +1176,7 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
   async deleteModel(modelName: string): Promise<void> {
     try {
       this.logChannel?.debug(`[client] deleting model: ${modelName}`);
-      await this.client.delete({ model: modelName });
+      await this.getClient().delete({ model: modelName });
       this.logChannel?.info(`[client] model deleted: ${modelName}`);
       this.refresh();
       window.showInformationMessage(`Model ${modelName} deleted`);
@@ -1177,7 +1195,7 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
       this.logChannel?.debug(`[client] starting local model: ${modelName}`);
       await window.withProgress({ location: 15, title: `Starting ${modelName}...` }, async () => {
         const isCloudModel = this.isCloudTaggedModel(modelName);
-        const activeClient = isCloudModel && this.context ? await getCloudOllamaClient(this.context) : this.client;
+        const activeClient = isCloudModel && this.context ? await getCloudOllamaClient(this.context) : this.getClient();
         if (isCloudModel) {
           // Cloud models should be pulled first (same behavior as `ollama run`).
           this.logChannel?.info(`[client] pulling cloud model before start: ${modelName}`);
@@ -1192,7 +1210,7 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
 
         let running = false;
         try {
-          const { models } = await this.client.ps();
+          const { models } = await this.getClient().ps();
           running = models.some(m => m.name === modelName);
         } catch {
           // If ps() fails, fall back to optimistic status messaging below.
@@ -1314,7 +1332,7 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
           cancellable: false
         },
         async () => {
-          const activeClient = isCloudModel && this.context ? await getCloudOllamaClient(this.context) : this.client;
+          const activeClient = isCloudModel && this.context ? await getCloudOllamaClient(this.context) : this.getClient();
           await activeClient.generate({
             model: modelName,
             prompt: '',
@@ -1325,7 +1343,7 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
           for (let i = 0; i < 30; i++) {
             await new Promise<void>(resolve => setTimeout(resolve, 1000));
             try {
-              const { models } = await this.client.ps();
+              const { models } = await this.getClient().ps();
               if (!models.some(m => m.name === modelName)) {
                 return; // Model stopped successfully
               }
@@ -1364,7 +1382,7 @@ export class LocalModelsProvider implements TreeDataProvider<ModelTreeItem>, Dis
               // Wait a moment and verify
               await new Promise(resolve => setTimeout(resolve, 1000));
               try {
-                const { models } = await this.client.ps();
+                const { models } = await this.getClient().ps();
                 if (!models.some(m => m.name === modelName)) {
                   this.logChannel?.info(`[client] model force-killed successfully: ${modelName}`);
                   this.refresh();
@@ -3125,6 +3143,36 @@ async function openCloudCapabilityPicker(cloudProvider: CloudModelsProvider): Pr
   cloudProvider.softRefresh();
 }
 
+/** Providers created by {@link registerSidebarProviders}. */
+export interface SidebarProviders {
+  localProvider: LocalModelsProvider;
+  cloudProvider: CloudModelsProvider;
+  libraryProvider: LibraryModelsProvider;
+}
+
+/**
+ * Eagerly register sidebar tree data providers so VS Code finds them
+ * before the async activation completes. Call this synchronously at the
+ * top of `activate()` — before any `await`.
+ */
+export function registerSidebarProviders(context: ExtensionContext, logChannel?: DiagnosticsLogger): SidebarProviders {
+  const localProvider = new LocalModelsProvider(undefined, context, logChannel);
+  const cloudProvider = new CloudModelsProvider(context, logChannel);
+  const libraryProvider = new LibraryModelsProvider(logChannel);
+  libraryProvider.attachContext(context);
+  libraryProvider.setLocalProvider(localProvider);
+
+  context.subscriptions.push(
+    window.registerTreeDataProvider('ollama-local-models', localProvider),
+    window.registerTreeDataProvider('ollama-cloud-models', cloudProvider),
+    window.registerTreeDataProvider('ollama-library-models', libraryProvider),
+  );
+
+  logChannel?.info('[client] sidebar tree data providers registered (eager)');
+
+  return { localProvider, cloudProvider, libraryProvider };
+}
+
 /**
  * Register sidebar with VS Code
  */
@@ -3133,36 +3181,45 @@ export function registerSidebar(
   client: Ollama,
   logChannel?: DiagnosticsLogger,
   onLocalModelsChanged?: () => void,
-  onCloudModelsChanged?: () => void
+  onCloudModelsChanged?: () => void,
+  providers?: SidebarProviders,
 ): SidebarRegistration {
   hydrateModelPreviewCacheFromStorage(context);
 
   let libraryProvider: LibraryModelsProvider | undefined;
-  const localProvider = new LocalModelsProvider(client, context, logChannel, () => {
-    onLocalModelsChanged?.();
-    libraryProvider?.refreshVariantStates();
-  });
-  const cloudProvider = new CloudModelsProvider(context, logChannel);
-  libraryProvider = new LibraryModelsProvider(logChannel);
+  const localProvider =
+    providers?.localProvider ??
+    new LocalModelsProvider(client, context, logChannel, () => {
+      onLocalModelsChanged?.();
+      libraryProvider?.refreshVariantStates();
+    });
+  const cloudProvider = providers?.cloudProvider ?? new CloudModelsProvider(context, logChannel);
+  libraryProvider = providers?.libraryProvider ?? new LibraryModelsProvider(logChannel);
   libraryProvider.attachContext(context);
   libraryProvider.setLocalProvider(localProvider);
 
+  // Inject the Ollama client if providers were created eagerly without one
+  if (providers) {
+    localProvider.setClient(client);
+    // Wire up the onLocalModelsChanged callback that was not available during eager registration
+    localProvider.setOnLocalModelsChanged(() => {
+      onLocalModelsChanged?.();
+      libraryProvider?.refreshVariantStates();
+    });
+  }
+
   logChannel?.info('[client] sidebar providers initialized');
 
-  const localTreeView = window.createTreeView('ollama-local-models', {
-    treeDataProvider: localProvider
-  });
-  const libraryTreeView = window.createTreeView('ollama-library-models', {
-    treeDataProvider: libraryProvider
-  });
-  const cloudTreeView = window.createTreeView('ollama-cloud-models', {
-    treeDataProvider: cloudProvider
-  });
+  // If providers were not eagerly registered, register tree views now
+  if (!providers) {
+    context.subscriptions.push(
+      window.createTreeView('ollama-local-models', { treeDataProvider: localProvider }),
+      window.createTreeView('ollama-library-models', { treeDataProvider: libraryProvider }),
+      window.createTreeView('ollama-cloud-models', { treeDataProvider: cloudProvider }),
+    );
+  }
 
   context.subscriptions.push(
-    localTreeView,
-    libraryTreeView,
-    cloudTreeView,
     commands.registerCommand('opilot.collapseLocalModels', () =>
       commands.executeCommand('workbench.actions.treeView.ollama-local-models.collapseAll')
     ),


### PR DESCRIPTION
## Problem

Sidebar shows "There is no data provider registered" when extension activates with sidebar visible. `activate()` has `await` calls (migrateLegacySettings, getOllamaClient, loadModelSettings) before `registerSidebar()` — VS Code tries rendering views before providers exist.

## Solution

Eagerly register tree data providers synchronously at top of `activate()`, before any `await`, using `registerSidebarProviders()`. LocalModelsProvider created without client initially, injected via `setClient()` after async setup.

## Changes

- **`src/sidebar.ts`**: client optional; added `setClient()`, `setOnLocalModelsChanged()`, `getClient()`; all `this.client.*` → `this.getClient().*`; added `registerSidebarProviders()` for early registration; `registerSidebar()` accepts pre-created providers
- **`src/extension.ts`**: calls `registerSidebarProviders()` before first `await`; passes providers to `registerSidebar()`