### PR TITLE
fix: bump engines.vscode to ^1.120.0, fix Codacy globals in wdio.conf.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -915,7 +915,7 @@
   },
   "packageManager": "pnpm@10.31.0+sha512.e3927388bfaa8078ceb79b748ffc1e8274e84d75163e67bc22e06c0d3aed43dd153151cbf11d7f8301ff4acb98c68bdc5cadf6989532801ffafe3b3e4a63c268",
   "engines": {
-    "vscode": "^1.111.0"
+    "vscode": "^1.120.0"
   },
   "icon": "logo.png",
   "pnpm": {

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,4 +1,4 @@
-/* eslint-env node */
+/* global require, module, exports */
 const path = require('node:path');
 
 exports.config = {


### PR DESCRIPTION
## Summary

Fixes two issues remaining from PR #141 that were merged before the fixes could be included.

## Changes

- **package.json**: Bump `engines.vscode` from `^1.111.0` to `^1.120.0` to match `@types/vscode ^1.120.0`. Resolves vsce validation error: `@types/vscode ^1.120.0 greater than engines.vscode ^1.111.0`
- **wdio.conf.js**: Replace `/* eslint-env node */` with `/* global require, module, exports */` — Codacy doesn't recognize the `eslint-env` comment directive; the `globals` directive is supported across JSHint and ESLint as a peer-reviewed alternative.