### PR TITLE
docs: add pnpm scripts and update README build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,14 +215,24 @@ For more information on Ollama's security and privacy model, see the [Ollama Git
 - [Node.js](https://nodejs.org/) 20+
 - [pnpm](https://pnpm.io/) (version pinned in `package.json`)
 - [VS Code](https://code.visualstudio.com/) 1.111.0+
+- [Task](https://taskfile.dev/) (optional; also installed via `pnpm install` as `node_modules/.bin/task`)
 
 ### Build
 
 ```bash
 pnpm install
-pnpm run compile        # type-check + lint + bundle
-pnpm run watch          # parallel watch for type-check and bundle
+pnpm run compile        # bundle extension to dist/
+pnpm run watch          # watch and recompile
 ```
+
+Type-check and lint separately:
+
+```bash
+pnpm run check-types
+pnpm run lint
+```
+
+Equivalent [Taskfile](Taskfile.yaml) commands: `task compile`, `task watch`, `task check-types`, `task lint`.
 
 ### Testing
 
@@ -230,7 +240,7 @@ pnpm run watch          # parallel watch for type-check and bundle
 pnpm test               # unit tests (Vitest)
 pnpm run test:coverage  # unit tests with coverage (target: 85%)
 pnpm run test:extension # VS Code integration tests
-pnpm run lint           # static analysis (oxlint)
+pnpm run lint           # lint and format check (Ultracite/Biome)
 ```
 
 ### Debugging

--- a/package.json
+++ b/package.json
@@ -39,7 +39,15 @@
     "languageModelThinkingPart"
   ],
   "scripts": {
-    "prepare": "husky"
+    "prepare": "husky",
+    "compile": "NODE_ENV=production node node_modules/tsup/dist/cli-default.js",
+    "watch": "node node_modules/tsup/dist/cli-default.js --watch",
+    "check-types": "node node_modules/typescript/bin/tsc --noEmit",
+    "lint": "node node_modules/ultracite/dist/index.js check",
+    "lint:fix": "node node_modules/ultracite/dist/index.js fix",
+    "test": "node node_modules/vitest/vitest.mjs run src",
+    "test:coverage": "node node_modules/vitest/vitest.mjs run src --coverage",
+    "test:extension": "node test/extension/index.mjs"
   },
   "contributes": {
     "chatParticipants": [


### PR DESCRIPTION
## Summary

The README documents `pnpm run compile`, `pnpm test`, and related commands, but `package.json` only defined a `prepare` script. Contributors following the README hit "no script exists" unless they install Task globally.

This adds `package.json` scripts that mirror the Taskfile commands and updates the README to clarify that `compile` bundles only (type-check and lint are separate).

## Changes

- Add `compile`, `watch`, `check-types`, `lint`, `lint:fix`, `test`, `test:coverage`, and `test:extension` scripts to `package.json`
- Update README Development section to match actual workflow

## Test plan

- [x] `pnpm install`
- [x] `pnpm run compile` produces `dist/extension.js`
- [x] `pnpm run check-types` runs TypeScript check
- [x] `pnpm run lint` runs Ultracite