### PR TITLE
fix: bundle @agentsy/context to fix extension activation

### DIFF
--- a/tsup.config.mjs
+++ b/tsup.config.mjs
@@ -8,7 +8,7 @@ export default defineConfig({
   format: ['cjs'],
   platform: 'node',
   external: ['vscode'],
-  noExternal: ['ollama', 'undici', /^@agentsy\/core/, /^@agentsy\/providers/],
+  noExternal: ['ollama', 'undici', /^@agentsy\//],
   sourcemap: !production,
   minify: production,
   clean: true,


### PR DESCRIPTION
## Summary

Fixes #130

v1.8.0 added `@agentsy/context` for conversation compression, but `tsup.config.mjs` only bundled `@agentsy/core` and `@agentsy/providers`. The published extension left an external `require('@agentsy/context')` in `dist/extension.js`, which fails at activation because VS Code extensions do not ship `node_modules`.

This matches prior bundling fixes for `undici` and `@agentsy/providers`.

## Changes

- Bundle all `@agentsy/*` packages via `noExternal: [..., /^@agentsy\//]`

## Test plan

- [x] `pnpm install && pnpm run compile` (via Taskfile)
- [x] `grep -E "require\(['\"]@agentsy/" dist/extension.js` returns no matches
- [x] Extension activates in VS Code — no `Cannot find module '@agentsy/context'` in Extension Host log
- [x] Ollama appears under Copilot Chat model providers
- [x] Opilot settings open without error